### PR TITLE
Fix permission issue with binding host directory on Ubuntu

### DIFF
--- a/scripts/ghidra/decompile-headless.sh
+++ b/scripts/ghidra/decompile-headless.sh
@@ -6,6 +6,7 @@
 # This source code is licensed in accordance with the terms specified in
 # the LICENSE file found in the root directory of this source tree.
 #
+SCRIPTS_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 if [ "$#" -lt 3 ]; then
     echo "Usage: $0 <input_file> <function_name> <output_file>"
@@ -18,7 +19,10 @@ OUTPUT_PATH=$3
 TMP_OUTPUT_PATH="/tmp/patchestry.out.json"
 
 # Create docker container and run the decompilation
-docker build -t trailofbits/patchestry-decompilation:latest -f DecompileHeadless.Dockerfile .
+docker build \
+    -t trailofbits/patchestry-decompilation:latest \
+    -f ${SCRIPTS_DIR}/DecompileHeadless.Dockerfile \
+    ${SCRIPTS_DIR}
 
 if [ $? -ne 0 ]; then
     echo "Docker build failed"

--- a/scripts/ghidra/decompile.sh
+++ b/scripts/ghidra/decompile.sh
@@ -18,6 +18,14 @@ INPUT_PATH=$1
 FUNCTION_NAME=$2
 OUTPUT_PATH=$3
 
+# Running with non-root user may cause permission issue on ubuntu
+# because binded directory will have root permission.
+# This is a hacky fix to avoid the issue. It can be avoided
+# by switching to using docker volume.
+if [ ! -w ${OUTPUT_PATH} ]; then
+  sudo chown ${USER}:${USER} ${OUTPUT_PATH}
+fi
+
 # Create a new Ghidra project and import the file
 ${GHIDRA_HEADLESS} ${GHIDRA_PROJECTS} patchestry-decompilation \
     -readOnly -deleteProject \


### PR DESCRIPTION
The permission issue may occur running docker as non-root user. It may or may not occur depending on if one is using docker-ce or docker desktop and how they bind host directory to the container. The fix avoid permission issue by changing the ownership of output directory. 