### PR TITLE
New lift approach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ CMakeLists.txt.user
 CMakeUserPresets.json
 compile_commands.json
 _site/
+/bin/
+.classpath
+.project
+.settings
+

--- a/scripts/ghidra/PatchestryDecompileFunctions.java
+++ b/scripts/ghidra/PatchestryDecompileFunctions.java
@@ -294,14 +294,9 @@ public class PatchestryDecompileFunctions extends GhidraScript {
         	
             PcodeOp op = null;
             Iterator<PcodeOp> op_iterator = block.getIterator();
+            name("operations").beginObject();
             while (op_iterator.hasNext()) {
-            	if (op == null) {
-            		op = op_iterator.next();
-                	name("first_operation").value(label(op));
-                    name("operations").beginObject();
-            	} else {
-            		op = op_iterator.next();
-            	}
+            	op = op_iterator.next();
             	
             	// NOTE(pag): INDIRECTs seem like a good way of modelling may-
             	//		      alias relations, as well as embedding control
@@ -317,9 +312,7 @@ public class PatchestryDecompileFunctions extends GhidraScript {
             		serialize(function, block, op);
             	}
             }
-            if (op != null) {
-                endObject();
-            }
+            endObject();
             
             // List out the operations in their order.
             op_iterator = block.getIterator();

--- a/test/ghidra/argc.c
+++ b/test/ghidra/argc.c
@@ -6,13 +6,13 @@
 
 // RUN: %decompile-headless --input %t.o --output %t %ci_output_folder
 // RUN: %file-check -vv --check-prefix=DECOMPILEA %s --input-file %t
-// DECOMPILEA: "arch":"{{.*}}","os":"{{.*}}","functions":{{...}}
+// DECOMPILEA: "arch":"{{.*}}","format":"{{.*}}","functions":{{...}}
 // DECOMPILEA-SAME: "name":"{{_?argc}}"
 // DECOMPILEA-SAME: "name":"{{_?main}}"
 
 // RUN: %cc %s -g -o %t.o
-// RUN: %decompile-headless --high-pcode --input %t.o --function argc --output %t %ci_output_folder
-// RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
+// RUN: %decompile-headless --high-pcode --input %t.o --function argc --output %t
+// %ci_output_folder RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
 // DECOMPILEHS: "name":"{{_?argc}}"
 
 // RUN: %decompile-headless --high-pcode --input %t.o --output %t %ci_output_folder

--- a/test/ghidra/array.c
+++ b/test/ghidra/array.c
@@ -6,13 +6,13 @@
 
 // RUN: %decompile-headless --input %t.o --output %t %ci_output_folder
 // RUN: %file-check -vv --check-prefix=DECOMPILEA %s --input-file %t
-// DECOMPILEA: "arch":"{{.*}}","os":"{{.*}}","functions":{{...}}
+// DECOMPILEA: "arch":"{{.*}}","format":"{{.*}}","functions":{{...}}
 // DECOMPILEA-SAME: "name":"{{_?array}}"
 // DECOMPILEA-SAME: "name":"{{_?main}}"
 
 // RUN: %cc %s -g -o %t.o
-// RUN: %decompile-headless --high-pcode --input %t.o --function array --output %t %ci_output_folder
-// RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
+// RUN: %decompile-headless --high-pcode --input %t.o --function array --output %t
+// %ci_output_folder RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
 // DECOMPILEHS: "name":"{{_?array}}"
 
 // RUN: %decompile-headless --high-pcode --input %t.o --output %t %ci_output_folder

--- a/test/ghidra/concat.c
+++ b/test/ghidra/concat.c
@@ -6,13 +6,13 @@
 
 // RUN: %decompile-headless --input %t.o --output %t %ci_output_folder
 // RUN: %file-check -vv --check-prefix=DECOMPILEA %s --input-file %t
-// DECOMPILEA: "arch":"{{.*}}","os":"{{.*}}","functions":{{...}}
+// DECOMPILEA: "arch":"{{.*}}","format":"{{.*}}","functions":{{...}}
 // DECOMPILEA-SAME: "name":"{{_?string_concat}}"
 // DECOMPILEA-SAME: "name":"{{_?main}}"
 
 // RUN: %cc %s -g -o %t.o
-// RUN: %decompile-headless --high-pcode --input %t.o --function string_concat --output %t %ci_output_folder
-// RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
+// RUN: %decompile-headless --high-pcode --input %t.o --function string_concat --output %t
+// %ci_output_folder RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
 // DECOMPILEHS: "name":"{{_?string_concat}}"
 
 // RUN: %decompile-headless --high-pcode --input %t.o --output %t %ci_output_folder

--- a/test/ghidra/fib.c
+++ b/test/ghidra/fib.c
@@ -6,13 +6,13 @@
 
 // RUN: %decompile-headless --input %t.o --output %t %ci_output_folder
 // RUN: %file-check -vv --check-prefix=DECOMPILEA %s --input-file %t
-// DECOMPILEA: "arch":"{{.*}}","os":"{{.*}}","functions":{{...}}
+// DECOMPILEA: "arch":"{{.*}}","format":"{{.*}}","functions":{{...}}
 // DECOMPILEA-SAME: "name":"{{_?fibonacci}}"
 // DECOMPILEA-SAME: "name":"{{_?main}}"
 
 // RUN: %cc %s -g -o %t.o
-// RUN: %decompile-headless --high-pcode --input %t.o --function fibonacci --output %t %ci_output_folder
-// RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
+// RUN: %decompile-headless --high-pcode --input %t.o --function fibonacci --output %t
+// %ci_output_folder RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
 // DECOMPILEHS: "name":"{{_?fibonacci}}"
 
 // RUN: %decompile-headless --high-pcode --input %t.o --output %t %ci_output_folder

--- a/test/ghidra/fread.c
+++ b/test/ghidra/fread.c
@@ -6,13 +6,13 @@
 
 // RUN: %decompile-headless --input %t.o --output %t %ci_output_folder
 // RUN: %file-check -vv --check-prefix=DECOMPILEA %s --input-file %t
-// DECOMPILEA: "arch":"{{.*}}","os":"{{.*}}","functions":{{...}}
+// DECOMPILEA: "arch":"{{.*}}","format":"{{.*}}","functions":{{...}}
 // DECOMPILEA-SAME: "name":"{{_?fread_test}}"
 // DECOMPILEA-SAME: "name":"{{_?main}}"
 
 // RUN: %cc %s -g -o %t.o
-// RUN: %decompile-headless --high-pcode --input %t.o --function fread_test --output %t %ci_output_folder
-// RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
+// RUN: %decompile-headless --high-pcode --input %t.o --function fread_test --output %t
+// %ci_output_folder RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
 // DECOMPILEHS: "name":"{{_?fread_test}}"
 
 // RUN: %decompile-headless --high-pcode --input %t.o --output %t %ci_output_folder

--- a/test/ghidra/fwrite.c
+++ b/test/ghidra/fwrite.c
@@ -6,13 +6,13 @@
 
 // RUN: %decompile-headless --input %t.o --output %t %ci_output_folder
 // RUN: %file-check -vv --check-prefix=DECOMPILEA %s --input-file %t
-// DECOMPILEA: "arch":"{{.*}}","os":"{{.*}}","functions":{{...}}
+// DECOMPILEA: "arch":"{{.*}}","format":"{{.*}}","functions":{{...}}
 // DECOMPILEA-SAME: "name":"{{_?write_file}}"
 // DECOMPILEA-SAME: "name":"{{_?main}}"
 
 // RUN: %cc %s -g -o %t.o
-// RUN: %decompile-headless --high-pcode --input %t.o --function write_file --output %t %ci_output_folder
-// RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
+// RUN: %decompile-headless --high-pcode --input %t.o --function write_file --output %t
+// %ci_output_folder RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
 // DECOMPILEHS: "name":"{{_?write_file}}"
 
 // RUN: %decompile-headless --high-pcode --input %t.o --output %t %ci_output_folder

--- a/test/ghidra/insert.c
+++ b/test/ghidra/insert.c
@@ -1,16 +1,17 @@
 // UNSUPPORTED: system-windows
 // RUN: %cc %s -g -o %t.o
-// RUN: %decompile-headless --input %t.o --function insert_substring --output %t %ci_output_folder
+// RUN: %decompile-headless --input %t.o --function insert_substring --output %t
+// %ci_output_folder
 
 // RUN: %decompile-headless --input %t.o --output %t %ci_output_folder
 // RUN: %file-check -vv --check-prefix=DECOMPILEA %s --input-file %t
-// DECOMPILEA: "arch":"{{.*}}","os":"{{.*}}","functions":{{...}}
+// DECOMPILEA: "arch":"{{.*}}","format":"{{.*}}","functions":{{...}}
 // DECOMPILEA-SAME: "name":"{{_?insert_substring}}"
 // DECOMPILEA-SAME: "name":"{{_?main}}"
 
 // RUN: %cc %s -g -o %t.o
-// RUN: %decompile-headless --high-pcode --input %t.o --function insert_substring --output %t %ci_output_folder
-// RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
+// RUN: %decompile-headless --high-pcode --input %t.o --function insert_substring --output %t
+// %ci_output_folder RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
 // DECOMPILEHS: "name":"{{_?insert_substring}}"
 
 // RUN: %decompile-headless --high-pcode --input %t.o --output %t %ci_output_folder

--- a/test/ghidra/list.c
+++ b/test/ghidra/list.c
@@ -6,13 +6,13 @@
 
 // RUN: %decompile-headless --input %t.o --output %t %ci_output_folder
 // RUN: %file-check -vv --check-prefix=DECOMPILEA %s --input-file %t
-// DECOMPILEA: "arch":"{{.*}}","os":"{{.*}}","functions":{{...}}
+// DECOMPILEA: "arch":"{{.*}}","format":"{{.*}}","functions":{{...}}
 // DECOMPILEA-SAME: "name":"{{_?print_list}}"
 // DECOMPILEA-SAME: "name":"{{_?main}}"
 
 // RUN: %cc %s -g -o %t.o
-// RUN: %decompile-headless --high-pcode --input %t.o --function print_list --output %t %ci_output_folder
-// RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
+// RUN: %decompile-headless --high-pcode --input %t.o --function print_list --output %t
+// %ci_output_folder RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
 // DECOMPILEHS: "name":"{{_?print_list}}"
 
 // RUN: %decompile-headless --high-pcode --input %t.o --output %t %ci_output_folder

--- a/test/ghidra/matrix.c
+++ b/test/ghidra/matrix.c
@@ -1,17 +1,19 @@
 // UNSUPPORTED: system-windows
 // RUN: %cc %s -g -o %t.o
+/* clang-format off */ 
 // RUN: %decompile-headless --input %t.o --function multiply_matrices --output %t %ci_output_folder
 // RUN: %file-check -vv --check-prefix=DECOMPILES %s --input-file %t
 // DECOMPILES: "name":"{{_?multiply_matrices}}"
 
 // RUN: %decompile-headless --input %t.o --output %t %ci_output_folder
 // RUN: %file-check -vv --check-prefix=DECOMPILEA %s --input-file %t
-// DECOMPILEA: "arch":"{{.*}}","os":"{{.*}}","functions":{{...}}
+// DECOMPILEA: "arch":"{{.*}}","format":"{{.*}}","functions":{{...}}
 // DECOMPILEA-SAME: "name":"{{_?multiply_matrices}}"
 // DECOMPILEA-SAME: "name":"{{_?main}}"
 
 // RUN: %cc %s -g -o %t.o
-// RUN: %decompile-headless --high-pcode --input %t.o --function multiply_matrices --output %t %ci_output_folder
+/* clang-format off */ 
+// RUN: %decompile-headless --high-pcode --input %t.o --function multiply_matrices --output %t %ci_output_folder 
 // RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
 // DECOMPILEHS: "name":"{{_?multiply_matrices}}"
 

--- a/test/ghidra/prime.c
+++ b/test/ghidra/prime.c
@@ -6,13 +6,13 @@
 
 // RUN: %decompile-headless --input %t.o --output %t %ci_output_folder
 // RUN: %file-check -vv --check-prefix=DECOMPILEA %s --input-file %t
-// DECOMPILEA: "arch":"{{.*}}","os":"{{.*}}","functions":{{...}}
+// DECOMPILEA: "arch":"{{.*}}","format":"{{.*}}","functions":{{...}}
 // DECOMPILEA-SAME: "name":"{{_?is_prime}}"
 // DECOMPILEA-SAME: "name":"{{_?main}}"
 
 // RUN: %cc %s -g -o %t.o
-// RUN: %decompile-headless --high-pcode --input %t.o --function is_prime --output %t %ci_output_folder
-// RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
+// RUN: %decompile-headless --high-pcode --input %t.o --function is_prime --output %t
+// %ci_output_folder RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
 // DECOMPILEHS: "name":"{{_?is_prime}}"
 
 // RUN: %decompile-headless --high-pcode --input %t.o --output %t %ci_output_folder

--- a/test/ghidra/queue.c
+++ b/test/ghidra/queue.c
@@ -6,15 +6,15 @@
 
 // RUN: %decompile-headless --input %t.o --output %t %ci_output_folder
 // RUN: %file-check -vv --check-prefix=DECOMPILEA %s --input-file %t
-// DECOMPILEA: "arch":"{{.*}}","os":"{{.*}}","functions":{{...}}
+// DECOMPILEA: "arch":"{{.*}}","format":"{{.*}}","functions":{{...}}
 // DECOMPILEA-SAME: "name":"{{_?init_queue}}"
 // DECOMPILEA-SAME: "name":"{{_?enqueue}}"
 // DECOMPILEA-SAME: "name":"{{_?dequeue}}"
 // DECOMPILEA-SAME: "name":"{{_?main}}"
 
 // RUN: %cc %s -g -o %t.o
-// RUN: %decompile-headless --high-pcode --input %t.o --function dequeue --output %t %ci_output_folder
-// RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
+// RUN: %decompile-headless --high-pcode --input %t.o --function dequeue --output %t
+// %ci_output_folder RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
 // DECOMPILEHS: "name":"{{_?dequeue}}"
 
 // RUN: %decompile-headless --high-pcode --input %t.o --output %t %ci_output_folder

--- a/test/ghidra/reverse.c
+++ b/test/ghidra/reverse.c
@@ -6,13 +6,13 @@
 
 // RUN: %decompile-headless --input %t.o --output %t %ci_output_folder
 // RUN: %file-check -vv --check-prefix=DECOMPILEA %s --input-file %t
-// DECOMPILEA: "arch":"{{.*}}","os":"{{.*}}","functions":{{...}}
+// DECOMPILEA: "arch":"{{.*}}","format":"{{.*}}","functions":{{...}}
 // DECOMPILEA-SAME: "name":"{{_?reverse_string}}"
 // DECOMPILEA-SAME: "name":"{{_?main}}"
 
 // RUN: %cc %s -g -o %t.o
-// RUN: %decompile-headless --high-pcode --input %t.o --function reverse_string --output %t %ci_output_folder
-// RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
+// RUN: %decompile-headless --high-pcode --input %t.o --function reverse_string --output %t
+// %ci_output_folder RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
 // DECOMPILEHS: "name":"{{_?reverse_string}}"
 
 // RUN: %decompile-headless --high-pcode --input %t.o --output %t %ci_output_folder

--- a/test/ghidra/sort.c
+++ b/test/ghidra/sort.c
@@ -6,13 +6,13 @@
 
 // RUN: %decompile-headless --input %t.o --output %t %ci_output_folder
 // RUN: %file-check -vv --check-prefix=DECOMPILEA %s --input-file %t
-// DECOMPILEA: "arch":"{{.*}}","os":"{{.*}}","functions":{{...}}
+// DECOMPILEA: "arch":"{{.*}}","format":"{{.*}}","functions":{{...}}
 // DECOMPILEA-SAME: "name":"{{_?sort_test}}"
 // DECOMPILEA-SAME: "name":"{{_?main}}"
 
 // RUN: %cc %s -g -o %t.o
-// RUN: %decompile-headless --high-pcode --input %t.o --function sort_test --output %t %ci_output_folder
-// RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
+// RUN: %decompile-headless --high-pcode --input %t.o --function sort_test --output %t
+// %ci_output_folder RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
 // DECOMPILEHS: "name":"{{_?sort_test}}"
 
 // RUN: %decompile-headless --high-pcode --input %t.o --output %t %ci_output_folder

--- a/test/ghidra/struct.c
+++ b/test/ghidra/struct.c
@@ -6,13 +6,13 @@
 
 // RUN: %decompile-headless --input %t.o --output %t %ci_output_folder
 // RUN: %file-check -vv --check-prefix=DECOMPILEA %s --input-file %t
-// DECOMPILEA: "arch":"{{.*}}","os":"{{.*}}","functions":{{...}}
+// DECOMPILEA: "arch":"{{.*}}","format":"{{.*}}","functions":{{...}}
 // DECOMPILEA-SAME: "name":"{{_?struct_test}}"
 // DECOMPILEA-SAME: "name":"{{_?main}}"
 
 // RUN: %cc %s -g -o %t.o
-// RUN: %decompile-headless --high-pcode --input %t.o --function struct_test --output %t %ci_output_folder
-// RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
+// RUN: %decompile-headless --high-pcode --input %t.o --function struct_test --output %t
+// %ci_output_folder RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
 // DECOMPILEHS: "name":"{{_?struct_test}}"
 
 // RUN: %decompile-headless --high-pcode --input %t.o --output %t %ci_output_folder

--- a/test/ghidra/structb.c
+++ b/test/ghidra/structb.c
@@ -6,13 +6,13 @@
 
 // RUN: %decompile-headless --input %t.o --output %t %ci_output_folder
 // RUN: %file-check -vv --check-prefix=DECOMPILEA %s --input-file %t
-// DECOMPILEA: "arch":"{{.*}}","os":"{{.*}}","functions":{{...}}
+// DECOMPILEA: "arch":"{{.*}}","format":"{{.*}}","functions":{{...}}
 // DECOMPILEA-SAME: "name":"{{_?structb}}"
 // DECOMPILEA-SAME: "name":"{{_?main}}"
 
 // RUN: %cc %s -g -o %t.o
-// RUN: %decompile-headless --high-pcode --input %t.o --function structb --output %t %ci_output_folder
-// RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
+// RUN: %decompile-headless --high-pcode --input %t.o --function structb --output %t
+// %ci_output_folder RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
 // DECOMPILEHS: "name":"{{_?structb}}"
 
 // RUN: %decompile-headless --high-pcode --input %t.o --output %t %ci_output_folder

--- a/test/ghidra/sub.c
+++ b/test/ghidra/sub.c
@@ -6,13 +6,13 @@
 
 // RUN: %decompile-headless --input %t.o --output %t %ci_output_folder
 // RUN: %file-check -vv --check-prefix=DECOMPILEA %s --input-file %t
-// DECOMPILEA: "arch":"{{.*}}","os":"{{.*}}","functions":{{...}}
+// DECOMPILEA: "arch":"{{.*}}","format":"{{.*}}","functions":{{...}}
 // DECOMPILEA-SAME: "name":"{{_?sub}}"
 // DECOMPILEA-SAME: "name":"{{_?main}}"
 
 // RUN: %cc %s -g -o %t.o
-// RUN: %decompile-headless --high-pcode --input %t.o --function sub --output %t %ci_output_folder
-// RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
+// RUN: %decompile-headless --high-pcode --input %t.o --function sub --output %t
+// %ci_output_folder RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
 // DECOMPILEHS: "name":"{{_?sub}}"
 
 // RUN: %decompile-headless --high-pcode --input %t.o --output %t %ci_output_folder

--- a/test/ghidra/test.c
+++ b/test/ghidra/test.c
@@ -6,13 +6,13 @@
 
 // RUN: %decompile-headless --input %t.o --output %t %ci_output_folder
 // RUN: %file-check -vv --check-prefix=DECOMPILEA %s --input-file %t
-// DECOMPILEA: "arch":"{{.*}}","os":"{{.*}}","functions":{{...}}
+// DECOMPILEA: "arch":"{{.*}}","format":"{{.*}}","functions":{{...}}
 // DECOMPILEA-SAME: "name":"{{_?test}}"
 // DECOMPILEA-SAME: "name":"{{_?main}}"
 
 // RUN: %cc %s -g -o %t.o
-// RUN: %decompile-headless --high-pcode --input %t.o --function test --output %t %ci_output_folder
-// RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
+// RUN: %decompile-headless --high-pcode --input %t.o --function test --output %t
+// %ci_output_folder RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
 // DECOMPILEHS: "name":"{{_?test}}"
 
 // RUN: %decompile-headless --high-pcode --input %t.o --output %t %ci_output_folder

--- a/test/ghidra/union.c
+++ b/test/ghidra/union.c
@@ -6,13 +6,13 @@
 
 // RUN: %decompile-headless --input %t.o --output %t %ci_output_folder
 // RUN: %file-check -vv --check-prefix=DECOMPILEA %s --input-file %t
-// DECOMPILEA: "arch":"{{.*}}","os":"{{.*}}","functions":{{...}}
+// DECOMPILEA: "arch":"{{.*}}","format":"{{.*}}","functions":{{...}}
 // DECOMPILEA-SAME: "name":"{{_?union_test}}"
 // DECOMPILEA-SAME: "name":"{{_?main}}"
 
 // RUN: %cc %s -g -o %t.o
-// RUN: %decompile-headless --high-pcode --input %t.o --function union_test --output %t %ci_output_folder
-// RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
+// RUN: %decompile-headless --high-pcode --input %t.o --function union_test --output %t
+// %ci_output_folder RUN: %file-check -vv --check-prefix=DECOMPILEHS %s --input-file %t
 // DECOMPILEHS: "name":"{{_?union_test}}"
 
 // RUN: %decompile-headless --high-pcode --input %t.o --output %t %ci_output_folder


### PR DESCRIPTION
- Migrates Akshay high p-code lifting support to the old script.
- Canonicalizes both the headless and gui codepaths to operate on lists of functions.
- Saturates a set of functions to lift, where the initial input set is treated as those for which we want definitions (i.e. high p-code)
- Starts doing p-code operation-specific lifting in the JSON representation. E.g. `CBRANCH` and `CALL`. This is important to eventually discover (and thus saturate) all referenced functions and global symbols.