### PR TITLE
ghidra: fix running of decompile analysis and upgrade Ghidra version

### DIFF
--- a/include/patchestry/AST/FunctionBuilder.hpp
+++ b/include/patchestry/AST/FunctionBuilder.hpp
@@ -62,8 +62,10 @@ namespace patchestry::ast {
          * @return A pointer to the created `clang::FunctionDecl` object. Returns `nullptr` if
          * the creation fails due to errors such as an empty function name or an invalid type.
          */
-        clang::FunctionDecl *
-        create_declaration(clang::ASTContext &ctx, bool is_definition = false);
+        clang::FunctionDecl *create_declaration(
+            clang::ASTContext &ctx, const clang::QualType &function_type,
+            bool is_definition = false
+        );
 
         /**
          * @brief Creates a function type based on the provided function prototype.

--- a/include/patchestry/AST/OperationBuilder.hpp
+++ b/include/patchestry/AST/OperationBuilder.hpp
@@ -62,6 +62,9 @@ namespace patchestry::ast {
         std::pair< clang::Stmt *, bool >
         create_callind(clang::ASTContext &ctx, const Function &function, const Operation &op);
 
+        std::pair< clang::Stmt *, bool >
+        create_callother(clang::ASTContext &ctx, const Function &function, const Operation &op);
+
         std::pair< clang::Stmt *, bool > create_userdefined(
             clang::ASTContext &ctx, const Function &function, const Operation &op
         );

--- a/include/patchestry/Ghidra/Pcode.def
+++ b/include/patchestry/Ghidra/Pcode.def
@@ -18,6 +18,7 @@
         X(BRANCHIND) \
         X(CALL) \
         X(CALLIND) \
+        X(CALLOTHER) \
         X(USERDEFINED) \
         X(RETURN) \
         X(PIECE) \

--- a/include/patchestry/Ghidra/PcodeOperations.hpp
+++ b/include/patchestry/Ghidra/PcodeOperations.hpp
@@ -52,14 +52,14 @@ namespace patchestry::ghidra {
 
         static Varnode::Kind convertToKind(const std::string &kdd) {
             static const std::unordered_map< std::string, Varnode::Kind > kind_map = {
-                {  "unknown",   VARNODE_UNKNOWN},
-                {   "global",    VARNODE_GLOBAL},
-                {    "local",     VARNODE_LOCAL},
-                {"parameter",     VARNODE_PARAM},
-                { "function",  VARNODE_FUNCTION},
-                {"temporary", VARNODE_TEMPORARY},
-                { "constant",  VARNODE_CONSTANT},
-                {   "string",    VARNODE_STRING}
+                {   "unknown",   VARNODE_UNKNOWN },
+                {    "global",    VARNODE_GLOBAL },
+                {     "local",     VARNODE_LOCAL },
+                { "parameter",     VARNODE_PARAM },
+                {  "function",  VARNODE_FUNCTION },
+                { "temporary", VARNODE_TEMPORARY },
+                {  "constant",  VARNODE_CONSTANT },
+                {    "string",    VARNODE_STRING }
             };
 
             // if kind is not present in the map, return varnode_unknown
@@ -111,6 +111,7 @@ namespace patchestry::ghidra {
 
         // Call Operation
         std::optional< OperationTarget > target;
+        std::optional< bool > has_return_value;
 
         // Branch Operation
         std::optional< std::string > target_block;

--- a/lib/patchestry/AST/FunctionBuilder.cpp
+++ b/lib/patchestry/AST/FunctionBuilder.cpp
@@ -516,6 +516,8 @@ namespace patchestry::ast {
                 return op_builder->create_call(ctx, function, op);
             case Mnemonic::OP_CALLIND:
                 return op_builder->create_callind(ctx, function, op);
+            case Mnemonic::OP_CALLOTHER:
+                return op_builder->create_callother(ctx, function, op);
             case Mnemonic::OP_USERDEFINED:
                 return op_builder->create_userdefined(ctx, function, op);
             case Mnemonic::OP_RETURN:

--- a/lib/patchestry/AST/OperationStmt.cpp
+++ b/lib/patchestry/AST/OperationStmt.cpp
@@ -716,6 +716,13 @@ namespace patchestry::ast {
         return {};
     }
 
+    std::pair< clang::Stmt *, bool > OpBuilder::create_callother(
+        clang::ASTContext &ctx, const Function &function, const Operation &op
+    ) {
+        (void) ctx, (void) function, (void) op;
+        return {};
+    }
+
     std::pair< clang::Stmt *, bool > OpBuilder::create_userdefined(
         clang::ASTContext &ctx, const Function &function, const Operation &op
     ) {

--- a/lib/patchestry/AST/OperationStmt.cpp
+++ b/lib/patchestry/AST/OperationStmt.cpp
@@ -579,8 +579,8 @@ namespace patchestry::ast {
 
         // get the callee and its prototy for creating function argument list
         const auto &callee = function_builder().function_list.get().at(*op.target->function);
-        auto *proto_type   = callee->getType()->getAs< clang::FunctionProtoType >();
-        auto num_params    = proto_type->getNumParams();
+        const auto *proto_type = callee->getType()->getAs< clang::FunctionProtoType >();
+        auto num_params        = proto_type->getNumParams();
 
         // The callee return type may be missing or incorrect during representing high pcode
         // into JSON format. Double check the function return type with operation type and fix
@@ -594,12 +594,15 @@ namespace patchestry::ast {
                 auto epi            = proto_type->getExtProtoInfo();
                 auto new_proto_type = ctx.getFunctionType(op_type, param_types, epi);
                 callee->setType(new_proto_type);
+                for (auto *decl : callee->redecls()) {
+                    decl->setType(new_proto_type);
+                }
             }
         }
 
         auto get_argument_type = [&](const clang::FunctionDecl *callee, clang::Expr *arg,
                                      unsigned index) -> clang::QualType {
-            auto *proto = callee->getType()->getAs< clang::FunctionProtoType >();
+            const auto *proto = callee->getType()->getAs< clang::FunctionProtoType >();
             if (proto->isVariadic() && (index >= proto->getNumParams())) {
                 return arg->getType();
             }

--- a/lib/patchestry/Ghidra/JsonDeserialize.cpp
+++ b/lib/patchestry/Ghidra/JsonDeserialize.cpp
@@ -445,8 +445,9 @@ namespace patchestry::ghidra {
             target.operation = call_op->str();
         }
 
-        target.is_noreturn = maybe_target->getBoolean("is_noreturn").value_or(false);
-        op.target          = std::move(target);
+        target.is_noreturn  = maybe_target->getBoolean("is_noreturn").value_or(false);
+        op.target           = std::move(target);
+        op.has_return_value = call_obj.getBoolean("has_return_value").value_or(false);
     }
 
     void JsonParser::deserialize_branch_operation(const JsonObject &branch_obj, Operation &op) {

--- a/scripts/ghidra/PatchestryDecompileFunctions.java
+++ b/scripts/ghidra/PatchestryDecompileFunctions.java
@@ -104,7 +104,6 @@ import ghidra.program.model.data.Undefined;
 import ghidra.program.model.data.Union;
 import ghidra.program.model.data.VoidDataType;
 import ghidra.program.model.data.WideCharDataType;
-import ghidra.program.model.data.UnsignedLongLongDataType;
 
 import ghidra.program.model.symbol.ExternalManager;
 import ghidra.program.model.symbol.Namespace;

--- a/scripts/ghidra/decompile-headless.dockerfile
+++ b/scripts/ghidra/decompile-headless.dockerfile
@@ -1,13 +1,13 @@
-FROM eclipse-temurin:17 AS base
+FROM eclipse-temurin:21 AS base
 
 FROM base AS build
 
-ENV GHIDRA_VERSION=11.1.2
+ENV GHIDRA_VERSION=11.3.2
 ENV GRADLE_VERSION=8.2
 ENV GRADLE_HOME=/opt/gradle
-ENV GHIDRA_RELEASE_TAG=20240709
+ENV GHIDRA_RELEASE_TAG=20250415
 ENV GHIDRA_PACKAGE=ghidra_${GHIDRA_VERSION}_PUBLIC_${GHIDRA_RELEASE_TAG}
-ENV GHIDRA_SHA256=219ec130b901645779948feeb7cc86f131dd2da6c36284cf538c3a7f3d44b588
+ENV GHIDRA_SHA256=99d45035bdcc3d6627e7b1232b7b379905a9fad76c772c920602e2b5d8b2dac2
 ENV GHIDRA_REPOSITORY=https://github.com/NationalSecurityAgency/ghidra
 
 RUN apt-get update && apt-get install -y \
@@ -37,8 +37,11 @@ RUN wget https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.
 # Set the PATH for Gradle
 ENV PATH="${GRADLE_HOME}/bin:${PATH}"
 
-RUN chmod +x /ghidra/support/buildNatives && \
-    /ghidra/support/buildNatives
+#RUN cd /ghidra/support/buildNatives && \
+#    /ghidra/support/buildNatives
+
+RUN cd /ghidra/support/gradle \
+    && gradle buildNatives
 
 RUN apt-get purge -y --auto-remove wget ca-certificates unzip && \
     apt-get clean


### PR DESCRIPTION
Fixes issues with running decompile auto analysis and upgrade ghidra version to 11.3.2 build. PR fixes #72 that was due to missing decompile auto analysis. 