### PR TITLE
Adds Z3 as a submodule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
       LLVM_EXTERNAL_LIT: "/usr/local/bin/lit"
       ENABLE_SANITIZER_UNDEFINED_BEHAVIOR: ${{ matrix.sanitizers }}
       ENABLE_SANITIZER_ADDRESS: ${{ matrix.sanitizers }}
+      CI: true
 
     steps:
       - name: Clean Docker to prevent space issues
@@ -65,7 +66,10 @@ jobs:
         run: cmake --build --preset ci --config ${{ matrix.build-type }} -j $(nproc)
 
       - name: Build the headless docker image
-        run: bash ./scripts/ghidra/build-headless-docker.sh
+        run: |
+          # Free more space before building Docker image
+          docker system prune -af --volumes || true
+          bash ./scripts/ghidra/build-headless-docker.sh
 
       - name: Test ${{ matrix.build-type }} with sanitizers set ${{ matrix.sanitizers }}
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -11,3 +11,6 @@
 [submodule "vendor/gflags/src"]
 	path = vendor/gflags/src
 	url = https://github.com/gflags/gflags.git
+[submodule "vendor/z3/src"]
+	path = vendor/z3/src
+	url = https://github.com/Z3Prover/z3.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,14 +110,13 @@ find_package(Clang 20 CONFIG REQUIRED HINTS "${PE_VENDOR_INSTALL_DIR}")
 message(STATUS "Using ClangConfig.cmake in: ${Clang_DIR}")
 
 
-
 set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
 set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
 
 
-
+include_directories(SYSTEM "${PE_VENDOR_INSTALL_DIR}/include")
 find_package(Z3 4.8 CONFIG REQUIRED HINTS "${PE_VENDOR_INSTALL_DIR}")
-message(STATUS "Using Z3Config.cmake in ${Z3_DIR}")
+message(STATUS "Using Z3Config.cmake in ${Z3_DIR} and Z3 headers in ${PE_VENDOR_INSTALL_DIR}/include")
 
 find_package(rellic REQUIRED HINTS "${PE_VENDOR_INSTALL_DIR}")
 message(STATUS "Using RellicConfig.cmake in: ${rellic_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,8 @@ set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
 
 
 
-find_package(Z3 4.8 CONFIG REQUIRED)
+find_package(Z3 4.8 CONFIG REQUIRED HINTS "${PE_VENDOR_INSTALL_DIR}")
+message(STATUS "Using Z3Config.cmake in ${Z3_DIR}")
 
 find_package(rellic REQUIRED HINTS "${PE_VENDOR_INSTALL_DIR}")
 message(STATUS "Using RellicConfig.cmake in: ${rellic_DIR}")

--- a/cmake/FindZ3.cmake
+++ b/cmake/FindZ3.cmake
@@ -49,7 +49,7 @@ endfunction(check_z3_version)
 # Looking for Z3 in LLVM_Z3_INSTALL_DIR
 find_path(Z3_INCLUDE_DIR NAMES z3.h
   NO_DEFAULT_PATH
-  PATHS ${LLVM_Z3_INSTALL_DIR}/include
+  PATHS ${PE_VENDOR_INSTALL_DIR}/include
   PATH_SUFFIXES libz3 z3
   )
 

--- a/lib/patchestry/Codegen/Codegen.cpp
+++ b/lib/patchestry/Codegen/Codegen.cpp
@@ -92,8 +92,11 @@ namespace patchestry::codegen {
             }
 
             // Decompile llvm IR using remill
-            rellic::DecompilationOptions opts{ .lower_switches   = false,
-                                               .remove_phi_nodes = false };
+            rellic::DecompilationOptions opts{ 
+		    .lower_switches   		= false,
+                    .remove_phi_nodes 		= false,
+		    .additional_providers 	= {},
+	    };
             auto results = rellic::Decompile(std::move(llvm_mod), std::move(opts));
             if (!results.Succeeded()) {
                 LOG(ERROR) << "Failed to decompile LLVM ir for transforming AST"

--- a/scripts/ghidra/build-headless-docker.sh
+++ b/scripts/ghidra/build-headless-docker.sh
@@ -5,6 +5,7 @@ SCRIPTS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 echo "Using SCRIPTS_DIR: $SCRIPTS_DIR"
 
 DOCKER_BUILDKIT=1 docker build \
+    --no-cache \
     -t trailofbits/patchestry-decompilation:latest \
     -f "${SCRIPTS_DIR}/decompile-headless.dockerfile" \
     "${SCRIPTS_DIR}"

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -4,15 +4,18 @@
 # This source code is licensed in accordance with the terms specified in
 # the LICENSE file found in the root directory of this source tree.
 #
+cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Git REQUIRED)
 
 execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory "${PE_VENDOR_INSTALL_DIR}")
 
+set(CMAKE_LINKER_TYPE LLD CACHE STRING "Linker type for the Patchestry build should overall be LLD!")
 
 add_subdirectory(gflags)
 add_subdirectory(glog)  # Depends on gflags
 if(USE_VENDORED_CLANG)
     add_subdirectory(clangir)
 endif()
+add_subdirectory(z3)
 add_subdirectory(rellic)

--- a/vendor/clangir/CMakeLists.txt
+++ b/vendor/clangir/CMakeLists.txt
@@ -84,3 +84,7 @@ execute_process(COMMAND ${CMAKE_COMMAND}
 #     specified CMAKE_BUILD_TYPE above in (b).
 execute_process(COMMAND ${CMAKE_COMMAND} --build . --target install
                 WORKING_DIRECTORY "${build_dir}")
+
+if(DEFINED ENV{CI})
+  execute_process(COMMAND ${CMAKE_COMMAND} -E remove_directory "${build_dir}")
+endif()

--- a/vendor/gflags/CMakeLists.txt
+++ b/vendor/gflags/CMakeLists.txt
@@ -71,3 +71,7 @@ execute_process(COMMAND ${CMAKE_COMMAND} --build . --target install
                 WORKING_DIRECTORY "${build_dir}")
 
 find_package(gflags CONFIG REQUIRED HINTS "${PE_VENDOR_INSTALL_DIR}" NO_DEFAULT_PATH)
+
+if(DEFINED ENV{CI})
+  execute_process(COMMAND ${CMAKE_COMMAND} -E remove_directory "${build_dir}")
+endif()

--- a/vendor/glog/CMakeLists.txt
+++ b/vendor/glog/CMakeLists.txt
@@ -4,6 +4,7 @@
 # This source code is licensed in accordance with the terms specified in
 # the LICENSE file found in the root directory of this source tree.
 #
+cmake_minimum_required(VERSION 3.20.0)
 
 find_package(gflags CONFIG REQUIRED QUIET HINTS "${PE_VENDOR_INSTALL_DIR}")
 

--- a/vendor/glog/CMakeLists.txt
+++ b/vendor/glog/CMakeLists.txt
@@ -57,3 +57,7 @@ execute_process(COMMAND ${CMAKE_COMMAND} --build . --target install
                 WORKING_DIRECTORY "${build_dir}")
 
 find_package(glog CONFIG REQUIRED HINTS "${PE_VENDOR_INSTALL_DIR}" NO_DEFAULT_PATH)
+
+if(DEFINED ENV{CI})
+  execute_process(COMMAND ${CMAKE_COMMAND} -E remove_directory "${build_dir}")
+endif()

--- a/vendor/rellic/CMakeLists.txt
+++ b/vendor/rellic/CMakeLists.txt
@@ -48,3 +48,7 @@ execute_process(COMMAND ${CMAKE_COMMAND}
 #     specified CMAKE_BUILD_TYPE above in (b).
 execute_process(COMMAND ${CMAKE_COMMAND} --build . --target install
                 WORKING_DIRECTORY "${build_dir}")
+
+if(DEFINED ENV{CI})
+  execute_process(COMMAND ${CMAKE_COMMAND} -E remove_directory "${build_dir}")
+endif()

--- a/vendor/z3/CMakeLists.txt
+++ b/vendor/z3/CMakeLists.txt
@@ -4,24 +4,6 @@
 # This source code is licensed in accordance with the terms specified in
 # the LICENSE file found in the root directory of this source tree.
 #
-cmake_minimum_required(VERSION 3.20.0)
-
-if(NOT PE_USE_VENDORED_GFLAGS)
-  find_package(gflags CONFIG QUIET)
-  if(gflags_FOUND)
-    if(NOT TARGET gflags::gflags)
-      if(TARGET gflags::gflags_static)
-        add_library(gflags::gflags ALIAS gflags::gflags_static)
-      elseif(TARGET gflags_static)
-        add_library(gflags::gflags_static ALIAS gflags_static)
-        add_library(gflags::gflags ALIAS gflags_static)
-      else()
-        message(FATAL_ERROR "Cannot find appropriate gflags target; known targets are ${gflags_LIBRARIES}")
-      endif()
-    endif()
-    return()
-  endif()
-endif()
 
 set(src_dir "${CMAKE_CURRENT_LIST_DIR}/src")
 set(build_dir "${CMAKE_CURRENT_BINARY_DIR}/build")
@@ -29,19 +11,15 @@ set(build_dir "${CMAKE_CURRENT_BINARY_DIR}/build")
 # Fetch the submodule if we don't yet have it.
 if(NOT EXISTS "${src_dir}/CMakeLists.txt")
   execute_process(
-    COMMAND "${GIT_EXECUTABLE}" submodule update --init vendor/gflags/src
+    COMMAND "${GIT_EXECUTABLE}" submodule update --init vendor/z3/src
     WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}")
 endif()
 
-# This is the main build, setup and execute the nested build
-# to ensure the gflags library exists before continuing
-
 execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory "${build_dir}")
 
-# (b) Nested CMake run. May need more -D... options than shown here.
 execute_process(COMMAND ${CMAKE_COMMAND}
                         -G "${CMAKE_GENERATOR}"
-                        "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+  			"-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
                         "-DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}"
                         "-DCMAKE_INSTALL_PREFIX=${PE_VENDOR_INSTALL_DIR}"
                         "-DCMAKE_INSTALL_RPATH=${CMAKE_INSTALL_RPATH}"
@@ -49,19 +27,10 @@ execute_process(COMMAND ${CMAKE_COMMAND}
                         "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
                         "-DCMAKE_LINKER_TYPE=${CMAKE_LINKER_TYPE}"
                         "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}"
-                        -DBUILD_SHARED_LIBS=OFF
-                        -DBUILD_STATIC_LIBS=ON
-                        -DBUILD_gflags_LIB=ON
-                        -DBUILD_gflags_nothreads_LIB=OFF
-                        -DBUILD_PACKAGING=ON
-                        -DBUILD_TESTING=OFF
-                        -DINSTALL_HEADERS=ON
-                        -DINSTALL_SHARED_LIBS=OFF
-                        -DINSTALL_STATIC_LIBS=ON
-                        -DREGISTER_BUILD_DIR=OFF
-                        -DREGISTER_INSTALL_PREFIX=OFF
                         "${src_dir}"
                WORKING_DIRECTORY "${build_dir}")
+
+set(LLVM_Z3_INSTALL_DIR "${PE_VENDOR_INSTALL_DIR}" PARENT_SCOPE)
 
 # (c) Build just mycomp in the nested build. Don't specify a --config
 #     because we cannot know what config the developer will be using
@@ -69,5 +38,3 @@ execute_process(COMMAND ${CMAKE_COMMAND}
 #     specified CMAKE_BUILD_TYPE above in (b).
 execute_process(COMMAND ${CMAKE_COMMAND} --build . --target install
                 WORKING_DIRECTORY "${build_dir}")
-
-find_package(gflags CONFIG REQUIRED HINTS "${PE_VENDOR_INSTALL_DIR}" NO_DEFAULT_PATH)

--- a/vendor/z3/CMakeLists.txt
+++ b/vendor/z3/CMakeLists.txt
@@ -19,7 +19,7 @@ execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory "${build_dir}")
 
 execute_process(COMMAND ${CMAKE_COMMAND}
                         -G "${CMAKE_GENERATOR}"
-  			"-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+                        "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
                         "-DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}"
                         "-DCMAKE_INSTALL_PREFIX=${PE_VENDOR_INSTALL_DIR}"
                         "-DCMAKE_INSTALL_RPATH=${CMAKE_INSTALL_RPATH}"
@@ -38,3 +38,7 @@ set(LLVM_Z3_INSTALL_DIR "${PE_VENDOR_INSTALL_DIR}" PARENT_SCOPE)
 #     specified CMAKE_BUILD_TYPE above in (b).
 execute_process(COMMAND ${CMAKE_COMMAND} --build . --target install
                 WORKING_DIRECTORY "${build_dir}")
+
+if(DEFINED ENV{CI})
+  execute_process(COMMAND ${CMAKE_COMMAND} -E remove_directory "${build_dir}")
+endif()


### PR DESCRIPTION
The Z3 finder thing didn't work for me since neither Z3 (-dev or normal) available on Ubuntu contains CMake files apparently. However, following the same submodule pattern we have to just build a z3 seems to work. 

If this PR is made in error and I've just done something unexpected in the build, happy to drop this PR and learn from others' experience, but this set of things at least made the build work for me in a very vanilla Ubuntu.

Correspondingly updated https://gist.github.com/kaoudis/e734c6197dbed595586ab659844df737.

To test this change yourself in an env that previously could build patchestry:

```bash-script
sudo apt-get install -y unzip pixz xz-utils lsb-release zlib1g-dev libomp-dev doctest-dev libunwind-dev
git clone git@github.com:lifting-bits/patchestry.git && cd patchestry
git fetch && git checkout kaoudis/add-z3-submodule
git submodule sync && git submodule update --init --recursive
# disclaimer: I am getting LIT from Python so it's installed in my venv, but just turn on LIT however you do it
source ~/venv/bin/activate
mkdir build && cd build
cmake --preset default \
   -DCMAKE_C_COMPILER=`which clang` \
   -DCMAKE_CXX_COMPILER=`which clang++` \
   -DCMAKE_PREFIX_PATH=/usr/local/lib/cmake/ \
   -DLLVM_Z3_INSTALL_DIR=/usr/local \
   -DCMAKE_INSTALL_RPATH=/usr/local \
   -DLLVM_EXTERNAL_LIT=`which lit` .
cmake --build builds/default/ -j$((`nproc`+1)) --preset debug
```

Before these changes, on Linux (Ubuntu Noble / 24.04) this sequence of build actions failed for several reasons:
1. lack of Z3 even if/when installed from the -dev package, since neither of the Ubuntu Z3 packages apparently includes Z3 CMake files
2. lack of libunwind
3. lack of other rellic dependencies installed with apt
4. a random Codegen.cpp error on a missing field made `cmake --build builds/default/ -j$((`nproc`+1)) --preset debug` fail until I specified `additional_providers` (I just set it to an empty `{}` since I would guess we don't need it if we didn't specify it before)? 
```
/home/kellykaoudis/patchestry/lib/patchestry/Codegen/Codegen.cpp:96:74: error: missing field 'additional_providers' initializer [-Werror,-Wmissing-designated-field-initializers]
   96 |                                                .remove_phi_nodes = false };
      |                                                                          ^
1 error generated.
```

**Open question I still have** is that CMake isn't able to find the version of the z3 install with FindZ3.cmake, but it seems like all the files are available to the Rellic build - going to get some lunch and think about this further