### PR TITLE
ghidra: rewrite call arguments to fix type mismatch

### DIFF
--- a/scripts/ghidra/PatchestryDecompileFunctions.java
+++ b/scripts/ghidra/PatchestryDecompileFunctions.java
@@ -1479,9 +1479,9 @@ public class PatchestryDecompileFunctions extends GhidraScript {
 				return false;
 			}
 
-			// TODO: Identify cases where we need explicit CAST operation to handle 
-			//       conversion. Some cases like pointer conversion of different types
-			//       or type conversion of builtin types gets handled during AST generation
+			// TODO: Identify cases where we need explicit CAST operations to handle conversions.
+ 			//       Some cases like pointer conversion between different types or type conversion
+			//       of builtin types are already handled during AST generation.
 
 			// Handle float to int and int to float conversion
 			if ((var_type instanceof AbstractFloatDataType && arg_type instanceof AbstractIntegerDataType) ||
@@ -1546,7 +1546,8 @@ public class PatchestryDecompileFunctions extends GhidraScript {
 				DataType arg_type = normalizeDataType(getArgumentType(callee, i-1));
 
 				// Skip if types match or both are compatible for implicit conversion
-				if (typesAreCompatible(var_type, arg_type)) {
+				if (var_type == null || arg_type == null
+					|| typesAreCompatible(var_type, arg_type)) {
 					continue;
 				}
 

--- a/test/ghidra/global.c
+++ b/test/ghidra/global.c
@@ -1,0 +1,66 @@
+// UNSUPPORTED: system-windows
+// RUN: %cc-x86_64 %s -g -c -o %t.o
+// RUN: %decompile-headless --input %t.o --function main --output %t %ci_output_folder
+// RUN: %file-check -vv --check-prefix=DECOMPILES %s --input-file %t
+// DECOMPILES: "name":"{{_?main}}"
+
+// RUN: %decompile-headless --input %t.o --output %t %ci_output_folder
+// RUN: %file-check -vv --check-prefix=DECOMPILEA %s --input-file %t
+// DECOMPILEA: "arch":"{{.*}}","format":"{{.*}}","functions":
+// DECOMPILEA-SAME: "name":"{{_?usbd_init}}"
+// DECOMPILEA-SAME: "name":"{{_?main}}"
+
+// RUN: %decompile-headless --input %t.o --list-functions --output %t %ci_output_folder
+// RUN: %file-check -vv --check-prefix=LISTFNS %s --input-file %t
+// LISTFNS: "program":"{{.*}}","functions":
+// LISTFNS-SAME: "name":"{{_?usbd_init}}"
+// LISTFNS-SAME: "name":"{{_?main}}"
+
+#include <stdio.h>
+#include <stdint.h>
+
+struct usbd_device;
+struct usbd_config;
+
+struct {
+	struct usbd_device *handle;
+} usb_g;
+
+struct usbd_device {
+    void* base_addr;
+    struct usbd_config *registered_config;
+};
+
+struct usbd_config {
+    int dummy_config_value;
+};
+
+
+void __attribute__((noinline))
+usbd_register_config(struct usbd_device *handle, struct usbd_config* config) {
+    if (handle == NULL) {
+        printf("handle is NULL\n");
+        return;
+    }
+    handle->registered_config = config;
+}
+
+void __attribute__((noinline)) bl_usb__setup() {
+    printf("initializing usb\n");
+}
+
+struct usbd_device* __attribute__((noinline))
+usbd_init() {
+    static struct usbd_device dev = {
+        .base_addr = (void*)(0xdeadbeef)
+    };
+    return &dev;
+}
+
+int main() {
+    bl_usb__setup();
+
+    usb_g.handle = usbd_init();
+    usbd_register_config(usb_g.handle, NULL);
+    return 0;
+}


### PR DESCRIPTION
- Adds logic to detect and handle type mismatches in CALL operations, which may occur due to inconsistent variable or type recovery. When a mismatch is found, the PcodeOp is rewritten to insert `ADDRESS_OF`/`CAST` operations. This ensures that the serialized Pcode maintains correct type semantics, fixing issues during AST generation from the serialized form.

- Fixes issue where CALL operations with a void return type incorrectly included an output variable. The return type is now adjusted to match the actual output variable type, ensuring consistency in the representation of function returns.

Fixes: #82 