### PR TITLE
decomp: Implement CALLIND pcode op

### DIFF
--- a/include/patchestry/Ghidra/PcodeOperations.hpp
+++ b/include/patchestry/Ghidra/PcodeOperations.hpp
@@ -105,21 +105,11 @@ namespace patchestry::ghidra {
             result += "  size: " + std::to_string(size) + "\n";
             result += "  type_key: " + type_key + "\n";
 
-            if (operation) {
-                result += "  operation: " + *operation + "\n";
-            }
-            if (function) {
-                result += "  function: " + *function + "\n";
-            }
-            if (value) {
-                result += "  value: " + std::to_string(*value) + "\n";
-            }
-            if (string_value) {
-                result += "  string_value: " + *string_value + "\n";
-            }
-            if (global) {
-                result += "  global: " + *global + "\n";
-            }
+            if (operation) { result += "  operation: " + *operation + "\n"; }
+            if (function) { result += "  function: " + *function + "\n"; }
+            if (value) { result += "  value: " + std::to_string(*value) + "\n"; }
+            if (string_value) { result += "  string_value: " + *string_value + "\n"; }
+            if (global) { result += "  global: " + *global + "\n"; }
 
             result += "}";
             return result;
@@ -151,6 +141,8 @@ namespace patchestry::ghidra {
         Varnode::Kind kind;
         std::optional< std::string > function;
         std::optional< std::string > operation;
+        std::optional< std::string > global;   // For CALLIND global var targets
+        std::optional< std::string > type_key; // Type of the target
         bool is_noreturn;
     };
 

--- a/lib/patchestry/Ghidra/JsonDeserialize.cpp
+++ b/lib/patchestry/Ghidra/JsonDeserialize.cpp
@@ -486,6 +486,18 @@ namespace patchestry::ghidra {
             target.operation = call_op->str();
         }
 
+        // For CALLIND: parse global variable target
+        auto global_key = maybe_target->getString("global");
+        if (global_key.has_value() && !global_key->empty()) {
+            target.global = global_key->str();
+        }
+
+        // For CALLIND: parse type of the target
+        auto type_key = maybe_target->getString("type");
+        if (type_key.has_value() && !type_key->empty()) {
+            target.type_key = type_key->str();
+        }
+
         target.is_noreturn  = maybe_target->getBoolean("is_noreturn").value_or(false);
         op.target           = std::move(target);
         op.has_return_value = call_obj.getBoolean("has_return_value").value_or(false);


### PR DESCRIPTION
- Add global and type_key fields to OperationTarget for indirect call type inference
- Implement create_callind() to handle calls through global or computed targets
- Parse global and type fields from JSON target in deserializer
- Infer function pointer type from inputs/outputs when not explicitly typed