### PR TITLE
decomp: improve test coverage for pcode operations

### DIFF
--- a/test/patchir-decomp/bit_ops.json
+++ b/test/patchir-decomp/bit_ops.json
@@ -1,0 +1,77 @@
+// RUN: bash %strip-json-comments %s > %t.json
+// RUN: %patchir-decomp -input %t.json -use-rellic-transform=false -emit-cir -emit-llvm -output %t >> /dev/null 2>&1
+// RUN: %file-check -vv -check-prefix=CIR %s --input-file %t.cir
+// RUN: %file-check -vv -check-prefix=LL  %s --input-file %t.ll
+// CIR-DAG: cir.func @popcount_test
+// CIR-DAG: cir.func @lzcount_test
+// CIR-DAG: cir.bit.popcount(
+// CIR-DAG: cir.bit.clz(
+// LL-DAG: define dso_local i32 @popcount_test
+// LL-DAG: define dso_local i32 @lzcount_test
+// LL-DAG: call i32 @llvm.ctpop.i32
+// LL-DAG: call i32 @llvm.ctlz.i32
+{
+  "architecture": "ARM",
+  "id": "ARM:LE:32:Cortex",
+  "format": "Executable and Linking Format (ELF)",
+  "functions": {
+    "ram:10000000": {
+      "name": "popcount_test",
+      "is_intrinsic": false,
+      "type": {
+        "return_type": "type_int",
+        "is_variadic": false,
+        "is_noreturn": false,
+        "parameter_types": ["type_int"]
+      },
+      "basic_blocks": {
+        "ram:10000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:10000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "br"]
+        },
+        "ram:10000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "POPCOUNT", "type": "type_int", "inputs": [{ "type": "type_int", "kind": "parameter", "operation": "p0" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_int", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:10000000:entry"
+    },
+    "ram:20000000": {
+      "name": "lzcount_test",
+      "is_intrinsic": false,
+      "type": {
+        "return_type": "type_int",
+        "is_variadic": false,
+        "is_noreturn": false,
+        "parameter_types": ["type_int"]
+      },
+      "basic_blocks": {
+        "ram:20000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a0", "type": "type_int", "kind": "parameter", "index": 0 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:20000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "br"]
+        },
+        "ram:20000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "LZCOUNT", "type": "type_int", "inputs": [{ "type": "type_int", "kind": "parameter", "operation": "p0" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_int", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:20000000:entry"
+    }
+  },
+  "globals": {},
+  "types": {
+    "type_int": { "name": "unsigned int", "size": 4, "kind": "integer" }
+  }
+}

--- a/test/patchir-decomp/bool_ops.json
+++ b/test/patchir-decomp/bool_ops.json
@@ -1,0 +1,92 @@
+// RUN: bash %strip-json-comments %s > %t.json
+// RUN: %patchir-decomp -input %t.json -use-rellic-transform=false -emit-cir -emit-llvm -output %t >> /dev/null 2>&1
+// RUN: %file-check -vv -check-prefix=CIR %s --input-file %t.cir
+// RUN: %file-check -vv -check-prefix=LL  %s --input-file %t.ll
+// CIR-DAG: cir.func @bool_neg_test
+// CIR-DAG: cir.func @bool_or_test
+// CIR-DAG: cir.func @bool_and_test
+// CIR-DAG: cir.unary(not,
+// CIR-DAG: cir.cast(bool_to_int,
+// LL-DAG: define {{.*}} @bool_neg_test
+// LL-DAG: define {{.*}} @bool_or_test
+// LL-DAG: define {{.*}} @bool_and_test
+// LL-DAG: zext i1
+{
+  "architecture": "ARM",
+  "id": "ARM:LE:32:Cortex",
+  "format": "Executable and Linking Format (ELF)",
+  "functions": {
+    "ram:10000000": {
+      "name": "bool_neg_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_bool", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_bool"] },
+      "basic_blocks": {
+        "ram:10000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_bool", "kind": "parameter", "index": 0 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:10000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "br"]
+        },
+        "ram:10000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "BOOL_NEGATE", "type": "type_bool", "inputs": [{ "type": "type_bool", "kind": "parameter", "operation": "p0" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_bool", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:10000000:entry"
+    },
+    "ram:20000000": {
+      "name": "bool_or_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_bool", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_bool", "type_bool"] },
+      "basic_blocks": {
+        "ram:20000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_bool", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_bool", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:20000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:20000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "BOOL_OR", "type": "type_bool", "inputs": [{ "type": "type_bool", "kind": "parameter", "operation": "p0" }, { "type": "type_bool", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_bool", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:20000000:entry"
+    },
+    "ram:30000000": {
+      "name": "bool_and_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_bool", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_bool", "type_bool"] },
+      "basic_blocks": {
+        "ram:30000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_bool", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_bool", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:30000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:30000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "BOOL_AND", "type": "type_bool", "inputs": [{ "type": "type_bool", "kind": "parameter", "operation": "p0" }, { "type": "type_bool", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_bool", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:30000000:entry"
+    }
+  },
+  "globals": {},
+  "types": {
+    "type_bool": { "name": "bool", "size": 1, "kind": "boolean" }
+  }
+}

--- a/test/patchir-decomp/copy_declare.json
+++ b/test/patchir-decomp/copy_declare.json
@@ -1,0 +1,65 @@
+// RUN: bash %strip-json-comments %s > %t.json
+// RUN: %patchir-decomp -input %t.json -use-rellic-transform=false -emit-cir -emit-llvm -output %t >> /dev/null 2>&1
+// RUN: %file-check -vv -check-prefix=CIR %s --input-file %t.cir
+// RUN: %file-check -vv -check-prefix=LL  %s --input-file %t.ll
+// CIR: cir.func @copy_declare_test
+// CIR: cir.alloca
+// CIR: cir.store
+// CIR: cir.load
+// LL: define dso_local i32 @copy_declare_test
+// LL: alloca i32
+// LL: store i32
+// LL: load i32
+{
+  "architecture": "ARM",
+  "id": "ARM:LE:32:Cortex",
+  "format": "Executable and Linking Format (ELF)",
+  "functions": {
+    "ram:10000000": {
+      "name": "copy_declare_test",
+      "is_intrinsic": false,
+      "type": {
+        "return_type": "type_int",
+        "is_variadic": false,
+        "is_noreturn": false,
+        "parameter_types": ["type_int"]
+      },
+      "basic_blocks": {
+        "ram:10000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "local0": { "mnemonic": "DECLARE_LOCAL", "kind": "local", "name": "my_local", "type": "type_int" },
+            "temp0": { "mnemonic": "DECLARE_TEMPORARY", "name": "my_temp", "kind": "temporary", "type": "type_int", "address": "ram:10000000:0:basic:copy_op" },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:10000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "local0", "temp0", "br"]
+        },
+        "ram:10000000:0:basic": {
+          "operations": {
+            "copy_op": {
+              "mnemonic": "COPY",
+              "type": "type_int",
+              "inputs": [{ "type": "type_int", "kind": "parameter", "operation": "p0" }]
+            },
+            "store_op": {
+              "mnemonic": "COPY",
+              "type": "type_int",
+              "output": { "kind": "local", "operation": "local0" },
+              "inputs": [{ "type": "type_int", "kind": "temporary", "operation": "copy_op" }]
+            },
+            "ret": {
+              "mnemonic": "RETURN",
+              "inputs": [{ "type": "type_int", "kind": "local", "operation": "local0" }]
+            }
+          },
+          "ordered_operations": ["copy_op", "store_op", "ret"]
+        }
+      },
+      "entry_block": "ram:10000000:entry"
+    }
+  },
+  "globals": {},
+  "types": {
+    "type_int": { "name": "unsigned int", "size": 4, "kind": "integer" }
+  }
+}

--- a/test/patchir-decomp/float_arith.json
+++ b/test/patchir-decomp/float_arith.json
@@ -1,0 +1,123 @@
+// RUN: bash %strip-json-comments %s > %t.json
+// RUN: %patchir-decomp -input %t.json -use-rellic-transform=false -emit-cir -emit-llvm -output %t >> /dev/null 2>&1
+// RUN: %file-check -vv -check-prefix=CIR %s --input-file %t.cir
+// RUN: %file-check -vv -check-prefix=LL  %s --input-file %t.ll
+// CIR-DAG: cir.func @float_add_test
+// CIR-DAG: cir.func @float_sub_test
+// CIR-DAG: cir.func @float_mult_test
+// CIR-DAG: cir.func @float_div_test
+// CIR-DAG: cir.binop(add,
+// CIR-DAG: cir.binop(sub,
+// CIR-DAG: cir.binop(mul,
+// CIR-DAG: cir.binop(div,
+// LL-DAG: define dso_local float @float_add_test
+// LL-DAG: define dso_local float @float_sub_test
+// LL-DAG: define dso_local float @float_mult_test
+// LL-DAG: define dso_local float @float_div_test
+// LL-DAG: fadd float
+// LL-DAG: fsub float
+// LL-DAG: fmul float
+// LL-DAG: fdiv float
+{
+  "architecture": "ARM",
+  "id": "ARM:LE:32:Cortex",
+  "format": "Executable and Linking Format (ELF)",
+  "functions": {
+    "ram:10000000": {
+      "name": "float_add_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_float", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_float", "type_float"] },
+      "basic_blocks": {
+        "ram:10000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_float", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_float", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:10000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:10000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "FLOAT_ADD", "type": "type_float", "inputs": [{ "type": "type_float", "kind": "parameter", "operation": "p0" }, { "type": "type_float", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_float", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:10000000:entry"
+    },
+    "ram:20000000": {
+      "name": "float_sub_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_float", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_float", "type_float"] },
+      "basic_blocks": {
+        "ram:20000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_float", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_float", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:20000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:20000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "FLOAT_SUB", "type": "type_float", "inputs": [{ "type": "type_float", "kind": "parameter", "operation": "p0" }, { "type": "type_float", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_float", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:20000000:entry"
+    },
+    "ram:30000000": {
+      "name": "float_mult_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_float", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_float", "type_float"] },
+      "basic_blocks": {
+        "ram:30000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_float", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_float", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:30000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:30000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "FLOAT_MULT", "type": "type_float", "inputs": [{ "type": "type_float", "kind": "parameter", "operation": "p0" }, { "type": "type_float", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_float", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:30000000:entry"
+    },
+    "ram:40000000": {
+      "name": "float_div_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_float", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_float", "type_float"] },
+      "basic_blocks": {
+        "ram:40000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_float", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_float", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:40000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:40000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "FLOAT_DIV", "type": "type_float", "inputs": [{ "type": "type_float", "kind": "parameter", "operation": "p0" }, { "type": "type_float", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_float", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:40000000:entry"
+    }
+  },
+  "globals": {},
+  "types": {
+    "type_float": { "name": "float", "size": 4, "kind": "float" }
+  }
+}

--- a/test/patchir-decomp/float_compare.json
+++ b/test/patchir-decomp/float_compare.json
@@ -1,0 +1,124 @@
+// RUN: bash %strip-json-comments %s > %t.json
+// RUN: %patchir-decomp -input %t.json -use-rellic-transform=false -emit-cir -emit-llvm -output %t >> /dev/null 2>&1
+// RUN: %file-check -vv -check-prefix=CIR %s --input-file %t.cir
+// RUN: %file-check -vv -check-prefix=LL  %s --input-file %t.ll
+// CIR-DAG: cir.func @float_eq_test
+// CIR-DAG: cir.func @float_ne_test
+// CIR-DAG: cir.func @float_lt_test
+// CIR-DAG: cir.func @float_le_test
+// CIR-DAG: cir.cmp(eq,
+// CIR-DAG: cir.cmp(ne,
+// CIR-DAG: cir.cmp(lt,
+// CIR-DAG: cir.cmp(le,
+// LL-DAG: define {{.*}} @float_eq_test
+// LL-DAG: define {{.*}} @float_ne_test
+// LL-DAG: define {{.*}} @float_lt_test
+// LL-DAG: define {{.*}} @float_le_test
+// LL-DAG: fcmp oeq float
+// LL-DAG: fcmp une float
+// LL-DAG: fcmp olt float
+// LL-DAG: fcmp ole float
+{
+  "architecture": "ARM",
+  "id": "ARM:LE:32:Cortex",
+  "format": "Executable and Linking Format (ELF)",
+  "functions": {
+    "ram:10000000": {
+      "name": "float_eq_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_bool", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_float", "type_float"] },
+      "basic_blocks": {
+        "ram:10000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_float", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_float", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:10000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:10000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "FLOAT_EQUAL", "type": "type_bool", "inputs": [{ "type": "type_float", "kind": "parameter", "operation": "p0" }, { "type": "type_float", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_bool", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:10000000:entry"
+    },
+    "ram:20000000": {
+      "name": "float_ne_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_bool", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_float", "type_float"] },
+      "basic_blocks": {
+        "ram:20000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_float", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_float", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:20000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:20000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "FLOAT_NOTEQUAL", "type": "type_bool", "inputs": [{ "type": "type_float", "kind": "parameter", "operation": "p0" }, { "type": "type_float", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_bool", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:20000000:entry"
+    },
+    "ram:30000000": {
+      "name": "float_lt_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_bool", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_float", "type_float"] },
+      "basic_blocks": {
+        "ram:30000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_float", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_float", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:30000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:30000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "FLOAT_LESS", "type": "type_bool", "inputs": [{ "type": "type_float", "kind": "parameter", "operation": "p0" }, { "type": "type_float", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_bool", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:30000000:entry"
+    },
+    "ram:40000000": {
+      "name": "float_le_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_bool", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_float", "type_float"] },
+      "basic_blocks": {
+        "ram:40000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_float", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_float", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:40000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:40000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "FLOAT_LESSEQUAL", "type": "type_bool", "inputs": [{ "type": "type_float", "kind": "parameter", "operation": "p0" }, { "type": "type_float", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_bool", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:40000000:entry"
+    }
+  },
+  "globals": {},
+  "types": {
+    "type_float": { "name": "float", "size": 4, "kind": "float" },
+    "type_bool": { "name": "bool", "size": 1, "kind": "boolean" }
+  }
+}

--- a/test/patchir-decomp/float_convert.json
+++ b/test/patchir-decomp/float_convert.json
@@ -1,0 +1,79 @@
+// RUN: bash %strip-json-comments %s > %t.json
+// RUN: %patchir-decomp -input %t.json -use-rellic-transform=false -emit-cir -emit-llvm -output %t >> /dev/null 2>&1
+// RUN: %file-check -vv -check-prefix=CIR %s --input-file %t.cir
+// RUN: %file-check -vv -check-prefix=LL  %s --input-file %t.ll
+// CIR-DAG: cir.func @float2float_test
+// CIR-DAG: cir.func @trunc_test
+// CIR-DAG: cir.cast(floating,
+// CIR-DAG: cir.cast(float_to_int,
+// LL-DAG: define dso_local double @float2float_test
+// LL-DAG: define dso_local i32 @trunc_test
+// LL-DAG: fpext float
+// LL-DAG: fptoui float
+{
+  "architecture": "ARM",
+  "id": "ARM:LE:32:Cortex",
+  "format": "Executable and Linking Format (ELF)",
+  "functions": {
+    "ram:10000000": {
+      "name": "float2float_test",
+      "is_intrinsic": false,
+      "type": {
+        "return_type": "type_double",
+        "is_variadic": false,
+        "is_noreturn": false,
+        "parameter_types": ["type_float"]
+      },
+      "basic_blocks": {
+        "ram:10000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_float", "kind": "parameter", "index": 0 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:10000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "br"]
+        },
+        "ram:10000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "FLOAT2FLOAT", "type": "type_double", "inputs": [{ "type": "type_float", "kind": "parameter", "operation": "p0" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_double", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:10000000:entry"
+    },
+    "ram:20000000": {
+      "name": "trunc_test",
+      "is_intrinsic": false,
+      "type": {
+        "return_type": "type_int",
+        "is_variadic": false,
+        "is_noreturn": false,
+        "parameter_types": ["type_float"]
+      },
+      "basic_blocks": {
+        "ram:20000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_float", "kind": "parameter", "index": 0 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:20000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "br"]
+        },
+        "ram:20000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "TRUNC", "type": "type_int", "inputs": [{ "type": "type_float", "kind": "parameter", "operation": "p0" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_int", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:20000000:entry"
+    }
+  },
+  "globals": {},
+  "types": {
+    "type_float": { "name": "float", "size": 4, "kind": "float" },
+    "type_double": { "name": "double", "size": 8, "kind": "float" },
+    "type_int": { "name": "unsigned int", "size": 4, "kind": "integer" }
+  }
+}

--- a/test/patchir-decomp/float_nan.json
+++ b/test/patchir-decomp/float_nan.json
@@ -1,0 +1,54 @@
+// RUN: bash %strip-json-comments %s > %t.json
+// RUN: %patchir-decomp -input %t.json -use-rellic-transform=false -emit-cir -emit-llvm -output %t >> /dev/null 2>&1
+// RUN: %file-check -vv -check-prefix=CIR %s --input-file %t.cir
+// RUN: %file-check -vv -check-prefix=LL  %s --input-file %t.ll
+// CIR: cir.func @float_nan_test
+// CIR: cir.cmp(ne,
+// LL: define {{.*}} @float_nan_test
+// LL: fcmp une float
+{
+  "architecture": "ARM",
+  "id": "ARM:LE:32:Cortex",
+  "format": "Executable and Linking Format (ELF)",
+  "functions": {
+    "ram:10000000": {
+      "name": "float_nan_test",
+      "is_intrinsic": false,
+      "type": {
+        "return_type": "type_bool",
+        "is_variadic": false,
+        "is_noreturn": false,
+        "parameter_types": ["type_float"]
+      },
+      "basic_blocks": {
+        "ram:10000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_float", "kind": "parameter", "index": 0 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:10000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "br"]
+        },
+        "ram:10000000:0:basic": {
+          "operations": {
+            "op0": {
+              "mnemonic": "FLOAT_NAN",
+              "type": "type_bool",
+              "inputs": [{ "type": "type_float", "kind": "parameter", "operation": "p0" }]
+            },
+            "ret": {
+              "mnemonic": "RETURN",
+              "inputs": [{ "type": "type_bool", "kind": "temporary", "operation": "op0" }]
+            }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:10000000:entry"
+    }
+  },
+  "globals": {},
+  "types": {
+    "type_float": { "name": "float", "size": 4, "kind": "float" },
+    "type_bool": { "name": "bool", "size": 1, "kind": "boolean" }
+  }
+}

--- a/test/patchir-decomp/int_arith.json
+++ b/test/patchir-decomp/int_arith.json
@@ -1,0 +1,150 @@
+// RUN: bash %strip-json-comments %s > %t.json
+// RUN: %patchir-decomp -input %t.json -use-rellic-transform=false -emit-cir -emit-llvm -output %t >> /dev/null 2>&1
+// RUN: %file-check -vv -check-prefix=CIR %s --input-file %t.cir
+// RUN: %file-check -vv -check-prefix=LL  %s --input-file %t.ll
+// CIR-DAG: cir.func @int_add_test
+// CIR-DAG: cir.func @int_sub_test
+// CIR-DAG: cir.func @int_mult_test
+// CIR-DAG: cir.func @int_div_test
+// CIR-DAG: cir.func @int_rem_test
+// CIR-DAG: cir.binop(add,
+// CIR-DAG: cir.binop(sub,
+// CIR-DAG: cir.binop(mul,
+// CIR-DAG: cir.binop(div,
+// CIR-DAG: cir.binop(rem,
+// LL-DAG: define dso_local i32 @int_add_test
+// LL-DAG: define dso_local i32 @int_sub_test
+// LL-DAG: define dso_local i32 @int_mult_test
+// LL-DAG: define dso_local i32 @int_div_test
+// LL-DAG: define dso_local i32 @int_rem_test
+// LL-DAG: add i32
+// LL-DAG: sub i32
+// LL-DAG: mul i32
+// LL-DAG: udiv i32
+// LL-DAG: urem i32
+{
+  "architecture": "ARM",
+  "id": "ARM:LE:32:Cortex",
+  "format": "Executable and Linking Format (ELF)",
+  "functions": {
+    "ram:10000000": {
+      "name": "int_add_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_int", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_int", "type_int"] },
+      "basic_blocks": {
+        "ram:10000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_int", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:10000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:10000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "INT_ADD", "type": "type_int", "inputs": [{ "type": "type_int", "kind": "parameter", "operation": "p0" }, { "type": "type_int", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_int", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:10000000:entry"
+    },
+    "ram:20000000": {
+      "name": "int_sub_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_int", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_int", "type_int"] },
+      "basic_blocks": {
+        "ram:20000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_int", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:20000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:20000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "INT_SUB", "type": "type_int", "inputs": [{ "type": "type_int", "kind": "parameter", "operation": "p0" }, { "type": "type_int", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_int", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:20000000:entry"
+    },
+    "ram:30000000": {
+      "name": "int_mult_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_int", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_int", "type_int"] },
+      "basic_blocks": {
+        "ram:30000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_int", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:30000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:30000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "INT_MULT", "type": "type_int", "inputs": [{ "type": "type_int", "kind": "parameter", "operation": "p0" }, { "type": "type_int", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_int", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:30000000:entry"
+    },
+    "ram:40000000": {
+      "name": "int_div_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_int", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_int", "type_int"] },
+      "basic_blocks": {
+        "ram:40000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_int", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:40000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:40000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "INT_DIV", "type": "type_int", "inputs": [{ "type": "type_int", "kind": "parameter", "operation": "p0" }, { "type": "type_int", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_int", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:40000000:entry"
+    },
+    "ram:50000000": {
+      "name": "int_rem_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_int", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_int", "type_int"] },
+      "basic_blocks": {
+        "ram:50000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_int", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:50000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:50000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "INT_REM", "type": "type_int", "inputs": [{ "type": "type_int", "kind": "parameter", "operation": "p0" }, { "type": "type_int", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_int", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:50000000:entry"
+    }
+  },
+  "globals": {},
+  "types": {
+    "type_int": { "name": "unsigned int", "size": 4, "kind": "integer" }
+  }
+}

--- a/test/patchir-decomp/int_arith_signed.json
+++ b/test/patchir-decomp/int_arith_signed.json
@@ -1,0 +1,95 @@
+// RUN: bash %strip-json-comments %s > %t.json
+// RUN: %patchir-decomp -input %t.json -use-rellic-transform=false -emit-cir -emit-llvm -output %t >> /dev/null 2>&1
+// RUN: %file-check -vv -check-prefix=CIR %s --input-file %t.cir
+// RUN: %file-check -vv -check-prefix=LL  %s --input-file %t.ll
+// CIR-DAG: cir.func @int_sdiv_test
+// CIR-DAG: cir.func @int_srem_test
+// CIR-DAG: cir.func @int_2comp_test
+// CIR-DAG: cir.binop(div,
+// CIR-DAG: cir.binop(rem,
+// CIR-DAG: cir.unary(minus,
+// LL-DAG: define dso_local i32 @int_sdiv_test
+// LL-DAG: define dso_local i32 @int_srem_test
+// LL-DAG: define dso_local i32 @int_2comp_test
+// LL-DAG: udiv i32
+// LL-DAG: urem i32
+// LL-DAG: sub i32 0,
+{
+  "architecture": "ARM",
+  "id": "ARM:LE:32:Cortex",
+  "format": "Executable and Linking Format (ELF)",
+  "functions": {
+    "ram:10000000": {
+      "name": "int_sdiv_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_int", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_int", "type_int"] },
+      "basic_blocks": {
+        "ram:10000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_int", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:10000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:10000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "INT_SDIV", "type": "type_int", "inputs": [{ "type": "type_int", "kind": "parameter", "operation": "p0" }, { "type": "type_int", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_int", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:10000000:entry"
+    },
+    "ram:20000000": {
+      "name": "int_srem_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_int", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_int", "type_int"] },
+      "basic_blocks": {
+        "ram:20000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_int", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:20000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:20000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "INT_SREM", "type": "type_int", "inputs": [{ "type": "type_int", "kind": "parameter", "operation": "p0" }, { "type": "type_int", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_int", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:20000000:entry"
+    },
+    "ram:30000000": {
+      "name": "int_2comp_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_int", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_int"] },
+      "basic_blocks": {
+        "ram:30000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:30000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "br"]
+        },
+        "ram:30000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "INT_2COMP", "type": "type_int", "inputs": [{ "type": "type_int", "kind": "parameter", "operation": "p0" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_int", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:30000000:entry"
+    }
+  },
+  "globals": {},
+  "types": {
+    "type_int": { "name": "unsigned int", "size": 4, "kind": "integer" }
+  }
+}

--- a/test/patchir-decomp/int_bitwise.json
+++ b/test/patchir-decomp/int_bitwise.json
@@ -1,0 +1,200 @@
+// RUN: bash %strip-json-comments %s > %t.json
+// RUN: %patchir-decomp -input %t.json -use-rellic-transform=false -emit-cir -emit-llvm -output %t >> /dev/null 2>&1
+// RUN: %file-check -vv -check-prefix=CIR %s --input-file %t.cir
+// RUN: %file-check -vv -check-prefix=LL  %s --input-file %t.ll
+// CIR-DAG: cir.func @int_xor_test
+// CIR-DAG: cir.func @int_and_test
+// CIR-DAG: cir.func @int_or_test
+// CIR-DAG: cir.func @int_left_test
+// CIR-DAG: cir.func @int_right_test
+// CIR-DAG: cir.func @int_sright_test
+// CIR-DAG: cir.func @int_negate_test
+// CIR-DAG: cir.binop(xor,
+// CIR-DAG: cir.binop(and,
+// CIR-DAG: cir.binop(or,
+// CIR-DAG: cir.shift(left,
+// CIR-DAG: cir.shift(right,
+// CIR-DAG: cir.unary(not,
+// LL-DAG: define dso_local i32 @int_xor_test
+// LL-DAG: define dso_local i32 @int_and_test
+// LL-DAG: define dso_local i32 @int_or_test
+// LL-DAG: define dso_local i32 @int_left_test
+// LL-DAG: define dso_local i32 @int_right_test
+// LL-DAG: define dso_local i32 @int_sright_test
+// LL-DAG: define dso_local i32 @int_negate_test
+// LL-DAG: xor i32
+// LL-DAG: and i32
+// LL-DAG: or i32
+// LL-DAG: shl i32
+// LL-DAG: lshr i32
+{
+  "architecture": "ARM",
+  "id": "ARM:LE:32:Cortex",
+  "format": "Executable and Linking Format (ELF)",
+  "functions": {
+    "ram:10000000": {
+      "name": "int_xor_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_int", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_int", "type_int"] },
+      "basic_blocks": {
+        "ram:10000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_int", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:10000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:10000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "INT_XOR", "type": "type_int", "inputs": [{ "type": "type_int", "kind": "parameter", "operation": "p0" }, { "type": "type_int", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_int", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:10000000:entry"
+    },
+    "ram:20000000": {
+      "name": "int_and_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_int", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_int", "type_int"] },
+      "basic_blocks": {
+        "ram:20000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_int", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:20000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:20000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "INT_AND", "type": "type_int", "inputs": [{ "type": "type_int", "kind": "parameter", "operation": "p0" }, { "type": "type_int", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_int", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:20000000:entry"
+    },
+    "ram:30000000": {
+      "name": "int_or_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_int", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_int", "type_int"] },
+      "basic_blocks": {
+        "ram:30000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_int", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:30000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:30000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "INT_OR", "type": "type_int", "inputs": [{ "type": "type_int", "kind": "parameter", "operation": "p0" }, { "type": "type_int", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_int", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:30000000:entry"
+    },
+    "ram:40000000": {
+      "name": "int_left_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_int", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_int", "type_int"] },
+      "basic_blocks": {
+        "ram:40000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_int", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:40000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:40000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "INT_LEFT", "type": "type_int", "inputs": [{ "type": "type_int", "kind": "parameter", "operation": "p0" }, { "type": "type_int", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_int", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:40000000:entry"
+    },
+    "ram:50000000": {
+      "name": "int_right_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_int", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_int", "type_int"] },
+      "basic_blocks": {
+        "ram:50000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_int", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:50000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:50000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "INT_RIGHT", "type": "type_int", "inputs": [{ "type": "type_int", "kind": "parameter", "operation": "p0" }, { "type": "type_int", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_int", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:50000000:entry"
+    },
+    "ram:60000000": {
+      "name": "int_sright_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_int", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_int", "type_int"] },
+      "basic_blocks": {
+        "ram:60000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_int", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:60000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:60000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "INT_SRIGHT", "type": "type_int", "inputs": [{ "type": "type_int", "kind": "parameter", "operation": "p0" }, { "type": "type_int", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_int", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:60000000:entry"
+    },
+    "ram:70000000": {
+      "name": "int_negate_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_int", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_int"] },
+      "basic_blocks": {
+        "ram:70000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:70000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "br"]
+        },
+        "ram:70000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "INT_NEGATE", "type": "type_int", "inputs": [{ "type": "type_int", "kind": "parameter", "operation": "p0" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_int", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:70000000:entry"
+    }
+  },
+  "globals": {},
+  "types": {
+    "type_int": { "name": "unsigned int", "size": 4, "kind": "integer" }
+  }
+}

--- a/test/patchir-decomp/int_carry.json
+++ b/test/patchir-decomp/int_carry.json
@@ -1,0 +1,88 @@
+// RUN: bash %strip-json-comments %s > %t.json
+// RUN: %patchir-decomp -input %t.json -use-rellic-transform=false -emit-cir -emit-llvm -output %t >> /dev/null 2>&1
+// RUN: %file-check -vv -check-prefix=CIR %s --input-file %t.cir
+// RUN: %file-check -vv -check-prefix=LL  %s --input-file %t.ll
+// CIR-DAG: cir.func @int_carry_test
+// CIR-DAG: cir.func @int_sborrow_test
+// CIR-DAG: cir.binop(add,
+// CIR-DAG: cir.binop(xor,
+// CIR-DAG: cir.binop(sub,
+// CIR-DAG: cir.cmp(lt,
+// LL-DAG: define {{.*}} @int_carry_test
+// LL-DAG: define {{.*}} @int_sborrow_test
+// LL-DAG: add i32
+// LL-DAG: xor i32
+// LL-DAG: sub i32
+// LL-DAG: icmp ult i32
+{
+  "architecture": "ARM",
+  "id": "ARM:LE:32:Cortex",
+  "format": "Executable and Linking Format (ELF)",
+  "functions": {
+    "ram:10000000": {
+      "name": "int_carry_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_bool", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_int", "type_int"] },
+      "basic_blocks": {
+        "ram:10000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_int", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:10000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:10000000:0:basic": {
+          "operations": {
+            "op0": {
+              "mnemonic": "INT_CARRY",
+              "type": "type_bool",
+              "inputs": [
+                { "type": "type_int", "kind": "parameter", "operation": "p0" },
+                { "type": "type_int", "kind": "parameter", "operation": "p1" }
+              ]
+            },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_bool", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:10000000:entry"
+    },
+    "ram:20000000": {
+      "name": "int_sborrow_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_bool", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_int", "type_int"] },
+      "basic_blocks": {
+        "ram:20000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_int", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:20000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:20000000:0:basic": {
+          "operations": {
+            "op0": {
+              "mnemonic": "INT_SBORROW",
+              "type": "type_bool",
+              "inputs": [
+                { "type": "type_int", "kind": "parameter", "operation": "p0" },
+                { "type": "type_int", "kind": "parameter", "operation": "p1" }
+              ]
+            },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_bool", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:20000000:entry"
+    }
+  },
+  "globals": {},
+  "types": {
+    "type_int": { "name": "unsigned int", "size": 4, "kind": "integer" },
+    "type_bool": { "name": "bool", "size": 1, "kind": "boolean" }
+  }
+}

--- a/test/patchir-decomp/int_compare.json
+++ b/test/patchir-decomp/int_compare.json
@@ -1,0 +1,174 @@
+// RUN: bash %strip-json-comments %s > %t.json
+// RUN: %patchir-decomp -input %t.json -use-rellic-transform=false -emit-cir -emit-llvm -output %t >> /dev/null 2>&1
+// RUN: %file-check -vv -check-prefix=CIR %s --input-file %t.cir
+// RUN: %file-check -vv -check-prefix=LL  %s --input-file %t.ll
+// CIR-DAG: cir.func @int_eq_test
+// CIR-DAG: cir.func @int_ne_test
+// CIR-DAG: cir.func @int_lt_test
+// CIR-DAG: cir.func @int_le_test
+// CIR-DAG: cir.func @int_slt_test
+// CIR-DAG: cir.func @int_sle_test
+// CIR-DAG: cir.cmp(eq,
+// CIR-DAG: cir.cmp(ne,
+// CIR-DAG: cir.cmp(lt,
+// CIR-DAG: cir.cmp(le,
+// LL-DAG: define {{.*}} @int_eq_test
+// LL-DAG: define {{.*}} @int_ne_test
+// LL-DAG: define {{.*}} @int_lt_test
+// LL-DAG: define {{.*}} @int_le_test
+// LL-DAG: define {{.*}} @int_slt_test
+// LL-DAG: define {{.*}} @int_sle_test
+// LL-DAG: icmp eq i32
+// LL-DAG: icmp ne i32
+// LL-DAG: icmp ult i32
+// LL-DAG: icmp ule i32
+{
+  "architecture": "ARM",
+  "id": "ARM:LE:32:Cortex",
+  "format": "Executable and Linking Format (ELF)",
+  "functions": {
+    "ram:10000000": {
+      "name": "int_eq_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_bool", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_int", "type_int"] },
+      "basic_blocks": {
+        "ram:10000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_int", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:10000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:10000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "INT_EQUAL", "type": "type_bool", "inputs": [{ "type": "type_int", "kind": "parameter", "operation": "p0" }, { "type": "type_int", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_bool", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:10000000:entry"
+    },
+    "ram:20000000": {
+      "name": "int_ne_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_bool", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_int", "type_int"] },
+      "basic_blocks": {
+        "ram:20000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_int", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:20000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:20000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "INT_NOTEQUAL", "type": "type_bool", "inputs": [{ "type": "type_int", "kind": "parameter", "operation": "p0" }, { "type": "type_int", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_bool", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:20000000:entry"
+    },
+    "ram:30000000": {
+      "name": "int_lt_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_bool", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_int", "type_int"] },
+      "basic_blocks": {
+        "ram:30000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_int", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:30000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:30000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "INT_LESS", "type": "type_bool", "inputs": [{ "type": "type_int", "kind": "parameter", "operation": "p0" }, { "type": "type_int", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_bool", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:30000000:entry"
+    },
+    "ram:40000000": {
+      "name": "int_le_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_bool", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_int", "type_int"] },
+      "basic_blocks": {
+        "ram:40000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_int", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:40000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:40000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "INT_LESSEQUAL", "type": "type_bool", "inputs": [{ "type": "type_int", "kind": "parameter", "operation": "p0" }, { "type": "type_int", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_bool", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:40000000:entry"
+    },
+    "ram:50000000": {
+      "name": "int_slt_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_bool", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_int", "type_int"] },
+      "basic_blocks": {
+        "ram:50000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_int", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:50000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:50000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "INT_SLESS", "type": "type_bool", "inputs": [{ "type": "type_int", "kind": "parameter", "operation": "p0" }, { "type": "type_int", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_bool", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:50000000:entry"
+    },
+    "ram:60000000": {
+      "name": "int_sle_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_bool", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_int", "type_int"] },
+      "basic_blocks": {
+        "ram:60000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "b", "type": "type_int", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:60000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:60000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "INT_SLESSEQUAL", "type": "type_bool", "inputs": [{ "type": "type_int", "kind": "parameter", "operation": "p0" }, { "type": "type_int", "kind": "parameter", "operation": "p1" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_bool", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:60000000:entry"
+    }
+  },
+  "globals": {},
+  "types": {
+    "type_int": { "name": "unsigned int", "size": 4, "kind": "integer" },
+    "type_bool": { "name": "bool", "size": 1, "kind": "boolean" }
+  }
+}

--- a/test/patchir-decomp/int_extend.json
+++ b/test/patchir-decomp/int_extend.json
@@ -1,0 +1,66 @@
+// RUN: bash %strip-json-comments %s > %t.json
+// RUN: %patchir-decomp -input %t.json -use-rellic-transform=false -emit-cir -emit-llvm -output %t >> /dev/null 2>&1
+// RUN: %file-check -vv -check-prefix=CIR %s --input-file %t.cir
+// RUN: %file-check -vv -check-prefix=LL  %s --input-file %t.ll
+// CIR-DAG: cir.func @int_zext_test
+// CIR-DAG: cir.func @int_sext_test
+// CIR-DAG: cir.cast(integral,
+// LL-DAG: define dso_local i32 @int_zext_test
+// LL-DAG: define dso_local i32 @int_sext_test
+// LL-DAG: zext i8
+{
+  "architecture": "ARM",
+  "id": "ARM:LE:32:Cortex",
+  "format": "Executable and Linking Format (ELF)",
+  "functions": {
+    "ram:10000000": {
+      "name": "int_zext_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_int", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_byte"] },
+      "basic_blocks": {
+        "ram:10000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_byte", "kind": "parameter", "index": 0 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:10000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "br"]
+        },
+        "ram:10000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "INT_ZEXT", "type": "type_int", "inputs": [{ "type": "type_byte", "kind": "parameter", "operation": "p0" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_int", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:10000000:entry"
+    },
+    "ram:20000000": {
+      "name": "int_sext_test",
+      "is_intrinsic": false,
+      "type": { "return_type": "type_int", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_byte"] },
+      "basic_blocks": {
+        "ram:20000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_byte", "kind": "parameter", "index": 0 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:20000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "br"]
+        },
+        "ram:20000000:0:basic": {
+          "operations": {
+            "op0": { "mnemonic": "INT_SEXT", "type": "type_int", "inputs": [{ "type": "type_byte", "kind": "parameter", "operation": "p0" }] },
+            "ret": { "mnemonic": "RETURN", "inputs": [{ "type": "type_int", "kind": "temporary", "operation": "op0" }] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:20000000:entry"
+    }
+  },
+  "globals": {},
+  "types": {
+    "type_int": { "name": "unsigned int", "size": 4, "kind": "integer" },
+    "type_byte": { "name": "unsigned char", "size": 1, "kind": "integer" }
+  }
+}

--- a/test/patchir-decomp/memory_ops.json
+++ b/test/patchir-decomp/memory_ops.json
@@ -1,0 +1,93 @@
+// RUN: bash %strip-json-comments %s > %t.json
+// RUN: %patchir-decomp -input %t.json -use-rellic-transform=false -emit-cir -emit-llvm -output %t >> /dev/null 2>&1
+// RUN: %file-check -vv -check-prefix=CIR %s --input-file %t.cir
+// RUN: %file-check -vv -check-prefix=LL  %s --input-file %t.ll
+// CIR-DAG: cir.func @load_test
+// CIR-DAG: cir.func @store_test
+// CIR-DAG: cir.load deref
+// CIR-DAG: cir.store
+// LL-DAG: define dso_local i32 @load_test
+// LL-DAG: define {{.*}} @store_test
+// LL-DAG: load i32, ptr
+// LL-DAG: store i32
+{
+  "architecture": "ARM",
+  "id": "ARM:LE:32:Cortex",
+  "format": "Executable and Linking Format (ELF)",
+  "functions": {
+    "ram:10000000": {
+      "name": "load_test",
+      "is_intrinsic": false,
+      "type": {
+        "return_type": "type_int",
+        "is_variadic": false,
+        "is_noreturn": false,
+        "parameter_types": ["type_ptr_int"]
+      },
+      "basic_blocks": {
+        "ram:10000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "ptr", "type": "type_ptr_int", "kind": "parameter", "index": 0 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:10000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "br"]
+        },
+        "ram:10000000:0:basic": {
+          "operations": {
+            "op0": {
+              "mnemonic": "LOAD",
+              "type": "type_int",
+              "inputs": [{ "type": "type_ptr_int", "kind": "parameter", "operation": "p0" }]
+            },
+            "ret": {
+              "mnemonic": "RETURN",
+              "inputs": [{ "type": "type_int", "kind": "temporary", "operation": "op0" }]
+            }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:10000000:entry"
+    },
+    "ram:20000000": {
+      "name": "store_test",
+      "is_intrinsic": false,
+      "type": {
+        "return_type": "type_void",
+        "is_variadic": false,
+        "is_noreturn": false,
+        "parameter_types": ["type_ptr_int", "type_int"]
+      },
+      "basic_blocks": {
+        "ram:20000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "ptr", "type": "type_ptr_int", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "val", "type": "type_int", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:20000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:20000000:0:basic": {
+          "operations": {
+            "op0": {
+              "mnemonic": "STORE",
+              "inputs": [
+                { "type": "type_ptr_int", "kind": "parameter", "operation": "p0" },
+                { "type": "type_int", "kind": "parameter", "operation": "p1" }
+              ]
+            },
+            "ret": { "mnemonic": "RETURN", "inputs": [] }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:20000000:entry"
+    }
+  },
+  "globals": {},
+  "types": {
+    "type_int": { "name": "unsigned int", "size": 4, "kind": "integer" },
+    "type_ptr_int": { "kind": "pointer", "size": 4, "element_type": "type_int" },
+    "type_void": { "name": "void", "size": 0, "kind": "void" }
+  }
+}

--- a/test/patchir-decomp/ptr_ops.json
+++ b/test/patchir-decomp/ptr_ops.json
@@ -1,0 +1,59 @@
+// RUN: bash %strip-json-comments %s > %t.json
+// RUN: %patchir-decomp -input %t.json -use-rellic-transform=false -emit-cir -emit-llvm -output %t >> /dev/null 2>&1
+// RUN: %file-check -vv -check-prefix=CIR %s --input-file %t.cir
+// RUN: %file-check -vv -check-prefix=LL  %s --input-file %t.ll
+// CIR: cir.func @ptradd_test
+// CIR: cir.ptr_stride(
+// LL: define {{.*}} @ptradd_test
+// LL: getelementptr i32
+{
+  "architecture": "ARM",
+  "id": "ARM:LE:32:Cortex",
+  "format": "Executable and Linking Format (ELF)",
+  "functions": {
+    "ram:10000000": {
+      "name": "ptradd_test",
+      "is_intrinsic": false,
+      "type": {
+        "return_type": "type_ptr_int",
+        "is_variadic": false,
+        "is_noreturn": false,
+        "parameter_types": ["type_ptr_int", "type_int"]
+      },
+      "basic_blocks": {
+        "ram:10000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "ptr", "type": "type_ptr_int", "kind": "parameter", "index": 0 },
+            "p1": { "mnemonic": "DECLARE_PARAMETER", "name": "offset", "type": "type_int", "kind": "parameter", "index": 1 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:10000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "p1", "br"]
+        },
+        "ram:10000000:0:basic": {
+          "operations": {
+            "op0": {
+              "mnemonic": "PTRADD",
+              "type": "type_ptr_int",
+              "inputs": [
+                { "type": "type_ptr_int", "kind": "parameter", "operation": "p0" },
+                { "type": "type_int", "kind": "parameter", "operation": "p1" },
+                { "type": "type_int", "kind": "constant", "value": 1 }
+              ]
+            },
+            "ret": {
+              "mnemonic": "RETURN",
+              "inputs": [{ "type": "type_ptr_int", "kind": "temporary", "operation": "op0" }]
+            }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:10000000:entry"
+    }
+  },
+  "globals": {},
+  "types": {
+    "type_int": { "name": "unsigned int", "size": 4, "kind": "integer" },
+    "type_ptr_int": { "kind": "pointer", "size": 4, "element_type": "type_int" }
+  }
+}

--- a/test/patchir-decomp/subpiece.json
+++ b/test/patchir-decomp/subpiece.json
@@ -1,0 +1,58 @@
+// RUN: bash %strip-json-comments %s > %t.json
+// RUN: %patchir-decomp -input %t.json -use-rellic-transform=false -emit-cir -emit-llvm -output %t >> /dev/null 2>&1
+// RUN: %file-check -vv -check-prefix=CIR %s --input-file %t.cir
+// RUN: %file-check -vv -check-prefix=LL  %s --input-file %t.ll
+// CIR: cir.func @subpiece_test
+// CIR: cir.cast(integral,
+// LL: define dso_local i8 @subpiece_test
+// LL: trunc i32
+{
+  "architecture": "ARM",
+  "id": "ARM:LE:32:Cortex",
+  "format": "Executable and Linking Format (ELF)",
+  "functions": {
+    "ram:10000000": {
+      "name": "subpiece_test",
+      "is_intrinsic": false,
+      "type": {
+        "return_type": "type_byte",
+        "is_variadic": false,
+        "is_noreturn": false,
+        "parameter_types": ["type_int"]
+      },
+      "basic_blocks": {
+        "ram:10000000:entry": {
+          "operations": {
+            "p0": { "mnemonic": "DECLARE_PARAMETER", "name": "a", "type": "type_int", "kind": "parameter", "index": 0 },
+            "br": { "mnemonic": "BRANCH", "target_block": "ram:10000000:0:basic" }
+          },
+          "ordered_operations": ["p0", "br"]
+        },
+        "ram:10000000:0:basic": {
+          "operations": {
+            "op0": {
+              "mnemonic": "SUBPIECE",
+              "type": "type_byte",
+              "inputs": [
+                { "type": "type_int", "kind": "parameter", "operation": "p0" },
+                { "type": "type_offset", "kind": "constant", "value": 0 }
+              ]
+            },
+            "ret": {
+              "mnemonic": "RETURN",
+              "inputs": [{ "type": "type_byte", "kind": "temporary", "operation": "op0" }]
+            }
+          },
+          "ordered_operations": ["op0", "ret"]
+        }
+      },
+      "entry_block": "ram:10000000:entry"
+    }
+  },
+  "globals": {},
+  "types": {
+    "type_int": { "name": "unsigned int", "size": 4, "kind": "integer" },
+    "type_byte": { "name": "unsigned char", "size": 1, "kind": "integer" },
+    "type_offset": { "name": "undefined4", "size": 4, "kind": "undefined" }
+  }
+}


### PR DESCRIPTION
Improved test coverage:
- Boolean operations: Added tests for negation, OR, and AND with proper parameter and return handling in `bool_ops.json`.
- Bit manipulation: Added tests for popcount and leading zero count operations in `bit_ops.json`.
- Float arithmetic: Added tests for addition, subtraction, multiplication, and division of floats in `float_arith.json`.
- Float comparison: Added tests for equality, inequality, less than, and less than or equal comparisons between floats in `float_compare.json`.
- Float ceiling: Added a test for the ceiling operation on floats in `float_ceil.json`.
- Variable declaration and copy: Added a test for declaring parameters, locals, and temporaries, and copying values between them in `copy_declare.json`.