### PR TITLE
docs: expand AGENTS coverage and add maintained flow diagram

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,7 @@ patchir-yaml-parser config.yaml --validate
 - Build walkthrough: `docs/GettingStarted/build.md`
 - Firmware example flow: `docs/GettingStarted/firmware_examples.md`
 - Host ARM64 image build for macOS: `.devcontainer/README-HOST-BUILD.md`
+- System data flow diagram: `docs/system_data_flow.md`
 - Claude-specific workflow notes: `.claude/rules/*.md`
 
 ## Test Suites
@@ -408,8 +409,19 @@ Before requesting review:
 2. Run targeted builds/tests for touched components, plus any affected integration tests.
 3. Include a clear PR description: behavior change, design notes, and test evidence.
 4. If changing docs/process, ensure commands are copy/paste valid and up to date.
+5. If changing a data-flow boundary, tool interface, or owned module interface, update `docs/system_data_flow.md` in the same PR.
 
 Commit message format:
 
 - `component: Simple sentence with a period.`
 - Keep subject <= 80 characters.
+
+## Gardening Tasks
+
+These are recurring maintenance tasks that keep the repository documentation and
+developer guidance aligned with the code:
+
+1. Validate that `docs/system_data_flow.md` still matches the actual toolchain, test coverage, and repository-owned interfaces.
+2. Update the module/interface inventory in this document when patchestry-owned libraries, tools, dialects, scripts, or test suites change.
+3. Keep vendored dependency revisions and purposes current when submodules or integration boundaries change.
+4. Ensure PRs that change affected interfaces or data-flow boundaries also update the corresponding diagram and docs in the same change.

--- a/docs/system_data_flow.md
+++ b/docs/system_data_flow.md
@@ -1,0 +1,90 @@
+# Patchestry System Data Flow
+
+This document describes the repository-owned data flow through Patchestry.
+It is intentionally scoped to patchestry code, interfaces, tools, scripts, and
+documented downstream handoff points. It does not attempt to document the
+internals of LLVM, MLIR, or vendored dependencies.
+
+## End-to-End Data Flow
+
+```text
+[Input firmware binary]
+    |
+    | scripts/ghidra/decompile-headless.sh
+    | scripts/ghidra/PatchestryDecompileFunctions.java
+    | scripts/ghidra/util/{FunctionSerializer,PcodeSerializer}.java
+    v
+[Ghidra-exported JSON]
+    |
+    | patchir-decomp
+    |   uses:
+    |   - patchestry_ghidra: JSON -> in-memory program/P-Code model
+    |   - patchestry_ast: Ghidra model -> Clang AST/CIR-ready structures
+    |   - patchestry_codegen: emit selected output form
+    v
+[Decompilation outputs]
+    |- High-level MLIR        (--emit-mlir)      [tested]
+    |- CIR                    (--emit-cir)       [tested]
+    |- LLVM IR                (--emit-llvm)      [tested]
+    |- Pretty-printed C TU    (--print-tu)       [tested]
+    |- Assembly               (--emit-asm)       [supported in code]
+    \- Object file            (--emit-obj)       [supported in code]
+
+Optional side path:
+[Ghidra-exported JSON]
+    |
+    | pcode-translate
+    |   uses patchestry_ghidra + MLIRPcode registration
+    v
+[P-Code translation output]
+    \- textual translation output via mlir-translate driver   [tested]
+
+Main patching path:
+[CIR from patchir-decomp or hand-provided CIR]
+    +
+[YAML patch/contract spec]
+    +
+[Patch C code / contract C code]
+    |
+    | patchir-transform
+    |   uses:
+    |   - patchestry_yaml: parse config/specs
+    |   - patchestry_passes: match + apply patch/contract actions
+    |   - MLIRContracts: contract attrs/metadata
+    v
+[Patched CIR]
+    |
+    | patchir-cir2llvm
+    |   uses:
+    |   - CIR lowering
+    |   - MLIRContracts metadata preservation
+    v
+[LLVM output]
+    |- LLVM IR text (.ll)     (-S)              [supported]
+    \- LLVM bitcode (.bc)     (default mode)    [supported]
+
+Downstream of this repo:
+[LLVM IR / bitcode with patch + contract metadata]
+    |
+    \- external binary rewriting / verification tools
+       e.g. final patched binary, KLEE/SeaHorn-style analysis
+```
+
+## Notes on Outputs
+
+- `patchir-decomp` can stop at multiple output layers depending on flags:
+  high-level MLIR, CIR, LLVM IR, pretty-printed C, assembly, or object output.
+- `patchir-transform` produces patched CIR.
+- `patchir-cir2llvm` produces LLVM IR text or LLVM bitcode.
+- `patchir-yaml-parser` produces validation/inspection output, not a transformed
+  firmware artifact.
+- Final patched binaries are downstream of this repository's core toolchain and
+  are not the primary in-repo artifact produced by the tested flows here.
+
+## Maintenance Contract
+
+- This diagram should match the current code, tests, and documented workflows.
+- If a change adds, removes, or reroutes an input, output, tool boundary,
+  script entrypoint, or interface handoff, update this document in the same PR.
+- If a PR changes an affected interface and does not update this diagram, treat
+  that as documentation debt to fix before merge.


### PR DESCRIPTION
## Summary
- expand `AGENTS.md` so it is exhaustive for patchestry-owned modules, interfaces, tests, and workflows
- add a maintained system data-flow diagram in `docs/system_data_flow.md` and require interface-affecting PRs to keep it current
- validate the host-native Apple Silicon macOS build path against the patched `trail-of-forks/clangir` toolchain and fix the issues surfaced by that validation
- update build and firmware docs so they match the build and test flow that actually works on macOS

## Build/validation changes
- make nested vendored dependency builds reconfigure cleanly when switching between host and container builds
- avoid forcing `lld` on Darwin in vendored nested builds
- make the vendored rellic path usable without network-only helper tools for the patchestry build
- remove exception-based YAML integer parsing so the build works with LLVM's `-fno-exceptions` flags
- make the standalone intrinsics build succeed on macOS
- fix lit environment setup so LLVM helper tools such as `not` are found during test runs

## Validated on Apple Silicon macOS
Using the patched `trail-of-forks/clangir` toolchain installed locally:

```sh
export LLVM_INSTALL_PREFIX=<patched clangir install>
export CC="${LLVM_INSTALL_PREFIX}/bin/clang"
export CXX="${LLVM_INSTALL_PREFIX}/bin/clang++"
export CMAKE_PREFIX_PATH="${LLVM_INSTALL_PREFIX}/lib/cmake/llvm;${LLVM_INSTALL_PREFIX}/lib/cmake/mlir;${LLVM_INSTALL_PREFIX}/lib/cmake/clang"

cmake --fresh --preset default -DLLVM_EXTERNAL_LIT=$(which lit)
cmake --build --preset debug -j4
cmake -S lib/patchestry/intrinsics -B lib/patchestry/intrinsics/build_standalone -DCMAKE_BUILD_TYPE=Release
cmake --build lib/patchestry/intrinsics/build_standalone -j4
bash ./scripts/ghidra/build-headless-docker.sh
lit ./builds/default/test -D BUILD_TYPE=Debug -v
```

## Test results
- `cmake --build --preset debug -j4`
- `cmake --build lib/patchestry/intrinsics/build_standalone -j4`
- `bash ./scripts/ghidra/build-headless-docker.sh`
- `lit ./builds/default/test -D BUILD_TYPE=Debug -v`
- full lit result: `Passed: 75/75`

## Notes
- the validated macOS path is host-native against the patched fork; the docs no longer present `linux/amd64` emulation on Apple Silicon as the routine path
- the Ghidra headless image was built natively for `linux_arm_64`
