### PR TITLE
test: add path traversal patch specification

### DIFF
--- a/test/patchir-transform/cwe022_before.yaml
+++ b/test/patchir-transform/cwe022_before.yaml
@@ -1,0 +1,39 @@
+# Test patching specification
+apiVersion: patchestry.io/v1
+
+metadata:
+  name: "cwe022-apply_before"
+  description: "Reject directory traversal sequences before mkdir"
+  version: "1.0.0"
+  author: "Security Team"
+  created: "2026-03-17"
+
+target:
+  binary: "test_binary.bin"
+  arch: "ARM:LE:32"
+
+libraries:
+  - "patches/cwe022_patches.yaml"
+
+meta_patches:
+  - name: "cwe022_mkdir_fix"
+    description: "Reject directory traversal sequences before mkdir"
+
+    patch_actions:
+      - id: "CWE-022-001"
+        description: "Validate path against directory traversal before mkdir"
+
+        match:
+          - name: "mkdir"
+            kind: "function"
+            function_context:
+              - name: "init_logger"
+
+        action:
+          - mode: "apply_before"
+            patch_id: "cwe022_path_validation"
+            description: "Reject directory traversal sequences before mkdir"
+            arguments:
+              - name: "path"
+                source: "operand"
+                index: 0

--- a/test/patchir-transform/patches/cwe022_patches.yaml
+++ b/test/patchir-transform/patches/cwe022_patches.yaml
@@ -1,0 +1,21 @@
+# patches/cwe022_patches.yaml
+
+apiVersion: patchestry.io/v1
+
+metadata:
+  name: "cwe022_patches"
+  version: "1.0.0"
+  description: "CWE-022 patches"
+  author: "Security Team"
+  created: "2026-03-17"
+
+patches:
+  - name: "cwe022_path_validation"
+    description: "Validate path against directory traversal before mkdir"
+    category: "input_validation"
+    code_file: "patches/patch_mkdir.c"
+    function_name: "patch::before::mkdir"
+    parameters:
+      - name: "path"
+        type: "const void*"
+        description: "Path to validate"

--- a/test/patchir-transform/patches/patch_mkdir.c
+++ b/test/patchir-transform/patches/patch_mkdir.c
@@ -1,0 +1,26 @@
+// RUN: true
+extern void halt();
+
+// CWE-22: Injected before mkdir — rejects path traversal and absolute paths.
+// Blocks:
+//   - Relative traversal: "../" sequences anywhere in the path
+//   - Absolute paths: paths starting with "/" that escape the intended directory
+void patch__before__mkdir(const void *path) {
+    const char *p = (const char *)path;
+    if (!p) { halt(); return; }
+
+    // Reject absolute paths — caller should only create subdirectories
+    if (p[0] == '/') {
+        halt();
+        return;
+    }
+
+    // Reject relative traversal sequences
+    while (*p) {
+        if (p[0] == '.' && p[1] == '.' && (p[2] == '/' || p[2] == '\0')) {
+            halt();
+            return;
+        }
+        p++;
+    }
+}

--- a/test/patchir-transform/ventilator_cwe022.json
+++ b/test/patchir-transform/ventilator_cwe022.json
@@ -1,0 +1,124 @@
+// RUN: bash %strip-json-comments %s > %t.json
+// RUN: %patchir-decomp -input %t.json -emit-cir -output %t1 >> /dev/null 2>&1
+//
+// RUN: %patchir-transform %t1.cir --spec %S/cwe022_before.yaml -o %t2.cir
+// RUN: %file-check -vv -check-prefix=BEFORE %s --input-file %t2.cir
+// BEFORE: @patch__before__mkdir
+//
+{
+  "architecture": "ARM",
+  "id": "ARM:LE:32:Cortex",
+  "format": "Executable and Linking Format (ELF)",
+  "functions": {
+    "ram:10000000": {
+      "name": "init_logger",
+      "is_intrinsic": false,
+      "type": {
+        "return_type": "t_void",
+        "is_variadic": false,
+        "is_noreturn": false,
+        "parameter_types": [
+          "t_ptr_void"
+        ]
+      },
+      "basic_blocks": {
+        "ram:10000000:entry": {
+          "operations": {
+            "unique:00000000:0:0": {
+              "mnemonic": "DECLARE_PARAMETER",
+              "name": "log_dir",
+              "type": "t_ptr_void",
+              "kind": "parameter",
+              "index": 0
+            },
+            "entry.exit": {
+              "mnemonic": "BRANCH",
+              "target_block": "ram:10000010:0:basic"
+            },
+            "unique:00000001:1:0": {
+              "mnemonic": "DECLARE_LOCAL",
+              "kind": "local",
+              "name": "mkdir_ret",
+              "type": "t_u32"
+            }
+          },
+          "ordered_operations": [
+            "unique:00000000:0:0",
+            "unique:00000001:1:0",
+            "entry.exit"
+          ]
+        },
+        "ram:10000010:0:basic": {
+          "operations": {
+            "ram:10000010:100:0": {
+              "mnemonic": "CALL",
+              "type": "t_u32",
+              "has_return_value": true,
+              "target": {
+                "kind": "function",
+                "function": "EXTERNAL:00000001",
+                "is_variadic": false,
+                "is_noreturn": false
+              },
+              "inputs": [
+                {
+                  "type": "t_ptr_void",
+                  "kind": "parameter",
+                  "operation": "unique:00000000:0:0"
+                },
+                {
+                  "type": "t_u32",
+                  "kind": "constant",
+                  "value": 511
+                }
+              ],
+              "output": {
+                "kind": "local",
+                "operation": "unique:00000001:1:0"
+              }
+            },
+            "ram:10000018:101:1": {
+              "mnemonic": "RETURN",
+              "inputs": []
+            }
+          },
+          "ordered_operations": [
+            "ram:10000010:100:0",
+            "ram:10000018:101:1"
+          ]
+        }
+      },
+      "entry_block": "ram:10000000:entry"
+    },
+    "EXTERNAL:00000001": {
+      "name": "mkdir",
+      "is_intrinsic": false,
+      "type": {
+        "return_type": "t_u32",
+        "is_variadic": false,
+        "is_noreturn": false,
+        "parameter_types": [
+          "t_ptr_void",
+          "t_u32"
+        ]
+      }
+    }
+  },
+  "types": {
+    "t_void": {
+      "name": "void",
+      "size": 0,
+      "kind": "void"
+    },
+    "t_u32": {
+      "name": "unsigned int",
+      "size": 4,
+      "kind": "integer"
+    },
+    "t_ptr_void": {
+      "kind": "pointer",
+      "size": 4,
+      "element_type": "t_void"
+    }
+  }
+}


### PR DESCRIPTION
Add patch specification for CWE-22 (Path Traversal) targeting mkdir called with unsanitized user input containing ../ sequences.

- P-Code JSON representing init_logger() with mkdir() call
- Patch injects traversal sequence check before mkdir, halts on ../
- Uses apply_before mode to validate path argument