### PR TITLE
test: add heap buffer overflow patch specification

### DIFF
--- a/test/patchir-transform/cwe122_replace.yaml
+++ b/test/patchir-transform/cwe122_replace.yaml
@@ -1,0 +1,48 @@
+# Test patching specification
+apiVersion: patchestry.io/v1
+
+metadata:
+  name: "cwe122-replace"
+  description: "Fix heap buffer overflow by bounding memcpy to allocation size"
+  version: "1.0.0"
+  author: "Security Team"
+  created: "2026-03-17"
+
+target:
+  binary: "test_binary.bin"
+  arch: "ARM:LE:32"
+
+libraries:
+  - "patches/cwe122_patches.yaml"
+
+meta_patches:
+  - name: "cwe122_memcpy_fix"
+    description: "Cap memcpy to allocation size in process_rx"
+
+    patch_actions:
+      - id: "CWE-122-001"
+        description: "Replace unbounded memcpy in process_rx"
+
+        match:
+          - name: "memcpy"
+            kind: "function"
+            function_context:
+              - name: "process_rx"
+
+        action:
+          - mode: "replace"
+            patch_id: "cwe122_bounded_memcpy"
+            description: "Replace memcpy with bounded version"
+            arguments:
+              - name: "dest"
+                source: "operand"
+                index: 0
+              - name: "src"
+                source: "operand"
+                index: 1
+              - name: "n"
+                source: "operand"
+                index: 2
+              - name: "max_size"
+                source: "constant"
+                value: 256

--- a/test/patchir-transform/patches/cwe122_patches.yaml
+++ b/test/patchir-transform/patches/cwe122_patches.yaml
@@ -1,0 +1,30 @@
+# patches/cwe122_patches.yaml
+
+apiVersion: patchestry.io/v1
+
+metadata:
+  name: "cwe122_patches"
+  version: "1.0.0"
+  description: "CWE-122 heap buffer overflow patches"
+  author: "Security Team"
+  created: "2026-03-17"
+
+patches:
+  - name: "cwe122_bounded_memcpy"
+    description: "Replace unbounded memcpy with size-capped version"
+    category: "memory_safety"
+    code_file: "patches/patch_memcpy.c"
+    function_name: "patch::replace::memcpy"
+    parameters:
+      - name: "dest"
+        type: "void*"
+        description: "Destination buffer"
+      - name: "src"
+        type: "const void*"
+        description: "Source buffer"
+      - name: "n"
+        type: "size_t"
+        description: "Original requested size"
+      - name: "max_size"
+        type: "size_t"
+        description: "Maximum allowed copy size"

--- a/test/patchir-transform/patches/patch_memcpy.c
+++ b/test/patchir-transform/patches/patch_memcpy.c
@@ -1,0 +1,15 @@
+// RUN: true
+typedef unsigned long size_t;
+
+extern void *memcpy(void *dest, const void *src, size_t n);
+
+// CWE-122: Replace unbounded memcpy with size-capped version.
+// The vulnerable pattern is memcpy into a heap buffer where the copy
+// size is attacker-controlled and can exceed the allocation size.
+void *patch__replace__memcpy(void *dest, const void *src,
+                             size_t n, size_t max_size) {
+    if (n > max_size) {
+        n = max_size;
+    }
+    return memcpy(dest, src, n);
+}

--- a/test/patchir-transform/ventilator_cwe122.json
+++ b/test/patchir-transform/ventilator_cwe122.json
@@ -1,0 +1,221 @@
+// RUN: bash %strip-json-comments %s > %t.json
+// RUN: %patchir-decomp -input %t.json -emit-cir -output %t1 >> /dev/null 2>&1
+//
+// RUN: %patchir-transform %t1.cir --spec %S/cwe122_replace.yaml -o %t2.cir
+// RUN: %file-check -vv -check-prefix=REPLACE %s --input-file %t2.cir
+// REPLACE: cir.call @patch__replace__memcpy({{.*}}) {patchestry_operation = "cir.call"}
+//
+{
+  "architecture": "ARM",
+  "id": "ARM:LE:32:Cortex",
+  "format": "Executable and Linking Format (ELF)",
+  "functions": {
+    "ram:10000000": {
+      "name": "process_rx",
+      "is_intrinsic": false,
+      "type": {
+        "return_type": "t_void",
+        "is_variadic": false,
+        "is_noreturn": false,
+        "parameter_types": [
+          "t_ptr_u8",
+          "t_u32"
+        ]
+      },
+      "basic_blocks": {
+        "ram:10000000:entry": {
+          "operations": {
+            "unique:00000000:0:0": {
+              "mnemonic": "DECLARE_PARAMETER",
+              "name": "data",
+              "type": "t_ptr_u8",
+              "kind": "parameter",
+              "index": 0
+            },
+            "unique:00000001:1:0": {
+              "mnemonic": "DECLARE_PARAMETER",
+              "name": "length",
+              "type": "t_u32",
+              "kind": "parameter",
+              "index": 1
+            },
+            "unique:00000002:2:0": {
+              "mnemonic": "DECLARE_LOCAL",
+              "kind": "local",
+              "name": "buf",
+              "type": "t_ptr_u8"
+            },
+            "unique:00000003:3:0": {
+              "mnemonic": "DECLARE_LOCAL",
+              "kind": "local",
+              "name": "alloc_ret",
+              "type": "t_ptr_void"
+            },
+            "entry.exit": {
+              "mnemonic": "BRANCH",
+              "target_block": "ram:10000010:0:basic"
+            }
+          },
+          "ordered_operations": [
+            "unique:00000000:0:0",
+            "unique:00000001:1:0",
+            "unique:00000002:2:0",
+            "unique:00000003:3:0",
+            "entry.exit"
+          ]
+        },
+        "ram:10000010:0:basic": {
+          "operations": {
+            "ram:10000010:100:0": {
+              "mnemonic": "CALL",
+              "type": "t_ptr_void",
+              "output": {
+                "kind": "local",
+                "operation": "unique:00000003:3:0"
+              },
+              "has_return_value": true,
+              "target": {
+                "kind": "function",
+                "function": "EXTERNAL:00000001",
+                "is_variadic": false,
+                "is_noreturn": false
+              },
+              "inputs": [
+                {
+                  "type": "t_u32",
+                  "kind": "constant",
+                  "value": 256
+                }
+              ]
+            },
+            "ram:10000018:101:1": {
+              "mnemonic": "CALL",
+              "type": "t_ptr_void",
+              "output": {
+                "kind": "local",
+                "operation": "unique:00000002:2:0"
+              },
+              "has_return_value": true,
+              "target": {
+                "kind": "function",
+                "function": "EXTERNAL:00000002",
+                "is_variadic": false,
+                "is_noreturn": false
+              },
+              "inputs": [
+                {
+                  "type": "t_ptr_void",
+                  "kind": "local",
+                  "operation": "unique:00000003:3:0"
+                },
+                {
+                  "type": "t_ptr_u8",
+                  "kind": "parameter",
+                  "operation": "unique:00000000:0:0"
+                },
+                {
+                  "type": "t_u32",
+                  "kind": "parameter",
+                  "operation": "unique:00000001:1:0"
+                }
+              ]
+            },
+            "ram:10000020:102:2": {
+              "mnemonic": "CALL",
+              "has_return_value": true,
+              "target": {
+                "kind": "function",
+                "function": "EXTERNAL:00000003",
+                "is_variadic": false,
+                "is_noreturn": false
+              },
+              "inputs": [
+                {
+                  "type": "t_ptr_void",
+                  "kind": "local",
+                  "operation": "unique:00000003:3:0"
+                }
+              ]
+            },
+            "ram:10000028:103:3": {
+              "mnemonic": "RETURN",
+              "inputs": []
+            }
+          },
+          "ordered_operations": [
+            "ram:10000010:100:0",
+            "ram:10000018:101:1",
+            "ram:10000020:102:2",
+            "ram:10000028:103:3"
+          ]
+        }
+      },
+      "entry_block": "ram:10000000:entry"
+    },
+    "EXTERNAL:00000001": {
+      "name": "malloc",
+      "is_intrinsic": false,
+      "type": {
+        "return_type": "t_ptr_void",
+        "is_variadic": false,
+        "is_noreturn": false,
+        "parameter_types": [
+          "t_u32"
+        ]
+      }
+    },
+    "EXTERNAL:00000002": {
+      "name": "memcpy",
+      "is_intrinsic": false,
+      "type": {
+        "return_type": "t_ptr_void",
+        "is_variadic": false,
+        "is_noreturn": false,
+        "parameter_types": [
+          "t_ptr_void",
+          "t_ptr_void",
+          "t_u32"
+        ]
+      }
+    },
+    "EXTERNAL:00000003": {
+      "name": "free",
+      "is_intrinsic": false,
+      "type": {
+        "return_type": "t_void",
+        "is_variadic": false,
+        "is_noreturn": false,
+        "parameter_types": [
+          "t_ptr_void"
+        ]
+      }
+    }
+  },
+  "types": {
+    "t_void": {
+      "name": "void",
+      "size": 0,
+      "kind": "void"
+    },
+    "t_u32": {
+      "name": "unsigned int",
+      "size": 4,
+      "kind": "integer"
+    },
+    "t_u8": {
+      "name": "unsigned char",
+      "size": 1,
+      "kind": "integer"
+    },
+    "t_ptr_u8": {
+      "kind": "pointer",
+      "size": 4,
+      "element_type": "t_u8"
+    },
+    "t_ptr_void": {
+      "kind": "pointer",
+      "size": 4,
+      "element_type": "t_void"
+    }
+  }
+}


### PR DESCRIPTION
Add patch specification for CWE-122 (Heap Buffer Overflow) targeting memcpy into a heap buffer where the copy size is attacker-controlled and can exceed the allocation size.

- P-Code JSON representing process_rx() with malloc + memcpy pattern
- Patch replaces memcpy with bounded version capping at allocation size
- Spec matches memcpy calls within process_rx function context