### PR TITLE
fix(ast): guard all unsafe .at() type lookups against missing keys

### DIFF
--- a/include/patchestry/AST/TypeBuilder.hpp
+++ b/include/patchestry/AST/TypeBuilder.hpp
@@ -8,10 +8,12 @@
 #pragma once
 
 #include <functional>
+#include <string>
 
 #include <clang/AST/ASTContext.h>
 
 #include <patchestry/Ghidra/JsonDeserialize.hpp>
+#include <patchestry/Util/Log.hpp>
 
 namespace patchestry::ast {
     using namespace patchestry::ghidra;
@@ -51,6 +53,28 @@ namespace patchestry::ast {
          */
 
         SerializedTypeMap &GetSerializedTypes(void) { return serialized_types; }
+
+        /**
+         * @brief Safely retrieves a serialized `clang::QualType` for the given key.
+         *
+         * Performs a lookup in the internal `serialized_types` map without throwing
+         * `std::out_of_range` when the key is not present. When the key is missing,
+         * a warning is logged and an empty `clang::QualType` is returned so that
+         * callers can propagate the failure via `QualType::isNull()`.
+         *
+         * @param key The type key to look up in the serialized type map.
+         *
+         * @return The `clang::QualType` associated with `key`, or an empty
+         *         `clang::QualType{}` if the key is not present in the map.
+         */
+        clang::QualType GetSerializedType(const std::string &key) const {
+            auto it = serialized_types.find(key);
+            if (it == serialized_types.end()) {
+                LOG(WARNING) << "Type key not found in serialized types: " << key;
+                return clang::QualType{};
+            }
+            return it->second;
+        }
 
         /**
          * @brief Creates and serializes all types defined in the `lifted_types`.

--- a/lib/patchestry/AST/ASTConsumer.cpp
+++ b/lib/patchestry/AST/ASTConsumer.cpp
@@ -342,7 +342,10 @@ namespace patchestry::ast {
                 continue;
             }
 
-            auto var_type       = type_builder->GetSerializedTypes().at(variable.type);
+            auto var_type       = type_builder->GetSerializedType(variable.type);
+            if (var_type.isNull()) {
+                continue;
+            }
             auto location       = SourceLocation(ctx.getSourceManager(), key);
             auto sanitized_name = SanitizeKeyToIdent(variable.name);
             auto *var_decl      = clang::VarDecl::Create(

--- a/lib/patchestry/AST/FunctionBuilder.cpp
+++ b/lib/patchestry/AST/FunctionBuilder.cpp
@@ -255,20 +255,21 @@ namespace patchestry::ast {
             return {};
         }
 
-        if (!type_builder.get().GetSerializedTypes().contains(proto.rttype_key)) {
+        auto rttype = type_builder.get().GetSerializedType(proto.rttype_key);
+        if (rttype.isNull()) {
             LOG(ERROR) << "Function return type is not serialized.\n";
             return {};
         }
 
         std::vector< clang::QualType > args_vector;
-        const auto &rttype = type_builder.get().GetSerializedTypes().at(proto.rttype_key);
         for (const auto &param : proto.parameters) {
-            if (!type_builder.get().GetSerializedTypes().contains(param)) {
+            auto param_type = type_builder.get().GetSerializedType(param);
+            if (param_type.isNull()) {
                 LOG(ERROR) << "Skipping, invalid parameter key in function.\n";
                 continue;
             }
 
-            args_vector.emplace_back(type_builder.get().GetSerializedTypes().at(param));
+            args_vector.emplace_back(param_type);
         }
 
         clang::FunctionProtoType::ExtProtoInfo ext_proto_info;
@@ -316,12 +317,12 @@ namespace patchestry::ast {
         uint index = 0;
         std::vector< clang::ParmVarDecl * > parameter_vec;
         for (const auto &param_key : proto.parameters) {
-            if (!type_builder.get().GetSerializedTypes().contains(param_key)) {
+            auto param_type = type_builder.get().GetSerializedType(param_key);
+            if (param_type.isNull()) {
                 LOG(ERROR) << "Skipping, invalid paramater type key in function prototype.\n";
                 continue;
             }
 
-            auto param_type  = type_builder.get().GetSerializedTypes().at(param_key);
             auto *param_decl = clang::ParmVarDecl::Create(
                 ctx, func_decl, SourceLocation(ctx.getSourceManager(), param_key),
                 SourceLocation(ctx.getSourceManager(), param_key),

--- a/lib/patchestry/AST/OperationBuilder.cpp
+++ b/lib/patchestry/AST/OperationBuilder.cpp
@@ -377,7 +377,7 @@ namespace patchestry::ast {
         bool is_wide = false;
         if (!vnode.type_key.empty()) {
             if (type_builder().GetSerializedTypes().contains(vnode.type_key)) {
-                auto type = type_builder().GetSerializedTypes().at(vnode.type_key);
+                auto type = type_builder().GetSerializedType(vnode.type_key);
                 is_wide   = type->isWideCharType();
             }
         }
@@ -423,7 +423,7 @@ namespace patchestry::ast {
         }
 
         if (type_builder().GetSerializedTypes().contains(vnode.type_key)) {
-            return type_builder().GetSerializedTypes().at(vnode.type_key);
+            return type_builder().GetSerializedType(vnode.type_key);
         }
 
         return GetTypeFromSize(ctx, vnode.size, /*is_signed=*/false, /*is_integer=*/true);

--- a/lib/patchestry/AST/OperationStmt.cpp
+++ b/lib/patchestry/AST/OperationStmt.cpp
@@ -1462,7 +1462,7 @@ namespace patchestry::ast {
             std::vector< clang::QualType > param_types;
             for (const auto &input : op.inputs) {
                 if (type_builder().GetSerializedTypes().contains(input.type_key)) {
-                    param_types.push_back(type_builder().GetSerializedTypes().at(input.type_key));
+                    param_types.push_back(type_builder().GetSerializedType(input.type_key));
                 } else {
                     param_types.push_back(ctx.IntTy); // Fallback
                 }
@@ -1471,7 +1471,7 @@ namespace patchestry::ast {
             // Infer return type from op.type
             clang::QualType return_type = ctx.VoidTy;
             if (op.type && type_builder().GetSerializedTypes().contains(*op.type)) {
-                return_type = type_builder().GetSerializedTypes().at(*op.type);
+                return_type = type_builder().GetSerializedType(*op.type);
             }
 
             // Build function type and pointer type
@@ -2494,12 +2494,12 @@ namespace patchestry::ast {
             return {};
         }
 
-        if (!type_builder().GetSerializedTypes().contains(*op.type)) {
+        auto op_type = type_builder().GetSerializedType(*op.type);
+        if (op_type.isNull()) {
             LOG(ERROR) << "INT2FLOAT operation type is not serialized. key: " << op.key << "\n";
             return {};
         }
 
-        const auto &op_type = type_builder().GetSerializedTypes().at(*op.type);
         auto op_loc         = SourceLocation(ctx.getSourceManager(), op.key);
 
         auto *input_expr =
@@ -2569,13 +2569,13 @@ namespace patchestry::ast {
             return {};
         }
 
-        if (!type_builder().GetSerializedTypes().contains(*op.type)) {
+        auto op_type = type_builder().GetSerializedType(*op.type);
+        if (op_type.isNull()) {
             LOG(ERROR) << "FLOAT2FLOAT operation type is not serialized. key: " << op.key
                        << "\n";
             return {};
         }
 
-        const auto &op_type = type_builder().GetSerializedTypes().at(*op.type);
         auto op_loc         = SourceLocation(ctx.getSourceManager(), op.key);
 
         auto *input_expr =
@@ -2607,14 +2607,14 @@ namespace patchestry::ast {
             return { nullptr, false };
         }
 
-        if (!type_builder().GetSerializedTypes().contains(*op.type)) {
+        auto op_type = type_builder().GetSerializedType(*op.type);
+        if (op_type.isNull()) {
             LOG(ERROR) << "TRUNC operation type is not serialized. key: " << op.key << "\n";
             return { nullptr, false };
         }
 
         auto merge_to_next = !op.output.has_value();
 
-        const auto &op_type = type_builder().GetSerializedTypes().at(*op.type);
         auto op_loc         = SourceLocation(ctx.getSourceManager(), op.key);
 
         auto *input_expr =
@@ -2724,14 +2724,14 @@ namespace patchestry::ast {
             return { nullptr, false };
         }
 
-        if (!type_builder().GetSerializedTypes().contains(*op.type)) {
+        auto op_type = type_builder().GetSerializedType(*op.type);
+        if (op_type.isNull()) {
             LOG(ERROR) << "PTRSUB operation type is not serialized. key: " << op.key << "\n";
             return { nullptr, false };
         }
 
         auto merge_to_next = !op.output.has_value();
 
-        const auto &op_type = type_builder().GetSerializedTypes().at(*op.type);
         auto op_loc         = SourceLocation(ctx.getSourceManager(), op.key);
 
         auto *input_expr =
@@ -2865,13 +2865,13 @@ namespace patchestry::ast {
             return {};
         }
 
-        if (!type_builder().GetSerializedTypes().contains(*op.type)) {
+        auto op_type = type_builder().GetSerializedType(*op.type);
+        if (op_type.isNull()) {
             LOG(ERROR) << "Operation type does not exist in serialized list. key: " << op.key
                        << "\n";
             return {};
         }
 
-        const auto &op_type = type_builder().GetSerializedTypes().at(*op.type);
         auto op_loc         = SourceLocation(ctx.getSourceManager(), op.key);
         auto *input_expr =
             clang::dyn_cast< clang::Expr >(create_varnode(ctx, function, op.inputs[0]));
@@ -2911,13 +2911,12 @@ namespace patchestry::ast {
             return {};
         }
 
-        if (!type_builder().GetSerializedTypes().contains(*op.type)) {
+        auto var_type = type_builder().GetSerializedType(*op.type);
+        if (var_type.isNull()) {
             LOG(ERROR) << "Skipping, local/temporary variable type is not serialized. key: "
                        << op.key << "\n";
             return {};
         }
-
-        const auto &var_type = type_builder().GetSerializedTypes()[*op.type];
         auto op_loc          = SourceLocation(ctx.getSourceManager(), op.key);
 
         std::string var_name = *op.name;


### PR DESCRIPTION
Add get_serialized_type() safe lookup wrapper to TypeBuilder that returns an empty QualType instead of throwing std::out_of_range when a type key is missing. Logs a warning for debugging.

Migrates all 13 call sites across ASTConsumer, FunctionBuilder, OperationBuilder, and OperationStmt from:
  type_builder().get_serialized_types().at(key)
to:
  type_builder().get_serialized_type(key)

Fixes #145