### PR TITLE
fix(ast): strip stack canary boilerplate from decompiled C output

### DIFF
--- a/include/patchestry/AST/FunctionBuilder.hpp
+++ b/include/patchestry/AST/FunctionBuilder.hpp
@@ -177,6 +177,8 @@ namespace patchestry::ast {
         std::reference_wrapper< std::unordered_map< std::string, clang::FunctionDecl * > >
             intrinsic_list;
 
+        bool is_stack_canary_operation(const Operation &op) const;
+
         std::unordered_map< std::string, clang::VarDecl * > local_variables;
         std::unordered_map< std::string, clang::LabelDecl * > labels_declaration;
         std::unordered_map< std::string, clang::Stmt * > operation_stmts;

--- a/lib/patchestry/AST/FunctionBuilder.cpp
+++ b/lib/patchestry/AST/FunctionBuilder.cpp
@@ -405,6 +405,36 @@ namespace patchestry::ast {
         return function_def;
     }
 
+    /**
+     * @brief Detects whether an operation is part of compiler-inserted stack canary
+     * boilerplate (__stack_chk_guard load/compare, __stack_chk_fail call).
+     */
+    bool FunctionBuilder::is_stack_canary_operation(const Operation &op) const {
+        auto is_canary_global = [this](const std::optional< std::string > &key) -> bool {
+            if (!key.has_value()) { return false; }
+            auto it = global_var_list.get().find(*key);
+            if (it == global_var_list.get().end()) { return false; }
+            const auto &name = it->second->getNameAsString();
+            return name == "__stack_chk_guard" || name == "___stack_chk_guard";
+        };
+
+        for (const auto &input : op.inputs) {
+            if (is_canary_global(input.global)) { return true; }
+        }
+
+        if (op.output.has_value() && is_canary_global(op.output->global)) { return true; }
+
+        if (op.target.has_value() && op.target->function.has_value()) {
+            auto it = function_list.get().find(*op.target->function);
+            if (it != function_list.get().end()) {
+                const auto &name = it->second->getNameAsString();
+                if (name == "__stack_chk_fail" || name == "___stack_chk_fail") { return true; }
+            }
+        }
+
+        return false;
+    }
+
     std::vector<clang::Stmt *>
     FunctionBuilder::create_block_stmts(clang::ASTContext &ctx, const BasicBlock &block) {
         if (block.ordered_operations.empty()) {
@@ -431,6 +461,10 @@ namespace patchestry::ast {
                 || operation.mnemonic == Mnemonic::OP_BRANCHIND) {
                 continue;
             }
+
+            // Skip compiler-inserted stack canary boilerplate
+            // (__stack_chk_guard load/compare, __stack_chk_fail call).
+            if (is_stack_canary_operation(operation)) { continue; }
 
             auto saved_pending = std::move(pending_materialized);
             pending_materialized.clear();

--- a/lib/patchestry/AST/OperationStmt.cpp
+++ b/lib/patchestry/AST/OperationStmt.cpp
@@ -1134,6 +1134,10 @@ namespace patchestry::ast {
                                 const auto &target_op = tb.operations.at(op_key);
                                 // Skip the terminal BRANCH — break replaces it.
                                 if (target_op.mnemonic == Mnemonic::OP_BRANCH) { continue; }
+                                // Skip compiler-inserted stack canary boilerplate so the
+                                // inlined case body matches what create_block_stmts emits
+                                // for non-inlined blocks.
+                                if (function_builder().is_stack_canary_operation(target_op)) { continue; }
                                 auto [stmt, merge] =
                                     function_builder().create_operation(ctx, target_op);
                                 for (auto *p : function_builder().pending_materialized) {

--- a/scripts/gen-call-checks.py
+++ b/scripts/gen-call-checks.py
@@ -84,6 +84,12 @@ def get_cir_symbol(func_obj):
     return name
 
 
+# Compiler-inserted stack-protector helpers that FunctionBuilder strips during
+# AST construction. They are intentionally absent from the decompiled output,
+# so the call-target verifier must not require them.
+CANARY_CALLEES = frozenset({"__stack_chk_fail", "___stack_chk_fail"})
+
+
 def collect_call_targets(func, functions):
     """Collect unique direct callee names and count indirect calls."""
     callees = set()
@@ -96,7 +102,10 @@ def collect_call_targets(func, functions):
                 target = op.get("target", {})
                 target_func_id = target.get("function")
                 if target_func_id and target_func_id in functions:
-                    callees.add(get_cir_symbol(functions[target_func_id]))
+                    symbol = get_cir_symbol(functions[target_func_id])
+                    if symbol in CANARY_CALLEES:
+                        continue
+                    callees.add(symbol)
             elif mnemonic == "CALLIND":
                 indirect_count += 1
 

--- a/test/patchir-decomp/bl_device__process_entry.json
+++ b/test/patchir-decomp/bl_device__process_entry.json
@@ -3,6 +3,13 @@
 // RUN: test -e %t.c
 // RUN: %patchir-decomp -input %t.json -use-structuring-pass -emit-cir -emit-mlir -emit-llvm -print-tu -output %t >> /dev/null 2>&1
 // RUN: test -e %t.c
+// RUN: %file-check -vv -check-prefix=CGEN %s --input-file %t.c
+// CGEN-LABEL: bl_device__process_entry(
+// The CALL to __stack_chk_fail is stripped from the function body. The
+// __stack_chk_guard exit comparison is a known unstripped case (issue #161):
+// the structuring pass re-materializes it from the CBRANCH, so it survives
+// the operation-level filter. Value-level taint tracking would be required.
+// CGEN-NOT: __stack_chk_fail
 // RUN: %file-check -vv -check-prefix=CIR %s --input-file %t.cir
 // CIR: cir.func dso_local @bl_device__process_entry
 // RUN: %file-check -vv -check-prefix=MLIR %s --input-file %t.mlir


### PR DESCRIPTION
Add is_stack_canary_operation() to FunctionBuilder that detects compiler-inserted stack protector patterns by checking:
- Operations with inputs referencing __stack_chk_guard globals
- CALL operations targeting __stack_chk_fail

Detected operations are skipped during basic block creation, removing the canary entry load and fail call from the generated C.

This is a temporary solution that handles the straightforward cases (entry guard load and fail call) by pattern-matching on global names and call targets. The exit comparison block (if guard == saved) is not fully removed because the AST structuring engine reorganizes it into an if-else before our filter can catch the individual operations.

A complete solution would require value-level taint tracking — marking values derived from __stack_chk_guard and propagating that taint through copies, comparisons, and branches so the entire canary exit path can be identified and stripped. That approach is more invasive and should be discussed before implementing.

Partial fix for #161