### PR TITLE
test(cwe-190): add integer overflow patch specification

### DIFF
--- a/test/patchir-transform/cwe190_replace.yaml
+++ b/test/patchir-transform/cwe190_replace.yaml
@@ -1,0 +1,42 @@
+# Test patching specification
+apiVersion: patchestry.io/v1
+
+metadata:
+  name: "cwe190-replace"
+  description: "Fix integer overflow by replacing unchecked 16-bit multiply with overflow-checked version"
+  version: "1.0.0"
+  author: "Security Team"
+  created: "2026-03-23"
+
+target:
+  binary: "test_binary.bin"
+  arch: "ARM:LE:32"
+
+libraries:
+  - "patches/cwe190_patches.yaml"
+
+meta_patches:
+  - name: "cwe190_int_overflow_fix"
+    description: "Replace unchecked count * block_size in PeekHandler::Process"
+
+    patch_actions:
+      - id: "CWE-190-001"
+        description: "Replace 16-bit multiply with overflow-checked version"
+
+        match:
+          - name: "cir.binop"
+            kind: "operation"
+            function_context:
+              - name: "peek_process"
+
+        action:
+          - mode: "replace"
+            patch_id: "cwe190_checked_mul16"
+            description: "Replace multiply with overflow-safe version"
+            arguments:
+              - name: "count"
+                source: "operand"
+                index: 0
+              - name: "block_size"
+                source: "operand"
+                index: 1

--- a/test/patchir-transform/patches/cwe190_patches.yaml
+++ b/test/patchir-transform/patches/cwe190_patches.yaml
@@ -1,0 +1,24 @@
+# patches/cwe190_patches.yaml
+
+apiVersion: patchestry.io/v1
+
+metadata:
+  name: "cwe190_patches"
+  version: "1.0.0"
+  description: "CWE-190 integer overflow patches"
+  author: "Security Team"
+  created: "2026-03-23"
+
+patches:
+  - name: "cwe190_checked_mul16"
+    description: "Replace unchecked 16-bit multiply with overflow-checked version"
+    category: "integer_safety"
+    code_file: "patches/patch_checked_mul16.c"
+    function_name: "patch::replace::int_mul16"
+    parameters:
+      - name: "count"
+        type: "unsigned int"
+        description: "Number of items (from debug request)"
+      - name: "block_size"
+        type: "unsigned int"
+        description: "Size per item (from debug request)"

--- a/test/patchir-transform/patches/patch_checked_mul16.c
+++ b/test/patchir-transform/patches/patch_checked_mul16.c
@@ -1,0 +1,21 @@
+// RUN: true
+typedef unsigned int uint32_t;
+typedef unsigned short uint16_t;
+
+extern void halt(void);
+
+// CWE-190: Replace unchecked 16-bit multiply with overflow-checked version.
+// The vulnerable pattern in PeekHandler::Process() multiplies two uint16_t
+// values (count * block_size) without checking for overflow. If the product
+// exceeds 65535, it wraps around and the subsequent bounds check passes
+// with the wrong value, enabling out-of-bounds memory reads.
+//
+// This patch widens the operands to 32-bit, performs the multiply, and
+// returns UINT16_MAX if the result would overflow uint16_t.
+unsigned int patch__replace__int_mul16(unsigned int a, unsigned int b) {
+    uint32_t wide_result = a * b;
+    if (wide_result > (uint32_t)0xFFFF) {
+        return (unsigned int)0xFFFF;
+    }
+    return (unsigned int)wide_result;
+}

--- a/test/patchir-transform/ventilator_cwe190.json
+++ b/test/patchir-transform/ventilator_cwe190.json
@@ -1,0 +1,255 @@
+// RUN: bash %strip-json-comments %s > %t.json
+// RUN: %patchir-decomp -input %t.json -emit-cir -output %t1 >> /dev/null 2>&1
+//
+// RUN: %patchir-transform %t1.cir --spec %S/cwe190_replace.yaml -o %t2.cir
+// RUN: %file-check -vv -check-prefix=REPLACE %s --input-file %t2.cir
+// REPLACE: @patch__replace__int_mul16
+//
+// CWE-190: Integer Overflow in PeekHandler::Process()
+// The vulnerable pattern is: uint16_t total_bytes = count * block_size;
+// Both count and block_size are attacker-controlled uint16_t values from
+// the debug serial request. When their product exceeds 65535, it wraps
+// around and the subsequent bounds check passes with the wrong value.
+//
+{
+  "architecture": "ARM",
+  "id": "ARM:LE:32:Cortex",
+  "format": "Executable and Linking Format (ELF)",
+  "functions": {
+    "ram:10000000": {
+      "name": "peek_process",
+      "is_intrinsic": false,
+      "type": {
+        "return_type": "t_u32",
+        "is_variadic": false,
+        "is_noreturn": false,
+        "parameter_types": [
+          "t_ptr_void",
+          "t_u32"
+        ]
+      },
+      "basic_blocks": {
+        "ram:10000000:entry": {
+          "operations": {
+            "unique:00000001:0:0": {
+              "mnemonic": "DECLARE_PARAMETER",
+              "name": "context",
+              "type": "t_ptr_void",
+              "kind": "parameter",
+              "index": 0
+            },
+            "unique:00000002:0:0": {
+              "mnemonic": "DECLARE_PARAMETER",
+              "name": "address_msw",
+              "type": "t_u32",
+              "kind": "parameter",
+              "index": 1
+            },
+            "unique:00000003:0:0": {
+              "mnemonic": "DECLARE_LOCAL",
+              "kind": "local",
+              "name": "count",
+              "type": "t_u32"
+            },
+            "unique:00000004:0:0": {
+              "mnemonic": "DECLARE_LOCAL",
+              "kind": "local",
+              "name": "block_size",
+              "type": "t_u32"
+            },
+            "unique:00000005:0:0": {
+              "mnemonic": "DECLARE_LOCAL",
+              "kind": "local",
+              "name": "total_bytes",
+              "type": "t_u32"
+            },
+            "entry.exit": {
+              "mnemonic": "BRANCH",
+              "target_block": "ram:10000010:0:basic"
+            }
+          },
+          "ordered_operations": [
+            "unique:00000001:0:0",
+            "unique:00000002:0:0",
+            "unique:00000003:0:0",
+            "unique:00000004:0:0",
+            "unique:00000005:0:0",
+            "entry.exit"
+          ]
+        },
+        "ram:10000010:0:basic": {
+          "operations": {
+            "ram:10000010:100:0": {
+              "mnemonic": "COPY",
+              "type": "t_u32",
+              "output": {
+                "kind": "local",
+                "operation": "unique:00000003:0:0"
+              },
+              "inputs": [
+                {
+                  "type": "t_u32",
+                  "kind": "constant",
+                  "value": 256
+                }
+              ]
+            },
+            "ram:10000014:101:1": {
+              "mnemonic": "COPY",
+              "type": "t_u32",
+              "output": {
+                "kind": "local",
+                "operation": "unique:00000004:0:0"
+              },
+              "inputs": [
+                {
+                  "type": "t_u32",
+                  "kind": "constant",
+                  "value": 257
+                }
+              ]
+            },
+            "ram:10000018:102:2": {
+              "mnemonic": "INT_MULT",
+              "type": "t_u32",
+              "output": {
+                "kind": "local",
+                "operation": "unique:00000005:0:0"
+              },
+              "inputs": [
+                {
+                  "type": "t_u32",
+                  "kind": "local",
+                  "operation": "unique:00000003:0:0"
+                },
+                {
+                  "type": "t_u32",
+                  "kind": "local",
+                  "operation": "unique:00000004:0:0"
+                }
+              ]
+            },
+            "ram:1000001c:103:3": {
+              "mnemonic": "INT_LESSEQUAL",
+              "type": "t_bool",
+              "inputs": [
+                {
+                  "type": "t_u32",
+                  "kind": "local",
+                  "operation": "unique:00000005:0:0"
+                },
+                {
+                  "type": "t_u32",
+                  "kind": "constant",
+                  "value": 497
+                }
+              ]
+            },
+            "ram:10000020:104:4": {
+              "mnemonic": "CBRANCH",
+              "taken_block": "ram:10000030:1:basic",
+              "not_taken_block": "ram:10000040:2:basic",
+              "condition": {
+                "type": "t_bool",
+                "kind": "temporary",
+                "operation": "ram:1000001c:103:3"
+              }
+            }
+          },
+          "ordered_operations": [
+            "ram:10000010:100:0",
+            "ram:10000014:101:1",
+            "ram:10000018:102:2",
+            "ram:1000001c:103:3",
+            "ram:10000020:104:4"
+          ]
+        },
+        "ram:10000030:1:basic": {
+          "operations": {
+            "ram:10000030:200:0": {
+              "mnemonic": "CALL",
+              "type": "t_ptr_void",
+              "has_return_value": true,
+              "target": {
+                "kind": "function",
+                "function": "EXTERNAL:memcpy",
+                "is_variadic": false,
+                "is_noreturn": false
+              },
+              "inputs": [
+                {
+                  "type": "t_ptr_void",
+                  "kind": "parameter",
+                  "operation": "unique:00000001:0:0"
+                },
+                {
+                  "type": "t_ptr_void",
+                  "kind": "parameter",
+                  "operation": "unique:00000001:0:0"
+                },
+                {
+                  "type": "t_u32",
+                  "kind": "local",
+                  "operation": "unique:00000005:0:0"
+                }
+              ]
+            },
+            "ram:10000034:201:1": {
+              "mnemonic": "RETURN",
+              "inputs": [
+                {
+                  "type": "t_u32",
+                  "kind": "constant",
+                  "value": 0
+                }
+              ]
+            }
+          },
+          "ordered_operations": [
+            "ram:10000030:200:0",
+            "ram:10000034:201:1"
+          ]
+        },
+        "ram:10000040:2:basic": {
+          "operations": {
+            "ram:10000040:300:0": {
+              "mnemonic": "RETURN",
+              "inputs": [
+                {
+                  "type": "t_u32",
+                  "kind": "constant",
+                  "value": 1
+                }
+              ]
+            }
+          },
+          "ordered_operations": [
+            "ram:10000040:300:0"
+          ]
+        }
+      },
+      "entry_block": "ram:10000000:entry"
+    },
+    "EXTERNAL:memcpy": {
+      "name": "memcpy",
+      "is_intrinsic": false,
+      "type": {
+        "return_type": "t_ptr_void",
+        "is_variadic": false,
+        "is_noreturn": false,
+        "parameter_types": [
+          "t_ptr_void",
+          "t_ptr_void",
+          "t_u32"
+        ]
+      }
+    }
+  },
+  "globals": {},
+  "types": {
+    "t_u32": { "name": "unsigned int", "size": 4, "kind": "integer" },
+    "t_bool": { "name": "bool", "size": 1, "kind": "integer" },
+    "t_ptr_void": { "kind": "pointer", "size": 4, "element_type": "t_void" },
+    "t_void": { "name": "void", "size": 0, "kind": "void" }
+  }
+}


### PR DESCRIPTION
Add CWE-190 patch specification for the Ventilator PeekHandler::Process() integer overflow vulnerability. The vulnerable pattern is an unchecked uint16_t multiply (count * block_size) where attacker-controlled values can wrap around, bypassing a subsequent bounds check and enabling out-of-bounds memory reads via memcpy.

The spec uses the new cir.binop replace mode (from #173) to directly replace the multiply operation with an overflow-checked version that widens operands to 32-bit and clamps to UINT16_MAX on overflow.

Files:
  - ventilator_cwe190.json: P-Code JSON representing peek_process() with INT_MULT, bounds check, and memcpy
  - cwe190_replace.yaml: Patch spec matching cir.binop in peek_process
  - patches/cwe190_patches.yaml: Patch library definition
  - patches/patch_checked_mul16.c: Overflow-checked 16-bit multiply

Resolves: https://github.com/lifting-bits/patchestry/issues/174