### PR TITLE
test(cwe-193): add off-by-one patch specification

### DIFF
--- a/test/patchir-transform/cwe193_replace.yaml
+++ b/test/patchir-transform/cwe193_replace.yaml
@@ -1,0 +1,42 @@
+# Test patching specification
+apiVersion: patchestry.io/v1
+
+metadata:
+  name: "cwe193-replace"
+  description: "Fix off-by-one in circular buffer by replacing >= comparison with >"
+  version: "1.0.0"
+  author: "Security Team"
+  created: "2026-03-23"
+
+target:
+  binary: "test_binary.bin"
+  arch: "ARM:LE:32"
+
+libraries:
+  - "patches/cwe193_patches.yaml"
+
+meta_patches:
+  - name: "cwe193_wrap_fix"
+    description: "Fix off-by-one wrap condition in CircularBuffer::Put"
+
+    patch_actions:
+      - id: "CWE-193-001"
+        description: "Replace >= comparison with corrected > check"
+
+        match:
+          - name: "cir.cmp"
+            kind: "operation"
+            function_context:
+              - name: "circular_buffer_put"
+
+        action:
+          - mode: "replace"
+            patch_id: "cwe193_fixed_wrap_check"
+            description: "Replace wrap comparison with fixed bounds check"
+            arguments:
+              - name: "new_head"
+                source: "operand"
+                index: 0
+              - name: "capacity"
+                source: "operand"
+                index: 1

--- a/test/patchir-transform/patches/cwe193_patches.yaml
+++ b/test/patchir-transform/patches/cwe193_patches.yaml
@@ -1,0 +1,24 @@
+# patches/cwe193_patches.yaml
+
+apiVersion: patchestry.io/v1
+
+metadata:
+  name: "cwe193_patches"
+  version: "1.0.0"
+  description: "CWE-193 off-by-one patches"
+  author: "Security Team"
+  created: "2026-03-23"
+
+patches:
+  - name: "cwe193_fixed_wrap_check"
+    description: "Replace off-by-one wrap condition with correct bounds check"
+    category: "bounds_safety"
+    code_file: "patches/patch_fixed_wrap_check.c"
+    function_name: "patch::replace::wrap_cmp"
+    parameters:
+      - name: "new_head"
+        type: "unsigned int"
+        description: "Next write index (head_ + 1)"
+      - name: "capacity"
+        type: "unsigned int"
+        description: "Buffer capacity N"

--- a/test/patchir-transform/patches/patch_fixed_wrap_check.c
+++ b/test/patchir-transform/patches/patch_fixed_wrap_check.c
@@ -1,0 +1,14 @@
+// RUN: true
+typedef unsigned int uint32_t;
+typedef unsigned char bool_t;
+
+// CWE-193: Replace off-by-one wrap condition in circular buffer Put().
+// The vulnerable code uses >= N to wrap, which skips index N entirely.
+// The buffer is sized N+1, so valid indices are 0 through N.
+// The fix uses > N so that index N is reachable before wrapping.
+bool_t patch__replace__wrap_cmp(unsigned int new_head, unsigned int capacity) {
+    if (new_head > capacity) {
+        return 1;
+    }
+    return 0;
+}

--- a/test/patchir-transform/ventilator_cwe193.json
+++ b/test/patchir-transform/ventilator_cwe193.json
@@ -1,0 +1,226 @@
+// RUN: bash %strip-json-comments %s > %t.json
+// RUN: %patchir-decomp -input %t.json -emit-cir -output %t1 >> /dev/null 2>&1
+//
+// RUN: %patchir-transform %t1.cir --spec %S/cwe193_replace.yaml -o %t2.cir
+// RUN: %file-check -vv -check-prefix=REPLACE %s --input-file %t2.cir
+// REPLACE: @patch__replace__wrap_cmp
+//
+// CWE-193: Off-by-one in CircularBuffer::Put()
+// The vulnerable pattern is: if (new_head >= N) { new_head = 0; }
+// The buffer is sized N+1 (indices 0..N), but >= wraps at N instead
+// of N+1, causing index N to be skipped. This loses one buffer slot
+// and desynchronizes head/tail tracking.
+//
+// The P-Code models this as INT_ADD (head + 1) followed by
+// INT_LESSEQUAL (new_head <= capacity), which becomes cir.cmp(le,...).
+// Note: Ghidra may normalize >= N to <= N with flipped operands.
+//
+{
+  "architecture": "ARM",
+  "id": "ARM:LE:32:Cortex",
+  "format": "Executable and Linking Format (ELF)",
+  "functions": {
+    "ram:10000000": {
+      "name": "circular_buffer_put",
+      "is_intrinsic": false,
+      "type": {
+        "return_type": "t_bool",
+        "is_variadic": false,
+        "is_noreturn": false,
+        "parameter_types": [
+          "t_ptr_void",
+          "t_u32"
+        ]
+      },
+      "basic_blocks": {
+        "ram:10000000:entry": {
+          "operations": {
+            "unique:00000001:0:0": {
+              "mnemonic": "DECLARE_PARAMETER",
+              "name": "this_ptr",
+              "type": "t_ptr_void",
+              "kind": "parameter",
+              "index": 0
+            },
+            "unique:00000002:0:0": {
+              "mnemonic": "DECLARE_PARAMETER",
+              "name": "dat",
+              "type": "t_u32",
+              "kind": "parameter",
+              "index": 1
+            },
+            "unique:00000003:0:0": {
+              "mnemonic": "DECLARE_LOCAL",
+              "kind": "local",
+              "name": "head",
+              "type": "t_u32"
+            },
+            "unique:00000004:0:0": {
+              "mnemonic": "DECLARE_LOCAL",
+              "kind": "local",
+              "name": "new_head",
+              "type": "t_u32"
+            },
+            "unique:00000005:0:0": {
+              "mnemonic": "DECLARE_LOCAL",
+              "kind": "local",
+              "name": "capacity",
+              "type": "t_u32"
+            },
+            "entry.exit": {
+              "mnemonic": "BRANCH",
+              "target_block": "ram:10000010:0:basic"
+            }
+          },
+          "ordered_operations": [
+            "unique:00000001:0:0",
+            "unique:00000002:0:0",
+            "unique:00000003:0:0",
+            "unique:00000004:0:0",
+            "unique:00000005:0:0",
+            "entry.exit"
+          ]
+        },
+        "ram:10000010:0:basic": {
+          "operations": {
+            "ram:10000010:100:0": {
+              "mnemonic": "COPY",
+              "type": "t_u32",
+              "output": {
+                "kind": "local",
+                "operation": "unique:00000003:0:0"
+              },
+              "inputs": [
+                {
+                  "type": "t_u32",
+                  "kind": "constant",
+                  "value": 5
+                }
+              ]
+            },
+            "ram:10000014:101:1": {
+              "mnemonic": "COPY",
+              "type": "t_u32",
+              "output": {
+                "kind": "local",
+                "operation": "unique:00000005:0:0"
+              },
+              "inputs": [
+                {
+                  "type": "t_u32",
+                  "kind": "constant",
+                  "value": 16
+                }
+              ]
+            },
+            "ram:10000018:102:2": {
+              "mnemonic": "INT_ADD",
+              "type": "t_u32",
+              "output": {
+                "kind": "local",
+                "operation": "unique:00000004:0:0"
+              },
+              "inputs": [
+                {
+                  "type": "t_u32",
+                  "kind": "local",
+                  "operation": "unique:00000003:0:0"
+                },
+                {
+                  "type": "t_u32",
+                  "kind": "constant",
+                  "value": 1
+                }
+              ]
+            },
+            "ram:1000001c:103:3": {
+              "mnemonic": "INT_LESSEQUAL",
+              "type": "t_bool",
+              "inputs": [
+                {
+                  "type": "t_u32",
+                  "kind": "local",
+                  "operation": "unique:00000005:0:0"
+                },
+                {
+                  "type": "t_u32",
+                  "kind": "local",
+                  "operation": "unique:00000004:0:0"
+                }
+              ]
+            },
+            "ram:10000020:104:4": {
+              "mnemonic": "CBRANCH",
+              "taken_block": "ram:10000030:1:basic",
+              "not_taken_block": "ram:10000040:2:basic",
+              "condition": {
+                "type": "t_bool",
+                "kind": "temporary",
+                "operation": "ram:1000001c:103:3"
+              }
+            }
+          },
+          "ordered_operations": [
+            "ram:10000010:100:0",
+            "ram:10000014:101:1",
+            "ram:10000018:102:2",
+            "ram:1000001c:103:3",
+            "ram:10000020:104:4"
+          ]
+        },
+        "ram:10000030:1:basic": {
+          "operations": {
+            "ram:10000030:200:0": {
+              "mnemonic": "COPY",
+              "type": "t_u32",
+              "output": {
+                "kind": "local",
+                "operation": "unique:00000004:0:0"
+              },
+              "inputs": [
+                {
+                  "type": "t_u32",
+                  "kind": "constant",
+                  "value": 0
+                }
+              ]
+            },
+            "ram:10000034:201:1": {
+              "mnemonic": "BRANCH",
+              "target_block": "ram:10000040:2:basic"
+            }
+          },
+          "ordered_operations": [
+            "ram:10000030:200:0",
+            "ram:10000034:201:1"
+          ]
+        },
+        "ram:10000040:2:basic": {
+          "operations": {
+            "ram:10000040:300:0": {
+              "mnemonic": "RETURN",
+              "inputs": [
+                {
+                  "type": "t_bool",
+                  "kind": "constant",
+                  "value": 1
+                }
+              ]
+            }
+          },
+          "ordered_operations": [
+            "ram:10000040:300:0"
+          ]
+        }
+      },
+      "entry_block": "ram:10000000:entry"
+    }
+  },
+  "globals": {},
+  "types": {
+    "t_u32": { "name": "unsigned int", "size": 4, "kind": "integer" },
+    "t_bool": { "name": "bool", "size": 1, "kind": "integer" },
+    "t_ptr_void": { "kind": "pointer", "size": 4, "element_type": "t_void" },
+    "t_void": { "name": "void", "size": 0, "kind": "void" }
+  }
+}


### PR DESCRIPTION
Add CWE-193 patch specification for the Ventilator CircularBuffer::Put() off-by-one vulnerability. The vulnerable pattern is a wrap condition that uses >= N instead of > N, causing index N to be skipped in a buffer sized N+1. This loses one buffer slot, desynchronizes head/tail tracking, and can cause stale sensor data to appear in trace reads.

The spec uses the new cir.cmp replace mode (from #173) to directly replace the comparison operation with a corrected bounds-check function that uses > instead of >=.

Files:
  - ventilator_cwe193.json: P-Code JSON representing circular_buffer_put() with INT_ADD (head + 1), INT_LESSEQUAL (wrap check), and CBRANCH
  - cwe193_replace.yaml: Patch spec matching cir.cmp in circular_buffer_put
  - patches/cwe193_patches.yaml: Patch library definition
  - patches/patch_fixed_wrap_check.c: Corrected wrap condition (> instead of >=)

Resolves: https://github.com/lifting-bits/patchestry/issues/176