### PR TITLE
test(cwe-415): add double free patch specification

### DIFF
--- a/test/patchir-transform/cwe415_after.yaml
+++ b/test/patchir-transform/cwe415_after.yaml
@@ -1,0 +1,40 @@
+# Test patching specification
+apiVersion: patchestry.io/v1
+
+metadata:
+  name: "cwe415-after"
+  description: "Fix double free by nulling pointer after first free via is_reference"
+  version: "1.0.0"
+  author: "Security Team"
+  created: "2026-03-23"
+
+target:
+  binary: "test_binary.bin"
+  arch: "ARM:LE:32"
+
+libraries:
+  - "patches/cwe415_patches.yaml"
+
+meta_patches:
+  - name: "cwe415_null_after_free"
+    description: "Null pointer after free in ProcessCommand to prevent double free"
+
+    patch_actions:
+      - id: "CWE-415-001"
+        description: "Apply null-after-free guard after first free() call"
+
+        match:
+          - name: "free"
+            kind: "function"
+            function_context:
+              - name: "process_command"
+
+        action:
+          - mode: "apply_after"
+            patch_id: "cwe415_null_after_free"
+            description: "Null the pointer after free via is_reference"
+            arguments:
+              - name: "ptr_ref"
+                source: "operand"
+                index: 0
+                is_reference: true

--- a/test/patchir-transform/patches/cwe415_patches.yaml
+++ b/test/patchir-transform/patches/cwe415_patches.yaml
@@ -1,0 +1,21 @@
+# patches/cwe415_patches.yaml
+
+apiVersion: patchestry.io/v1
+
+metadata:
+  name: "cwe415_patches"
+  version: "1.0.0"
+  description: "CWE-415 double free patches"
+  author: "Security Team"
+  created: "2026-03-23"
+
+patches:
+  - name: "cwe415_null_after_free"
+    description: "Null pointer after free to prevent double free"
+    category: "memory_safety"
+    code_file: "patches/patch_null_after_free.c"
+    function_name: "patch::after::free"
+    parameters:
+      - name: "ptr_ref"
+        type: "void*"
+        description: "Reference to the pointer being freed (via is_reference)"

--- a/test/patchir-transform/patches/patch_null_after_free.c
+++ b/test/patchir-transform/patches/patch_null_after_free.c
@@ -1,0 +1,15 @@
+// RUN: true
+
+// CWE-415: Null-after-free guard for double free prevention.
+// This patch is applied after a free() call with is_reference: true.
+// The is_reference mechanism creates an alloca for the pointer operand
+// and passes its address (void**). By setting *ptr_ref = NULL, we null
+// the pointer after free. The update_state_after_patch mechanism then
+// propagates this NULL to all subsequent dominated uses of the pointer,
+// making the second free(ptr) become free(NULL) — a safe no-op.
+//
+// Parameter type is void** to match the alloca type produced by
+// is_reference for a void* operand.
+void patch__after__free(void **ptr_ref) {
+    *ptr_ref = (void *)0;
+}

--- a/test/patchir-transform/ventilator_cwe415.json
+++ b/test/patchir-transform/ventilator_cwe415.json
@@ -1,0 +1,275 @@
+// RUN: bash %strip-json-comments %s > %t.json
+// RUN: %patchir-decomp -input %t.json -emit-cir -output %t1 >> /dev/null 2>&1
+//
+// RUN: %patchir-transform %t1.cir --spec %S/cwe415_after.yaml -o %t2.cir
+// RUN: %file-check -vv -check-prefix=AFTER %s --input-file %t2.cir
+// AFTER: @patch__after__free
+//
+// CWE-415: Double Free in Interface::ProcessCommand()
+// The vulnerable pattern: cmd_log is allocated with new[], freed inside
+// an error-handling block, then unconditionally freed again after the
+// block (missing return statement). The patch applies null-after-free
+// via is_reference: after the first free(), the pointer is set to NULL
+// so the second free(NULL) is a safe no-op.
+//
+{
+  "architecture": "ARM",
+  "id": "ARM:LE:32:Cortex",
+  "format": "Executable and Linking Format (ELF)",
+  "functions": {
+    "ram:10000000": {
+      "name": "process_command",
+      "is_intrinsic": false,
+      "type": {
+        "return_type": "t_void",
+        "is_variadic": false,
+        "is_noreturn": false,
+        "parameter_types": [
+          "t_ptr_void"
+        ]
+      },
+      "basic_blocks": {
+        "ram:10000000:entry": {
+          "operations": {
+            "unique:00000001:0:0": {
+              "mnemonic": "DECLARE_PARAMETER",
+              "name": "context",
+              "type": "t_ptr_void",
+              "kind": "parameter",
+              "index": 0
+            },
+            "unique:00000002:0:0": {
+              "mnemonic": "DECLARE_LOCAL",
+              "kind": "local",
+              "name": "cmd_log",
+              "type": "t_ptr_void"
+            },
+            "unique:00000003:0:0": {
+              "mnemonic": "DECLARE_LOCAL",
+              "kind": "local",
+              "name": "error",
+              "type": "t_u32"
+            },
+            "entry.exit": {
+              "mnemonic": "BRANCH",
+              "target_block": "ram:10000010:0:basic"
+            }
+          },
+          "ordered_operations": [
+            "unique:00000001:0:0",
+            "unique:00000002:0:0",
+            "unique:00000003:0:0",
+            "entry.exit"
+          ]
+        },
+        "ram:10000010:0:basic": {
+          "operations": {
+            "ram:10000010:100:0": {
+              "mnemonic": "CALL",
+              "type": "t_ptr_void",
+              "output": {
+                "kind": "local",
+                "operation": "unique:00000002:0:0"
+              },
+              "has_return_value": true,
+              "target": {
+                "kind": "function",
+                "function": "EXTERNAL:malloc",
+                "is_variadic": false,
+                "is_noreturn": false
+              },
+              "inputs": [
+                {
+                  "type": "t_u32",
+                  "kind": "constant",
+                  "value": 64
+                }
+              ]
+            },
+            "ram:10000018:101:1": {
+              "mnemonic": "CALL",
+              "type": "t_u32",
+              "output": {
+                "kind": "local",
+                "operation": "unique:00000003:0:0"
+              },
+              "has_return_value": true,
+              "target": {
+                "kind": "function",
+                "function": "EXTERNAL:handler_process",
+                "is_variadic": false,
+                "is_noreturn": false
+              },
+              "inputs": [
+                {
+                  "type": "t_ptr_void",
+                  "kind": "parameter",
+                  "operation": "unique:00000001:0:0"
+                }
+              ]
+            },
+            "ram:1000001c:102:2": {
+              "mnemonic": "INT_NOTEQUAL",
+              "type": "t_bool",
+              "inputs": [
+                {
+                  "type": "t_u32",
+                  "kind": "local",
+                  "operation": "unique:00000003:0:0"
+                },
+                {
+                  "type": "t_u32",
+                  "kind": "constant",
+                  "value": 0
+                }
+              ]
+            },
+            "ram:10000020:103:3": {
+              "mnemonic": "CBRANCH",
+              "taken_block": "ram:10000030:1:basic",
+              "not_taken_block": "ram:10000040:2:basic",
+              "condition": {
+                "type": "t_bool",
+                "kind": "temporary",
+                "operation": "ram:1000001c:102:2"
+              }
+            }
+          },
+          "ordered_operations": [
+            "ram:10000010:100:0",
+            "ram:10000018:101:1",
+            "ram:1000001c:102:2",
+            "ram:10000020:103:3"
+          ]
+        },
+        "ram:10000030:1:basic": {
+          "operations": {
+            "ram:10000030:200:0": {
+              "mnemonic": "CALL",
+              "type": "t_void",
+              "has_return_value": false,
+              "target": {
+                "kind": "function",
+                "function": "EXTERNAL:free",
+                "is_variadic": false,
+                "is_noreturn": false
+              },
+              "inputs": [
+                {
+                  "type": "t_ptr_void",
+                  "kind": "local",
+                  "operation": "unique:00000002:0:0"
+                }
+              ]
+            },
+            "ram:10000034:201:1": {
+              "mnemonic": "CALL",
+              "type": "t_void",
+              "has_return_value": false,
+              "target": {
+                "kind": "function",
+                "function": "EXTERNAL:send_error",
+                "is_variadic": false,
+                "is_noreturn": false
+              },
+              "inputs": [
+                {
+                  "type": "t_u32",
+                  "kind": "local",
+                  "operation": "unique:00000003:0:0"
+                }
+              ]
+            },
+            "ram:10000038:202:2": {
+              "mnemonic": "BRANCH",
+              "target_block": "ram:10000040:2:basic"
+            }
+          },
+          "ordered_operations": [
+            "ram:10000030:200:0",
+            "ram:10000034:201:1",
+            "ram:10000038:202:2"
+          ]
+        },
+        "ram:10000040:2:basic": {
+          "operations": {
+            "ram:10000040:300:0": {
+              "mnemonic": "CALL",
+              "type": "t_void",
+              "has_return_value": false,
+              "target": {
+                "kind": "function",
+                "function": "EXTERNAL:free",
+                "is_variadic": false,
+                "is_noreturn": false
+              },
+              "inputs": [
+                {
+                  "type": "t_ptr_void",
+                  "kind": "local",
+                  "operation": "unique:00000002:0:0"
+                }
+              ]
+            },
+            "ram:10000044:301:1": {
+              "mnemonic": "RETURN",
+              "inputs": []
+            }
+          },
+          "ordered_operations": [
+            "ram:10000040:300:0",
+            "ram:10000044:301:1"
+          ]
+        }
+      },
+      "entry_block": "ram:10000000:entry"
+    },
+    "EXTERNAL:malloc": {
+      "name": "malloc",
+      "is_intrinsic": false,
+      "type": {
+        "return_type": "t_ptr_void",
+        "is_variadic": false,
+        "is_noreturn": false,
+        "parameter_types": ["t_u32"]
+      }
+    },
+    "EXTERNAL:free": {
+      "name": "free",
+      "is_intrinsic": false,
+      "type": {
+        "return_type": "t_void",
+        "is_variadic": false,
+        "is_noreturn": false,
+        "parameter_types": ["t_ptr_void"]
+      }
+    },
+    "EXTERNAL:handler_process": {
+      "name": "handler_process",
+      "is_intrinsic": false,
+      "type": {
+        "return_type": "t_u32",
+        "is_variadic": false,
+        "is_noreturn": false,
+        "parameter_types": ["t_ptr_void"]
+      }
+    },
+    "EXTERNAL:send_error": {
+      "name": "send_error",
+      "is_intrinsic": false,
+      "type": {
+        "return_type": "t_void",
+        "is_variadic": false,
+        "is_noreturn": false,
+        "parameter_types": ["t_u32"]
+      }
+    }
+  },
+  "globals": {},
+  "types": {
+    "t_u32": { "name": "unsigned int", "size": 4, "kind": "integer" },
+    "t_bool": { "name": "bool", "size": 1, "kind": "integer" },
+    "t_ptr_void": { "kind": "pointer", "size": 4, "element_type": "t_void" },
+    "t_void": { "name": "void", "size": 0, "kind": "void" }
+  }
+}


### PR DESCRIPTION
Add CWE-415 patch specification for the Ventilator Interface::ProcessCommand() double free vulnerability. The vulnerable pattern: cmd_log is freed inside an error-handling block, then unconditionally freed again after the block (missing return statement).

This is the first spec to use the is_reference: true mechanism for state propagation. The patch is applied after the first free() call with is_reference on the pointer operand. The is_reference mechanism:
  1. Creates an alloca for the pointer, storing its value
  2. Passes the alloca address (void**) to the patch function
  3. The patch sets *ptr_ref = NULL (null-after-free)
  4. update_state_after_patch loads the NULL back and replaces all dominated uses of the original pointer

This makes the second free(cmd_log) become free(NULL) — a safe no-op.

Key finding: the patch function must take void** (not void*) to match the alloca type produced by is_reference for a void* operand. Using void* causes a CIR cast error between incompatible pointer depths.

Files:
  - ventilator_cwe415.json: P-Code JSON representing process_command() with malloc, conditional free (error path), and unconditional free
  - cwe415_after.yaml: Patch spec using apply_after + is_reference
  - patches/cwe415_patches.yaml: Patch library definition
  - patches/patch_null_after_free.c: Null-after-free via void** deref

Resolves: https://github.com/lifting-bits/patchestry/issues/175