### PR TITLE
decomp: improve clang emitter to better identify terminator for if-else both ending with terminator

### DIFF
--- a/include/patchestry/AST/ClangEmitter.hpp
+++ b/include/patchestry/AST/ClangEmitter.hpp
@@ -11,8 +11,16 @@
 
 #include <clang/AST/ASTContext.h>
 #include <clang/AST/Decl.h>
+#include <clang/AST/Stmt.h>
 
 namespace patchestry::ast {
+
+    namespace detail {
+        // Check if a stmt ends with a control flow terminator
+        // (goto/break/continue/return).  Recurses into CompoundStmt,
+        // LabelStmt, and IfStmt (both arms must terminate).
+        bool EndsWithTerminator(clang::Stmt *s);
+    } // namespace detail
 
     // Convert an SNode tree back to a Clang CompoundStmt and set it as the
     // function body.

--- a/lib/patchestry/AST/ASTConsumer.cpp
+++ b/lib/patchestry/AST/ASTConsumer.cpp
@@ -157,13 +157,10 @@ namespace patchestry::ast {
                                         auto &tn = flow_graph.Node(
                                             node.succs[sc.succ_index]);
                                         if (tn.original_label.empty()) {
-                                            LOG(ERROR) << "switch default target node "
+                                            LOG(FATAL) << "switch default target node "
                                                        << node.succs[sc.succ_index]
-                                                       << " has no label — possible CGraph "
-                                                          "builder bug. Generating fallback.\n";
-                                            tn.original_label = "switch_target_"
-                                                + std::to_string(node.succs[sc.succ_index]);
-                                            tn.label = tn.original_label;
+                                                       << " has no original_label — "
+                                                          "CGraph builder bug.\n";
                                         }
                                         sw->SetDefaultBody(factory.Make<SGoto>(
                                             factory.Intern(tn.original_label)));
@@ -186,14 +183,11 @@ namespace patchestry::ast {
                                         auto &tn = flow_graph.Node(
                                             node.succs[sc.succ_index]);
                                         if (tn.original_label.empty()) {
-                                            LOG(ERROR) << "switch case " << sc.value
+                                            LOG(FATAL) << "switch case " << sc.value
                                                        << " target node "
                                                        << node.succs[sc.succ_index]
-                                                       << " has no label — possible CGraph "
-                                                          "builder bug. Generating fallback.\n";
-                                            tn.original_label = "switch_target_"
-                                                + std::to_string(node.succs[sc.succ_index]);
-                                            tn.label = tn.original_label;
+                                                       << " has no original_label — "
+                                                          "CGraph builder bug.\n";
                                         }
                                         body = factory.Make<SGoto>(
                                             factory.Intern(tn.original_label));

--- a/lib/patchestry/AST/ASTConsumer.cpp
+++ b/lib/patchestry/AST/ASTConsumer.cpp
@@ -1,4 +1,4 @@
-*
+/*
  * Copyright (c) 2024, Trail of Bits, Inc.
  *
  * This source code is licensed in accordance with the terms specified in
@@ -156,8 +156,15 @@ namespace patchestry::ast {
                                     if (sc.succ_index < node.succs.size()) {
                                         auto &tn = flow_graph.Node(
                                             node.succs[sc.succ_index]);
-                                        assert(!tn.original_label.empty()
-                                               && "switch default target missing label");
+                                        if (tn.original_label.empty()) {
+                                            LOG(ERROR) << "switch default target node "
+                                                       << node.succs[sc.succ_index]
+                                                       << " has no label — possible CGraph "
+                                                          "builder bug. Generating fallback.\n";
+                                            tn.original_label = "switch_target_"
+                                                + std::to_string(node.succs[sc.succ_index]);
+                                            tn.label = tn.original_label;
+                                        }
                                         sw->SetDefaultBody(factory.Make<SGoto>(
                                             factory.Intern(tn.original_label)));
                                     } else {
@@ -178,8 +185,16 @@ namespace patchestry::ast {
                                     if (sc.succ_index < node.succs.size()) {
                                         auto &tn = flow_graph.Node(
                                             node.succs[sc.succ_index]);
-                                        assert(!tn.original_label.empty()
-                                               && "switch case target missing label");
+                                        if (tn.original_label.empty()) {
+                                            LOG(ERROR) << "switch case " << sc.value
+                                                       << " target node "
+                                                       << node.succs[sc.succ_index]
+                                                       << " has no label — possible CGraph "
+                                                          "builder bug. Generating fallback.\n";
+                                            tn.original_label = "switch_target_"
+                                                + std::to_string(node.succs[sc.succ_index]);
+                                            tn.label = tn.original_label;
+                                        }
                                         body = factory.Make<SGoto>(
                                             factory.Intern(tn.original_label));
                                     } else {

--- a/lib/patchestry/AST/ASTConsumer.cpp
+++ b/lib/patchestry/AST/ASTConsumer.cpp
@@ -1,4 +1,4 @@
-/*
+*
  * Copyright (c) 2024, Trail of Bits, Inc.
  *
  * This source code is licensed in accordance with the terms specified in
@@ -117,102 +117,107 @@ namespace patchestry::ast {
                     tracer.Dump(flow_graph, "BuildCGraph", true);
                 }
 
-                // Emit the CGraph blocks sequentially with goto-based
-                // control flow from terminals.
-                // Switch blocks get an SSwitch with goto-to-label cases.
                 SNodeFactory factory;
-                auto *seq = factory.Make<SSeq>();
+                SNode *root_snode = nullptr;
 
-                for (auto &node : flow_graph.nodes) {
-                    if (node.IsCollapsed()) continue;
-                    auto *blk = factory.Make<SBlock>();
-                    for (auto *s : node.stmts) blk->AddStmt(s);
+                if (options.use_structuring_pass) {
+                    LOG(ERROR) << "--use-structuring-pass is not implemented yet.\n";
 
-                    // Switch block: build SSwitch with goto cases
-                    if (!node.switch_cases.empty() && node.branch_cond) {
-                        auto *sw = factory.Make<SSwitch>(node.branch_cond);
-                        auto resolve_switch_target_label = [&](size_t succ_id) -> std::string {
-                            auto &tn = flow_graph.Node(succ_id);
-                            if (!tn.original_label.empty()) {
-                                return tn.original_label;
-                            }
-                            if (!tn.label.empty()) {
-                                tn.original_label = tn.label;
-                                return tn.original_label;
-                            }
-
-                            // Deterministic fallback for unlabeled synthetic/collapsed targets.
-                            // Write back to node labels so goto target and emitted SLabel match.
-                            tn.label          = "switch_target_" + std::to_string(succ_id);
-                            tn.original_label = tn.label;
-                            return tn.original_label;
-                        };
-
-                        // Use the discriminant's type for case literals to
-                        // avoid truncation on targets where uintptr_t > int.
-                        // For enum types, use the underlying integer type for
-                        // the width since getIntWidth requires a BuiltinType.
-                        auto case_type = node.branch_cond->getType();
-                        if (case_type->isEnumeralType()) {
-                            case_type = case_type->castAs<clang::EnumType>()
-                                ->getDecl()->getIntegerType();
-                        }
-                        unsigned case_width = ctx.getIntWidth(case_type);
-                        for (const auto &sc : node.switch_cases) {
-                            if (sc.is_default) {
-                                // Default arm: goto target label
-                                if (sc.succ_index < node.succs.size()) {
-                                    auto target_id = node.succs[sc.succ_index];
-                                    auto lbl = resolve_switch_target_label(target_id);
-                                    sw->SetDefaultBody(factory.Make<SGoto>(
-                                        factory.Intern(lbl)));
-                                } else {
-                                    LOG(WARNING) << "switch default succ_index "
-                                                 << sc.succ_index << " out of range (succs="
-                                                 << node.succs.size() << ")\n";
-                                }
-                            } else {
-                                auto *val = clang::IntegerLiteral::Create(
-                                    ctx, llvm::APInt(case_width, static_cast<uint64_t>(sc.value), true),
-                                    case_type, clang::SourceLocation());
-                                SNode *body = nullptr;
-                                if (sc.succ_index < node.succs.size()) {
-                                    auto target_id = node.succs[sc.succ_index];
-                                    auto lbl = resolve_switch_target_label(target_id);
-                                    body = factory.Make<SGoto>(
-                                        factory.Intern(lbl));
-                                } else {
-                                    LOG(WARNING) << "switch case " << sc.value
-                                                 << " succ_index " << sc.succ_index
-                                                 << " out of range (succs="
-                                                 << node.succs.size() << ")\n";
-                                }
-                                sw->AddCase(val, body);
-                            }
-                        }
-                        auto *sw_seq = factory.Make<SSeq>();
-                        if (!blk->Stmts().empty()) sw_seq->AddChild(blk);
-                        sw_seq->AddChild(sw);
-                        if (!node.label.empty()) {
-                            seq->AddChild(factory.Make<SLabel>(
-                                factory.Intern(node.label), sw_seq));
-                        } else {
-                            seq->AddChild(sw_seq);
-                        }
-                        continue;
-                    }
-
-                    // Non-switch: append terminal (goto/if-goto)
-                    if (node.terminal) blk->AddStmt(node.terminal);
-                    if (!node.label.empty()) {
-                        auto *lbl = factory.Make<SLabel>(
-                            factory.Intern(node.label), blk);
-                        seq->AddChild(lbl);
-                    } else {
-                        seq->AddChild(blk);
-                    }
                 }
-                EmitClangAST(seq, fn, ctx);
+
+                if (!root_snode) {
+                    // Goto-based path (original, unchanged).
+                    // Emit the CGraph blocks sequentially with goto-based
+                    // control flow from terminals.
+                    // Switch blocks get an SSwitch with goto-to-label cases.
+                    auto *seq = factory.Make<SSeq>();
+
+                    for (auto &node : flow_graph.nodes) {
+                        if (node.IsCollapsed()) continue;
+                        auto *blk = factory.Make<SBlock>();
+                        for (auto *s : node.stmts) blk->AddStmt(s);
+
+                        // Switch block: build SSwitch with goto cases
+                        if (!node.switch_cases.empty() && node.branch_cond) {
+                            auto *sw = factory.Make<SSwitch>(node.branch_cond);
+                            // Use the discriminant's type for case literals to
+                            // avoid truncation on targets where uintptr_t > int.
+                            // For enum types, use the underlying integer type for
+                            // the width since getIntWidth requires a BuiltinType.
+                            auto case_type = node.branch_cond->getType();
+                            if (case_type->isEnumeralType()) {
+                                case_type = case_type->castAs<clang::EnumType>()
+                                    ->getDecl()->getIntegerType();
+                            }
+                            unsigned case_width = ctx.getIntWidth(case_type);
+                            for (const auto &sc : node.switch_cases) {
+                                if (sc.is_default) {
+                                    // Default arm: goto target label
+                                    if (sc.succ_index < node.succs.size()) {
+                                        auto &tn = flow_graph.Node(
+                                            node.succs[sc.succ_index]);
+                                        assert(!tn.original_label.empty()
+                                               && "switch default target missing label");
+                                        sw->SetDefaultBody(factory.Make<SGoto>(
+                                            factory.Intern(tn.original_label)));
+                                    } else {
+                                        LOG(WARNING)
+                                            << "switch default succ_index "
+                                            << sc.succ_index
+                                            << " out of range (succs="
+                                            << node.succs.size() << ")\n";
+                                    }
+                                } else {
+                                    auto *val = clang::IntegerLiteral::Create(
+                                        ctx,
+                                        llvm::APInt(case_width,
+                                                    static_cast<uint64_t>(sc.value),
+                                                    true),
+                                        case_type, clang::SourceLocation());
+                                    SNode *body = nullptr;
+                                    if (sc.succ_index < node.succs.size()) {
+                                        auto &tn = flow_graph.Node(
+                                            node.succs[sc.succ_index]);
+                                        assert(!tn.original_label.empty()
+                                               && "switch case target missing label");
+                                        body = factory.Make<SGoto>(
+                                            factory.Intern(tn.original_label));
+                                    } else {
+                                        LOG(WARNING)
+                                            << "switch case " << sc.value
+                                            << " succ_index " << sc.succ_index
+                                            << " out of range (succs="
+                                            << node.succs.size() << ")\n";
+                                    }
+                                    sw->AddCase(val, body);
+                                }
+                            }
+                            auto *sw_seq = factory.Make<SSeq>();
+                            if (!blk->Stmts().empty()) sw_seq->AddChild(blk);
+                            sw_seq->AddChild(sw);
+                            if (!node.label.empty()) {
+                                seq->AddChild(factory.Make<SLabel>(
+                                    factory.Intern(node.label), sw_seq));
+                            } else {
+                                seq->AddChild(sw_seq);
+                            }
+                            continue;
+                        }
+
+                        // Non-switch: append terminal (goto/if-goto)
+                        if (node.terminal) blk->AddStmt(node.terminal);
+                        if (!node.label.empty()) {
+                            auto *lbl = factory.Make<SLabel>(
+                                factory.Intern(node.label), blk);
+                            seq->AddChild(lbl);
+                        } else {
+                            seq->AddChild(blk);
+                        }
+                    }
+                    root_snode = seq;
+                }
+
+                EmitClangAST(root_snode, fn, ctx);
 
                 CleanupPrettyPrint(fn, ctx);
             }

--- a/lib/patchestry/AST/ASTConsumer.cpp
+++ b/lib/patchestry/AST/ASTConsumer.cpp
@@ -121,8 +121,8 @@ namespace patchestry::ast {
                 SNode *root_snode = nullptr;
 
                 if (options.use_structuring_pass) {
-                    LOG(ERROR) << "--use-structuring-pass is not implemented yet.\n";
-
+                    LOG(WARNING) << "--use-structuring-pass is not implemented yet. "
+                                    "Falling back to goto-based Clang AST emission.\n";
                 }
 
                 if (!root_snode) {

--- a/lib/patchestry/AST/ClangEmitter.cpp
+++ b/lib/patchestry/AST/ClangEmitter.cpp
@@ -131,8 +131,9 @@ namespace patchestry::ast {
             return new (ctx) clang::ParenExpr(loc, loc, expr);
         }
 
-    } // close anonymous namespace
+    } // anonymous namespace
 
+    // Shared utility — used by both ClangEmitter and ClangEmitterCleanup.
     namespace detail {
         bool EndsWithTerminator(clang::Stmt *s) {
             llvm::SmallVector< clang::Stmt *, 4 > worklist;
@@ -271,7 +272,14 @@ namespace patchestry::ast {
             clang::Stmt *EmitDoWhile(const SDoWhile *dw) {
                 auto *body = Emit(dw->Body());
                 if (!body) body = new (ctx_) clang::NullStmt(Loc());
-                auto *cond = EnsureRValue(ctx_, CloneExpr(ctx_, dw->Cond()));
+                clang::Expr *cond = nullptr;
+                if (dw->Cond()) {
+                    cond = EnsureRValue(ctx_, CloneExpr(ctx_, dw->Cond()));
+                } else {
+                    // do { ... } while(1) — SDoWhile with null condition.
+                    cond = clang::IntegerLiteral::Create(
+                        ctx_, llvm::APInt(32, 1), ctx_.IntTy, Loc());
+                }
 
                 return new (ctx_) clang::DoStmt(body, cond, Loc(), Loc(), Loc());
             }

--- a/lib/patchestry/AST/ClangEmitter.cpp
+++ b/lib/patchestry/AST/ClangEmitter.cpp
@@ -131,24 +131,44 @@ namespace patchestry::ast {
             return new (ctx) clang::ParenExpr(loc, loc, expr);
         }
 
-        // Check if a stmt ends with a control flow terminator (goto/break/continue/return).
-        // Also handles IfStmt where both arms terminate — common for
-        // inlined stack-canary epilogues from ConvertGotoToReturn.
+    } // close anonymous namespace
+
+    namespace detail {
         bool EndsWithTerminator(clang::Stmt *s) {
-            if (!s) return false;
-            if (llvm::isa< clang::GotoStmt >(s) || llvm::isa< clang::BreakStmt >(s) ||
-                llvm::isa< clang::ContinueStmt >(s) || llvm::isa< clang::ReturnStmt >(s))
-                return true;
-            if (auto *cs = llvm::dyn_cast< clang::CompoundStmt >(s))
-                return !cs->body_empty() && EndsWithTerminator(cs->body_back());
-            if (auto *ls = llvm::dyn_cast< clang::LabelStmt >(s))
-                return EndsWithTerminator(ls->getSubStmt());
-            if (auto *ifs = llvm::dyn_cast< clang::IfStmt >(s))
-                return ifs->getThen() && ifs->getElse()
-                    && EndsWithTerminator(ifs->getThen())
-                    && EndsWithTerminator(ifs->getElse());
-            return false;
+            llvm::SmallVector< clang::Stmt *, 4 > worklist;
+            if (s) worklist.push_back(s);
+
+            while (!worklist.empty()) {
+                auto *cur = worklist.pop_back_val();
+                if (!cur) return false;
+
+                if (llvm::isa< clang::GotoStmt >(cur)
+                    || llvm::isa< clang::BreakStmt >(cur)
+                    || llvm::isa< clang::ContinueStmt >(cur)
+                    || llvm::isa< clang::ReturnStmt >(cur))
+                    continue;
+                if (auto *cs = llvm::dyn_cast< clang::CompoundStmt >(cur)) {
+                    if (cs->body_empty()) return false;
+                    worklist.push_back(cs->body_back());
+                    continue;
+                }
+                if (auto *ls = llvm::dyn_cast< clang::LabelStmt >(cur)) {
+                    worklist.push_back(ls->getSubStmt());
+                    continue;
+                }
+                if (auto *ifs = llvm::dyn_cast< clang::IfStmt >(cur)) {
+                    if (!ifs->getThen() || !ifs->getElse()) return false;
+                    worklist.push_back(ifs->getThen());
+                    worklist.push_back(ifs->getElse());
+                    continue;
+                }
+                return false;
+            }
+            return true;
         }
+    } // namespace detail
+
+    namespace {
 
         // Recursively convert SNode tree to Clang Stmt*
         class Emitter {
@@ -208,11 +228,9 @@ namespace patchestry::ast {
             }
 
             clang::Stmt *EmitIfThenElse(const SIfThenElse *ite) {
-                if (!ite->Cond()) {
-                    // Degenerate: no condition → just emit then-branch.
-                    auto *body = Emit(ite->ThenBranch());
-                    return body ? body : new (ctx_) clang::NullStmt(Loc());
-                }
+                LOG_FATAL_IF(!ite->Cond(),
+                    "SIfThenElse has null condition - structuring "
+                    "rule produced a branch without a guard expression");
                 auto *cond = EnsureRValue(ctx_, CloneExpr(ctx_, ite->Cond()));
                 auto *then_stmt = Emit(ite->ThenBranch());
                 auto *else_stmt = ite->ElseBranch() ? Emit(ite->ElseBranch()) : nullptr;
@@ -293,7 +311,7 @@ namespace patchestry::ast {
                         }
 
                         std::vector< clang::Stmt * > case_stmts = { case_body };
-                        if (!EndsWithTerminator(case_body)) {
+                        if (!detail::EndsWithTerminator(case_body)) {
                             case_stmts.push_back(new (ctx_) clang::BreakStmt(Loc()));
                         }
                         case_stmt->setSubStmt(detail::MakeCompound(ctx_, case_stmts));
@@ -310,7 +328,7 @@ namespace patchestry::ast {
                     }
 
                     std::vector< clang::Stmt * > def_stmts = { def_body };
-                    if (!EndsWithTerminator(def_body)) {
+                    if (!detail::EndsWithTerminator(def_body)) {
                         def_stmts.push_back(new (ctx_) clang::BreakStmt(Loc()));
                     }
 

--- a/lib/patchestry/AST/ClangEmitter.cpp
+++ b/lib/patchestry/AST/ClangEmitter.cpp
@@ -132,6 +132,8 @@ namespace patchestry::ast {
         }
 
         // Check if a stmt ends with a control flow terminator (goto/break/continue/return).
+        // Also handles IfStmt where both arms terminate — common for
+        // inlined stack-canary epilogues from ConvertGotoToReturn.
         bool EndsWithTerminator(clang::Stmt *s) {
             if (!s) return false;
             if (llvm::isa< clang::GotoStmt >(s) || llvm::isa< clang::BreakStmt >(s) ||
@@ -139,6 +141,12 @@ namespace patchestry::ast {
                 return true;
             if (auto *cs = llvm::dyn_cast< clang::CompoundStmt >(s))
                 return !cs->body_empty() && EndsWithTerminator(cs->body_back());
+            if (auto *ls = llvm::dyn_cast< clang::LabelStmt >(s))
+                return EndsWithTerminator(ls->getSubStmt());
+            if (auto *ifs = llvm::dyn_cast< clang::IfStmt >(s))
+                return ifs->getThen() && ifs->getElse()
+                    && EndsWithTerminator(ifs->getThen())
+                    && EndsWithTerminator(ifs->getElse());
             return false;
         }
 
@@ -200,11 +208,23 @@ namespace patchestry::ast {
             }
 
             clang::Stmt *EmitIfThenElse(const SIfThenElse *ite) {
+                if (!ite->Cond()) {
+                    // Degenerate: no condition → just emit then-branch.
+                    auto *body = Emit(ite->ThenBranch());
+                    return body ? body : new (ctx_) clang::NullStmt(Loc());
+                }
                 auto *cond = EnsureRValue(ctx_, CloneExpr(ctx_, ite->Cond()));
                 auto *then_stmt = Emit(ite->ThenBranch());
                 auto *else_stmt = ite->ElseBranch() ? Emit(ite->ElseBranch()) : nullptr;
 
                 if (!then_stmt) then_stmt = new (ctx_) clang::NullStmt(Loc());
+
+                // Unwrap CompoundStmt around a single IfStmt in the else
+                // branch so Clang's printer emits "else if" not "else { if".
+                if (auto *cs = llvm::dyn_cast_or_null< clang::CompoundStmt >(else_stmt)) {
+                    if (cs->size() == 1 && llvm::isa< clang::IfStmt >(cs->body_front()))
+                        else_stmt = cs->body_front();
+                }
 
                 return clang::IfStmt::Create(
                     ctx_, Loc(), clang::IfStatementKind::Ordinary,
@@ -214,7 +234,14 @@ namespace patchestry::ast {
             }
 
             clang::Stmt *EmitWhile(const SWhile *w) {
-                auto *cond = EnsureRValue(ctx_, CloneExpr(ctx_, w->Cond()));
+                clang::Expr *cond = nullptr;
+                if (w->Cond()) {
+                    cond = EnsureRValue(ctx_, CloneExpr(ctx_, w->Cond()));
+                } else {
+                    // while(1) — SWhile with null condition.
+                    cond = clang::IntegerLiteral::Create(
+                        ctx_, llvm::APInt(32, 1), ctx_.IntTy, Loc());
+                }
                 auto *body = Emit(w->Body());
                 if (!body) body = new (ctx_) clang::NullStmt(Loc());
 

--- a/lib/patchestry/AST/ClangEmitterCleanup.cpp
+++ b/lib/patchestry/AST/ClangEmitterCleanup.cpp
@@ -348,23 +348,22 @@ namespace detail {
             // and contains no live labels, it is unreachable and can
             // be removed.
             auto is_terminator = [](clang::Stmt *st) -> bool {
-                if (!st) {
+                std::function< bool(clang::Stmt *) > check;
+                check = [&](clang::Stmt *s) -> bool {
+                    if (!s) return false;
+                    if (llvm::isa< clang::ReturnStmt >(s)
+                        || llvm::isa< clang::GotoStmt >(s)
+                        || llvm::isa< clang::BreakStmt >(s)
+                        || llvm::isa< clang::ContinueStmt >(s))
+                        return true;
+                    if (auto *cs_inner = llvm::dyn_cast< clang::CompoundStmt >(s))
+                        return !cs_inner->body_empty() && check(cs_inner->body_back());
+                    if (auto *ifs = llvm::dyn_cast< clang::IfStmt >(s))
+                        return ifs->getThen() && ifs->getElse()
+                            && check(ifs->getThen()) && check(ifs->getElse());
                     return false;
-                }
-                if (llvm::isa< clang::ReturnStmt >(st) || llvm::isa< clang::GotoStmt >(st)
-                    || llvm::isa< clang::BreakStmt >(st)
-                    || llvm::isa< clang::ContinueStmt >(st))
-                {
-                    return true;
-                }
-                if (auto *cs_inner = llvm::dyn_cast< clang::CompoundStmt >(st)) {
-                    return !cs_inner->body_empty()
-                        && (llvm::isa< clang::ReturnStmt >(cs_inner->body_back())
-                            || llvm::isa< clang::GotoStmt >(cs_inner->body_back())
-                            || llvm::isa< clang::BreakStmt >(cs_inner->body_back())
-                            || llvm::isa< clang::ContinueStmt >(cs_inner->body_back()));
-                }
-                return false;
+                };
+                return check(st);
             };
 
             for (size_t i = 1; i < children.size();) {
@@ -1013,6 +1012,59 @@ namespace detail {
             return detail::MakeCompound(ctx, body);
         }
 
+        // Collect all LabelDecls that have a LabelStmt definition in the tree.
+        void CollectDefinedLabels(clang::Stmt *s,
+                                  std::unordered_set< clang::LabelDecl * > &defined,
+                                  std::unordered_set< clang::Stmt * > &seen) {
+            if (!s || !seen.insert(s).second) return;
+            if (auto *ls = llvm::dyn_cast< clang::LabelStmt >(s)) {
+                defined.insert(ls->getDecl());
+            }
+            for (auto *child : s->children()) {
+                CollectDefinedLabels(child, defined, seen);
+            }
+        }
+
+        // Replace GotoStmts whose target label has no LabelStmt in the
+        // function body with NullStmt.  Returns a new tree if changes
+        // were made, nullptr otherwise.
+        clang::Stmt *RemoveOrphanedGotos(
+            clang::ASTContext &ctx, clang::Stmt *s,
+            const std::unordered_set< clang::LabelDecl * > &defined
+        ) {
+            if (!s) return nullptr;
+
+            if (auto *gs = llvm::dyn_cast< clang::GotoStmt >(s)) {
+                if (!defined.count(gs->getLabel())) {
+                    return new (ctx) clang::NullStmt(gs->getGotoLoc());
+                }
+                return nullptr;
+            }
+
+            if (auto *cs = llvm::dyn_cast< clang::CompoundStmt >(s)) {
+                std::vector< clang::Stmt * > children;
+                bool changed = false;
+                for (auto *child : cs->body()) {
+                    auto *repl = RemoveOrphanedGotos(ctx, child, defined);
+                    children.push_back(repl ? repl : child);
+                    if (repl) changed = true;
+                }
+                return changed ? detail::MakeCompound(ctx, children) : nullptr;
+            }
+
+            // Recurse into IfStmt, LabelStmt, etc. via child iteration.
+            bool changed = false;
+            for (auto it = s->child_begin(); it != s->child_end(); ++it) {
+                if (!*it) continue;
+                auto *repl = RemoveOrphanedGotos(ctx, *it, defined);
+                if (repl) {
+                    *it = repl;
+                    changed = true;
+                }
+            }
+            return changed ? s : nullptr;
+        }
+
     } // anonymous namespace
 
     void CleanupPrettyPrint(clang::FunctionDecl *fn, clang::ASTContext &ctx) {
@@ -1061,6 +1113,18 @@ namespace detail {
         body = RemoveDeadLabels(ctx, fn->getBody(), goto_targets);
         if (body) {
             fn->setBody(body);
+        }
+
+        // Remove gotos whose target label was never emitted (orphaned
+        // by structuring rules that absorbed the target block).
+        {
+            std::unordered_set< clang::LabelDecl * > defined;
+            std::unordered_set< clang::Stmt * > seen2;
+            CollectDefinedLabels(fn->getBody(), defined, seen2);
+            body = RemoveOrphanedGotos(ctx, fn->getBody(), defined);
+            if (body) {
+                fn->setBody(body);
+            }
         }
 
         // Final pass: remove empty CompoundStmts and NullStmts.

--- a/lib/patchestry/AST/ClangEmitterCleanup.cpp
+++ b/lib/patchestry/AST/ClangEmitterCleanup.cpp
@@ -1000,14 +1000,17 @@ namespace detail {
 
         // Collect all LabelDecls that have a LabelStmt definition in the tree.
         void CollectDefinedLabels(clang::Stmt *s,
-                                  std::unordered_set< clang::LabelDecl * > &defined,
-                                  std::unordered_set< clang::Stmt * > &seen) {
-            if (!s || !seen.insert(s).second) return;
-            if (auto *ls = llvm::dyn_cast< clang::LabelStmt >(s)) {
-                defined.insert(ls->getDecl());
-            }
-            for (auto *child : s->children()) {
-                CollectDefinedLabels(child, defined, seen);
+                                  std::unordered_set< clang::LabelDecl * > &defined) {
+            llvm::SmallVector< clang::Stmt *, 16 > worklist;
+            if (s) worklist.push_back(s);
+
+            while (!worklist.empty()) {
+                auto *cur = worklist.pop_back_val();
+                if (!cur) continue;
+                if (auto *ls = llvm::dyn_cast< clang::LabelStmt >(cur))
+                    defined.insert(ls->getDecl());
+                for (auto *child : cur->children())
+                    if (child) worklist.push_back(child);
             }
         }
 
@@ -1016,9 +1019,16 @@ namespace detail {
         // were made, nullptr otherwise.
         clang::Stmt *RemoveOrphanedGotos(
             clang::ASTContext &ctx, clang::Stmt *s,
-            const std::unordered_set< clang::LabelDecl * > &defined
+            const std::unordered_set< clang::LabelDecl * > &defined,
+            unsigned depth = 0
         ) {
             if (!s) return nullptr;
+            if (depth > 256) {
+                LOG(ERROR) << "RemoveOrphanedGotos: recursion depth exceeded "
+                              "(depth=" << depth << "). Possible malformed AST "
+                              "or unexpectedly deep nesting — skipping subtree.\n";
+                return nullptr;
+            }
 
             if (auto *gs = llvm::dyn_cast< clang::GotoStmt >(s)) {
                 if (!defined.count(gs->getLabel())) {
@@ -1036,7 +1046,7 @@ namespace detail {
                 std::vector< clang::Stmt * > children;
                 bool changed = false;
                 for (auto *child : cs->body()) {
-                    auto *repl = RemoveOrphanedGotos(ctx, child, defined);
+                    auto *repl = RemoveOrphanedGotos(ctx, child, defined, depth + 1);
                     children.push_back(repl ? repl : child);
                     if (repl) changed = true;
                 }
@@ -1047,7 +1057,7 @@ namespace detail {
             bool changed = false;
             for (auto it = s->child_begin(); it != s->child_end(); ++it) {
                 if (!*it) continue;
-                auto *repl = RemoveOrphanedGotos(ctx, *it, defined);
+                auto *repl = RemoveOrphanedGotos(ctx, *it, defined, depth + 1);
                 if (repl) {
                     *it = repl;
                     changed = true;
@@ -1109,8 +1119,7 @@ namespace detail {
         // Remove gotos whose target label was never emitted (orphaned
         // by structuring rules that absorbed the target block).
         std::unordered_set< clang::LabelDecl * > defined;
-        std::unordered_set< clang::Stmt * > seen2;
-        CollectDefinedLabels(fn->getBody(), defined, seen2);
+        CollectDefinedLabels(fn->getBody(), defined);
         body = RemoveOrphanedGotos(ctx, fn->getBody(), defined);
         if (body) {
             fn->setBody(body);

--- a/lib/patchestry/AST/ClangEmitterCleanup.cpp
+++ b/lib/patchestry/AST/ClangEmitterCleanup.cpp
@@ -1015,12 +1015,13 @@ namespace detail {
         }
 
         // Replace GotoStmts whose target label has no LabelStmt in the
-        // function body with NullStmt.  Returns a new tree if changes
-        // were made, nullptr otherwise.
+        // function body with NullStmt.  When the orphaned goto is inside
+        // a switch case body (in_switch_case=true), replace with BreakStmt
+        // instead to prevent unintended fallthrough.
         clang::Stmt *RemoveOrphanedGotos(
             clang::ASTContext &ctx, clang::Stmt *s,
             const std::unordered_set< clang::LabelDecl * > &defined,
-            unsigned depth = 0
+            unsigned depth = 0, bool in_switch_case = false
         ) {
             if (!s) return nullptr;
             if (depth > 256) {
@@ -1037,16 +1038,25 @@ namespace detail {
                                << "' with no matching LabelStmt in function body. "
                                   "This may indicate a structuring rule bug that "
                                   "dropped the target label — verify emitted output.\n";
+                    if (in_switch_case) {
+                        return new (ctx) clang::BreakStmt(gs->getGotoLoc());
+                    }
                     return new (ctx) clang::NullStmt(gs->getGotoLoc());
                 }
                 return nullptr;
             }
 
+            // Track whether children are inside a switch case body.
+            bool child_in_case = in_switch_case
+                || llvm::isa< clang::CaseStmt >(s)
+                || llvm::isa< clang::DefaultStmt >(s);
+
             if (auto *cs = llvm::dyn_cast< clang::CompoundStmt >(s)) {
                 std::vector< clang::Stmt * > children;
                 bool changed = false;
                 for (auto *child : cs->body()) {
-                    auto *repl = RemoveOrphanedGotos(ctx, child, defined, depth + 1);
+                    auto *repl = RemoveOrphanedGotos(
+                        ctx, child, defined, depth + 1, child_in_case);
                     children.push_back(repl ? repl : child);
                     if (repl) changed = true;
                 }
@@ -1057,7 +1067,8 @@ namespace detail {
             bool changed = false;
             for (auto it = s->child_begin(); it != s->child_end(); ++it) {
                 if (!*it) continue;
-                auto *repl = RemoveOrphanedGotos(ctx, *it, defined, depth + 1);
+                auto *repl = RemoveOrphanedGotos(
+                    ctx, *it, defined, depth + 1, child_in_case);
                 if (repl) {
                     *it = repl;
                     changed = true;

--- a/lib/patchestry/AST/ClangEmitterCleanup.cpp
+++ b/lib/patchestry/AST/ClangEmitterCleanup.cpp
@@ -7,6 +7,7 @@
 
 #include <patchestry/AST/ClangEmitter.hpp>
 #include <patchestry/AST/Utils.hpp>
+#include <patchestry/Util/Log.hpp>
 
 #include <functional>
 #include <string>
@@ -348,22 +349,7 @@ namespace detail {
             // and contains no live labels, it is unreachable and can
             // be removed.
             auto is_terminator = [](clang::Stmt *st) -> bool {
-                std::function< bool(clang::Stmt *) > check;
-                check = [&](clang::Stmt *s) -> bool {
-                    if (!s) return false;
-                    if (llvm::isa< clang::ReturnStmt >(s)
-                        || llvm::isa< clang::GotoStmt >(s)
-                        || llvm::isa< clang::BreakStmt >(s)
-                        || llvm::isa< clang::ContinueStmt >(s))
-                        return true;
-                    if (auto *cs_inner = llvm::dyn_cast< clang::CompoundStmt >(s))
-                        return !cs_inner->body_empty() && check(cs_inner->body_back());
-                    if (auto *ifs = llvm::dyn_cast< clang::IfStmt >(s))
-                        return ifs->getThen() && ifs->getElse()
-                            && check(ifs->getThen()) && check(ifs->getElse());
-                    return false;
-                };
-                return check(st);
+                return detail::EndsWithTerminator(st);
             };
 
             for (size_t i = 1; i < children.size();) {
@@ -1036,6 +1022,11 @@ namespace detail {
 
             if (auto *gs = llvm::dyn_cast< clang::GotoStmt >(s)) {
                 if (!defined.count(gs->getLabel())) {
+                    LOG(ERROR) << "ORPHANED GOTO: removing 'goto "
+                               << gs->getLabel()->getName()
+                               << "' with no matching LabelStmt in function body. "
+                                  "This may indicate a structuring rule bug that "
+                                  "dropped the target label — verify emitted output.\n";
                     return new (ctx) clang::NullStmt(gs->getGotoLoc());
                 }
                 return nullptr;
@@ -1117,14 +1108,12 @@ namespace detail {
 
         // Remove gotos whose target label was never emitted (orphaned
         // by structuring rules that absorbed the target block).
-        {
-            std::unordered_set< clang::LabelDecl * > defined;
-            std::unordered_set< clang::Stmt * > seen2;
-            CollectDefinedLabels(fn->getBody(), defined, seen2);
-            body = RemoveOrphanedGotos(ctx, fn->getBody(), defined);
-            if (body) {
-                fn->setBody(body);
-            }
+        std::unordered_set< clang::LabelDecl * > defined;
+        std::unordered_set< clang::Stmt * > seen2;
+        CollectDefinedLabels(fn->getBody(), defined, seen2);
+        body = RemoveOrphanedGotos(ctx, fn->getBody(), defined);
+        if (body) {
+            fn->setBody(body);
         }
 
         // Final pass: remove empty CompoundStmts and NullStmts.

--- a/test/patchir-decomp/unimplemented_flags.json
+++ b/test/patchir-decomp/unimplemented_flags.json
@@ -1,8 +1,6 @@
 // RUN: bash %strip-json-comments %s > %t.json
 // RUN: not %patchir-decomp -input %t.json -emit-obj -output %t 2>&1 | %file-check -vv -check-prefix=OBJ %s
-// RUN: not %patchir-decomp -input %t.json -use-structuring-pass -output %t 2>&1 | %file-check -vv -check-prefix=STRUCT %s
 // OBJ: --emit-obj is not implemented
-// STRUCT: --use-structuring-pass is not implemented
 {
   "architecture": "ARM",
   "id": "ARM:LE:32:Cortex",

--- a/tools/patchir-decomp/main.cpp
+++ b/tools/patchir-decomp/main.cpp
@@ -87,7 +87,7 @@ namespace {
 
     const llvm::cl::opt< bool > use_structuring_pass( // NOLINT(cert-err58-cpp)
         "use-structuring-pass",
-        llvm::cl::desc("Enable the CfgFoldStructure structuring pass"),
+        llvm::cl::desc("Enable the CFGStructure structuring pass"),
         llvm::cl::init(false)
     );
 
@@ -125,11 +125,6 @@ namespace {
             return false;
         }
 
-        if (options.use_structuring_pass) {
-            LOG(ERROR) << "--use-structuring-pass is not implemented. The direct JSON -> CGraph "
-                          "path is the only supported structuring mode in this branch.\n";
-            return false;
-        }
 
         return true;
     }

--- a/tools/patchir-decomp/main.cpp
+++ b/tools/patchir-decomp/main.cpp
@@ -125,7 +125,6 @@ namespace {
             return false;
         }
 
-
         return true;
     }
 


### PR DESCRIPTION
Summary                                                                                                                                                      
                                     
  - Improved terminator detection in `ClangEmitter.cpp` and `ClangEmitterCleanup.cpp` to handle IfStmt where both branches end with a terminator (e.g., inlined stack-canary epilogues from `ConvertGotoToReturn`). The EndsWithTerminator and is_terminator lambdas now recurse into IfStmt/LabelStmt/CompoundStmt instead of only checking the last statement.                                                                                                                            
  - Added orphaned goto removal pass in `ClangEmitterCleanup.cpp `— collects all defined LabelDecls in the function body, then replaces GotoStmts targeting labels that were never emitted (absorbed by structuring rules) with NullStmt.                                                                                
  - Emitter robustness fixes in `ClangEmitter.cpp`:
    - EmitIfThenElse: handles degenerate null-condition case; unwraps single-IfStmt CompoundStmt in else branch so Clang prints else if instead of else { if.  
    - EmitWhile: handles null condition by emitting while(1).                                                                                                  
  - Refactored `ASTConsumer.cpp` goto-based emission path into a clearer root_snode flow, preparing the structure for a future `--use-structuring-pass` path. Switch target label resolution now uses assert on original_label instead of a fallback lambda.                                                               