### PR TITLE
decomp: option flags to disable rellic build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,9 @@ include_directories(SYSTEM "${PE_VENDOR_INSTALL_DIR}/include")
 find_package(Z3 4.8 CONFIG REQUIRED HINTS "${PE_VENDOR_INSTALL_DIR}")
 message(STATUS "Using Z3Config.cmake in ${Z3_DIR} and Z3 headers in ${PE_VENDOR_INSTALL_DIR}/include")
 
+find_package(gflags CONFIG REQUIRED HINTS "${PE_VENDOR_INSTALL_DIR}")
+find_package(glog CONFIG REQUIRED HINTS "${PE_VENDOR_INSTALL_DIR}")
+
 if(PE_USE_RELLIC)
   find_package(rellic REQUIRED HINTS "${PE_VENDOR_INSTALL_DIR}")
   message(STATUS "Using RellicConfig.cmake in: ${rellic_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,9 +118,14 @@ include_directories(SYSTEM "${PE_VENDOR_INSTALL_DIR}/include")
 find_package(Z3 4.8 CONFIG REQUIRED HINTS "${PE_VENDOR_INSTALL_DIR}")
 message(STATUS "Using Z3Config.cmake in ${Z3_DIR} and Z3 headers in ${PE_VENDOR_INSTALL_DIR}/include")
 
-find_package(rellic REQUIRED HINTS "${PE_VENDOR_INSTALL_DIR}")
-message(STATUS "Using RellicConfig.cmake in: ${rellic_DIR}")
-get_target_property(RELLIC_INCLUDE_DIRS rellic::rellic INTERFACE_INCLUDE_DIRECTORIES)
+if(PE_USE_RELLIC)
+  find_package(rellic REQUIRED HINTS "${PE_VENDOR_INSTALL_DIR}")
+  message(STATUS "Using RellicConfig.cmake in: ${rellic_DIR}")
+  get_target_property(RELLIC_INCLUDE_DIRS rellic::rellic INTERFACE_INCLUDE_DIRECTORIES)
+else()
+  set(RELLIC_INCLUDE_DIRS "")
+  message(STATUS "RELLIC disabled (PE_USE_RELLIC=OFF)")
+endif()
 
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 include_directories(SYSTEM ${MLIR_INCLUDE_DIRS})
@@ -175,6 +180,10 @@ target_include_directories(patchestry_settings INTERFACE
   $<BUILD_INTERFACE:${PATCHESTRY_BINARY_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
+
+if(PE_USE_RELLIC)
+  target_compile_definitions(patchestry_settings INTERFACE PATCHESTRY_ENABLE_RELLIC=1)
+endif()
 
 include(compiler_warnings)
 set_project_warnings(patchestry_settings)

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -23,4 +23,5 @@ option(PE_USE_VENDORED_Z3 "Set to OFF to disable default building of Z3 as a ven
 option(PE_USE_VENDORED_GLOG "Set to OFF to disable default building of Google glog as a vendored library." ON)
 option(PE_USE_VENDORED_GFLAGS "Set to OFF to disable default building of gflags as a vendored library." ON)
 option(PE_USE_VENDORED_CLANG "Set to OFF to disable default building of Clang/LLVM as a vendored library." OFF)
+option(PE_USE_RELLIC "Set to ON to build and link the vendored RELLIC decompiler library." OFF)
 option(PE_ENABLE_EXAMPLE_FIRMWARE_E2E "Enable the opt-in example firmware end-to-end validation target." OFF)

--- a/lib/patchestry/AST/ASTConsumer.cpp
+++ b/lib/patchestry/AST/ASTConsumer.cpp
@@ -30,6 +30,7 @@
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/raw_ostream.h>
 
+#ifdef PATCHESTRY_ENABLE_RELLIC
 #include "rellic/AST/LoopRefine.h"
 #include "rellic/AST/MaterializeConds.h"
 #include "rellic/AST/NestedCondProp.h"
@@ -42,6 +43,7 @@
 #include <rellic/AST/ExprCombine.h>
 #include <rellic/AST/LocalDeclRenamer.h>
 #include <rellic/AST/StructFieldRenamer.h>
+#endif
 
 #include <patchestry/AST/ASTConsumer.hpp>
 #include <patchestry/AST/CfgDotEmitter.hpp>

--- a/lib/patchestry/AST/CMakeLists.txt
+++ b/lib/patchestry/AST/CMakeLists.txt
@@ -31,7 +31,9 @@ target_link_libraries(patchestry_ast
     glog::glog
 )
 
-target_include_directories(patchestry_ast
-  PRIVATE
-    "$<BUILD_INTERFACE:${RELLIC_INCLUDE_DIRS}>"
-)
+if(PE_USE_RELLIC)
+  target_include_directories(patchestry_ast
+    PRIVATE
+      "$<BUILD_INTERFACE:${RELLIC_INCLUDE_DIRS}>"
+  )
+endif()

--- a/lib/patchestry/Codegen/CMakeLists.txt
+++ b/lib/patchestry/Codegen/CMakeLists.txt
@@ -22,12 +22,14 @@ target_link_libraries(patchestry_codegen
   PRIVATE
     LLVMSupport
     patchestry_settings
-    rellic::rellic
+    $<$<BOOL:${PE_USE_RELLIC}>:rellic::rellic>
     glog::glog
     ${CLANG_IR_LIBS}
 )
 
-target_include_directories(patchestry_codegen
-  PRIVATE
-    "$<BUILD_INTERFACE:${RELLIC_INCLUDE_DIRS}>"
-)
+if(PE_USE_RELLIC)
+  target_include_directories(patchestry_codegen
+    PRIVATE
+      "$<BUILD_INTERFACE:${RELLIC_INCLUDE_DIRS}>"
+  )
+endif()

--- a/lib/patchestry/Codegen/Codegen.cpp
+++ b/lib/patchestry/Codegen/Codegen.cpp
@@ -40,7 +40,9 @@
 #include <mlir/Target/LLVMIR/Export.h>
 
 #include <clang/CodeGen/ModuleBuilder.h>
+#ifdef PATCHESTRY_ENABLE_RELLIC
 #include <rellic/Decompiler.h>
+#endif
 
 #include <patchestry/AST/ASTConsumer.hpp>
 #include <patchestry/Codegen/Codegen.hpp>
@@ -80,6 +82,12 @@ namespace patchestry::codegen {
 
     void
     CodeGenerator::lower_to_ir(clang::ASTContext &actx, const patchestry::Options &options) {
+        // Check if diagnostic error is set. If yes, ignore it.
+        if (actx.getDiagnostics().hasErrorOccurred()) {
+            actx.getDiagnostics().Reset();
+        }
+
+#ifdef PATCHESTRY_ENABLE_RELLIC
         // NOTE: We use rellic to improve the generated AST. There are issues running rellic AST
         // passes directly on AST. Temporarily we lower the AST to llvm IR and regenerate AST
 
@@ -110,11 +118,6 @@ namespace patchestry::codegen {
             return results.TakeValue();
         };
 
-        // Check if diagnostic error is set. If yes, ignore it.
-        if (actx.getDiagnostics().hasErrorOccurred()) {
-            actx.getDiagnostics().Reset();
-        }
-
         if (options.use_rellic_transform) {
             auto results = transform_ast(actx);
             if (results && results->ast) {
@@ -124,6 +127,13 @@ namespace patchestry::codegen {
             LOG(WARNING
             ) << "Failed to transform AST using remill; Fallback to default generation";
         }
+#else
+        if (options.use_rellic_transform) {
+            LOG(WARNING
+            ) << "use_rellic_transform requested but RELLIC support was disabled at build "
+                 "time (PE_USE_RELLIC=OFF); using default generation";
+        }
+#endif
 
         emit_cir(actx, options);
     }

--- a/tools/patchir-decomp/CMakeLists.txt
+++ b/tools/patchir-decomp/CMakeLists.txt
@@ -20,7 +20,7 @@ target_link_libraries(patchir-decomp
         patchestry::ast
         patchestry::codegen
         patchestry::yaml
-        rellic::rellic
+        $<$<BOOL:${PE_USE_RELLIC}>:rellic::rellic>
         glog::glog
         clangFrontend
 )

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -26,4 +26,6 @@ if(PE_USE_VENDORED_CLANG)
     add_subdirectory(clangir)
 endif()
 
-add_subdirectory(rellic)  # Depends on glog and clangir (if vendored)
+if(PE_USE_RELLIC)
+    add_subdirectory(rellic)  # Depends on glog and clangir (if vendored)
+endif()


### PR DESCRIPTION
This pull request adds optional support for the Rellic decompiler library, enabling or disabling it at build time via a new `PE_USE_RELLIC` CMake option. The codebase and build scripts are updated to conditionally include RELLIC headers, libraries, and related code only when this option is enabled. This improves build flexibility and allows users to build the project without Rellic.