### PR TITLE
ci: add arm64 matrix to all CI jobs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -42,6 +42,12 @@ COPY ./install-clangir.sh /tmp/
 RUN chmod +x /tmp/install-clangir.sh && \
     /tmp/install-clangir.sh
 
+# Install non-native glibc headers for LIT cross-compile tests. No-op on amd64
+# hosts (which ship x86_64 headers natively and pull aarch64 from multiarch).
+COPY ./install-cross-headers.sh /tmp/
+RUN chmod +x /tmp/install-cross-headers.sh && \
+    /tmp/install-cross-headers.sh
+
 # Remove old versions of LLVM and Clang
 RUN apt-get -y purge llvm-14 clang-14
 

--- a/.devcontainer/install-cross-headers.sh
+++ b/.devcontainer/install-cross-headers.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Install glibc headers for the non-native target architecture so LIT tests
+# that cross-compile C sources via `clang -target <arch>-linux-gnu` can find
+# system headers like <stdio.h>.
+#
+# The LIT suite under test/ghidra/ compiles `%cc-x86_64` sources to produce
+# x86_64 object files for Ghidra to decompile; `extraout_sanitize.c` does the
+# same for aarch64. On arm64 hosts the x86_64 headers are missing; on amd64
+# hosts the base image already ships with both sides' multiarch headers.
+
+set -eu
+
+ARCH=$(dpkg --print-architecture)
+if [ "$ARCH" != "arm64" ]; then
+    echo "Host arch is '$ARCH'; no cross-arch headers needed."
+    exit 0
+fi
+
+# arm64 Ubuntu's sources.list points at ports.ubuntu.com, which does not serve
+# amd64 packages. Scope the existing entries to arm64 and add archive.ubuntu.com
+# for amd64.
+sed -i 's|^deb http|deb [arch=arm64] http|' /etc/apt/sources.list
+cat > /etc/apt/sources.list.d/amd64-cross.list <<'EOF'
+deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy main universe
+deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy-updates main universe
+deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy-security main universe
+EOF
+
+dpkg --add-architecture amd64
+apt-get update
+apt-get install -y --no-install-recommends libc6-dev-amd64-cross
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+
+# clang searches `/usr/include/<triple>/` by default, but the cross package
+# installs to `/usr/x86_64-linux-gnu/include/`. Symlink so clang finds the
+# bits/ subdirectory under its default multiarch path.
+ln -sf /usr/x86_64-linux-gnu/include /usr/include/x86_64-linux-gnu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,11 @@ jobs:
     strategy:
       matrix:
         image-version: [22.04]
-    runs-on: ubuntu-${{ matrix.image-version }}
-    timeout-minutes: 30
+        arch: [amd64, arm64]
+    runs-on: ${{ matrix.arch == 'arm64' && format('ubuntu-{0}-arm', matrix.image-version) || format('ubuntu-{0}', matrix.image-version) }}
+    # Ghidra-from-source build (gradle buildGhidra + IntegrationTest) dominates
+    # wall time; 60 min covers both arches with headroom.
+    timeout-minutes: 60
     env:
       CI: true
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,13 @@ jobs:
         image-version: [22.04]
         build-type: [Release, Debug]
         sanitizers: [OFF]
-    runs-on: ubuntu-${{ matrix.image-version }}
+        arch: [amd64, arm64]
+    runs-on: ${{ matrix.arch == 'arm64' && format('ubuntu-{0}-arm', matrix.image-version) || format('ubuntu-{0}', matrix.image-version) }}
     timeout-minutes: 30
     env:
-      DEV_IMAGE: ghcr.io/lifting-bits/patchestry-ubuntu-${{ matrix.image-version }}-llvm-${{ matrix.llvm-version }}-dev:latest
+      # amd64 uses the legacy `-dev:latest` tag; arm64 uses `-dev-arm64:latest`.
+      # See .github/workflows/devcontainer.yml for how these tags are produced.
+      DEV_IMAGE: ghcr.io/lifting-bits/patchestry-ubuntu-${{ matrix.image-version }}-llvm-${{ matrix.llvm-version }}-dev${{ matrix.arch == 'arm64' && '-arm64' || '' }}:latest
       CMAKE_PREFIX_PATH: "/usr/lib/llvm-${{ matrix.llvm-version }}/lib/cmake/mlir/;/usr/lib/llvm-${{ matrix.llvm-version }}/lib/cmake/clang/"
       LLVM_EXTERNAL_LIT: "/usr/local/bin/lit"
       ENABLE_SANITIZER_UNDEFINED_BEHAVIOR: ${{ matrix.sanitizers }}
@@ -169,7 +172,9 @@ jobs:
             lit ./builds/ci/test -D BUILD_TYPE=${{ matrix.build-type }} -v -DCI_OUTPUT_FOLDER=/workspace/builds/ci/test/ghidra/Output
 
       - name: Run KLEE on generated harnesses
-        if: matrix.build-type == 'Debug' && matrix.sanitizers == 'OFF'
+        # KLEE's POSIX runtime uses klee-uclibc, which is x86/x86_64-only.
+        # Skip on arm64; re-enable if the runtime is ever ported.
+        if: matrix.build-type == 'Debug' && matrix.sanitizers == 'OFF' && matrix.arch != 'arm64'
         continue-on-error: true
         env:
           KLEE_IMAGE: ghcr.io/lifting-bits/patchestry-klee-ubuntu-${{ matrix.image-version }}-llvm-${{ matrix.llvm-version }}:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,9 @@ jobs:
     runs-on: ${{ matrix.arch == 'arm64' && format('ubuntu-{0}-arm', matrix.image-version) || format('ubuntu-{0}', matrix.image-version) }}
     timeout-minutes: 30
     env:
-      # amd64 uses the legacy `-dev:latest` tag; arm64 uses `-dev-arm64:latest`.
-      # See .github/workflows/devcontainer.yml for how these tags are produced.
-      DEV_IMAGE: ghcr.io/lifting-bits/patchestry-ubuntu-${{ matrix.image-version }}-llvm-${{ matrix.llvm-version }}-dev${{ matrix.arch == 'arm64' && '-arm64' || '' }}:latest
+      # `-dev:latest` is a multi-arch manifest published by devcontainer.yml;
+      # Docker resolves the correct platform on pull.
+      DEV_IMAGE: ghcr.io/lifting-bits/patchestry-ubuntu-${{ matrix.image-version }}-llvm-${{ matrix.llvm-version }}-dev:latest
       CMAKE_PREFIX_PATH: "/usr/lib/llvm-${{ matrix.llvm-version }}/lib/cmake/mlir/;/usr/lib/llvm-${{ matrix.llvm-version }}/lib/cmake/clang/"
       LLVM_EXTERNAL_LIT: "/usr/local/bin/lit"
       ENABLE_SANITIZER_UNDEFINED_BEHAVIOR: ${{ matrix.sanitizers }}

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -15,14 +15,17 @@ jobs:
       matrix:
         llvm-version: [20]
         image-version: [22.04]
-    runs-on: ubuntu-22.04
+        arch: [amd64, arm64]
+    runs-on: ${{ matrix.arch == 'arm64' && format('ubuntu-{0}-arm', matrix.image-version) || format('ubuntu-{0}', matrix.image-version) }}
 
     permissions:
         packages: write
         contents: read
 
+    # amd64 publishes the legacy `-dev:latest` tag so existing references keep
+    # working. arm64 publishes alongside under `-dev-arm64:latest`.
     env:
-      IMAGE_NAME: "ghcr.io/lifting-bits/patchestry-ubuntu-${{ matrix.image-version }}-llvm-${{ matrix.llvm-version }}-dev:latest"
+      IMAGE_NAME: "ghcr.io/lifting-bits/patchestry-ubuntu-${{ matrix.image-version }}-llvm-${{ matrix.llvm-version }}-dev${{ matrix.arch == 'arm64' && '-arm64' || '' }}:latest"
 
     steps:
       - name: Cleanup working directory with container root

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -10,7 +10,9 @@ name: Build Dev Container
 on: workflow_dispatch
 
 jobs:
-  build:
+  # Builds the dev container once per arch on native runners and publishes
+  # per-arch tags (`-dev:amd64`, `-dev:arm64`).
+  build-per-arch:
     strategy:
       matrix:
         llvm-version: [20]
@@ -22,10 +24,8 @@ jobs:
         packages: write
         contents: read
 
-    # amd64 publishes the legacy `-dev:latest` tag so existing references keep
-    # working. arm64 publishes alongside under `-dev-arm64:latest`.
     env:
-      IMAGE_NAME: "ghcr.io/lifting-bits/patchestry-ubuntu-${{ matrix.image-version }}-llvm-${{ matrix.llvm-version }}-dev${{ matrix.arch == 'arm64' && '-arm64' || '' }}:latest"
+      ARCH_IMAGE: "ghcr.io/lifting-bits/patchestry-ubuntu-${{ matrix.image-version }}-llvm-${{ matrix.llvm-version }}-dev:${{ matrix.arch }}"
 
     steps:
       - name: Cleanup working directory with container root
@@ -42,10 +42,39 @@ jobs:
         working-directory: .devcontainer
         run: |
           docker pull ubuntu:${{ matrix.image-version }}
-          docker build . --no-cache -t "${IMAGE_NAME}" --build-arg="IMAGE=ubuntu-${{ matrix.image-version }}" --build-arg="LLVM_VERSION=${{ matrix.llvm-version }}"
+          docker build . --no-cache -t "${ARCH_IMAGE}" --build-arg="IMAGE=ubuntu-${{ matrix.image-version }}" --build-arg="LLVM_VERSION=${{ matrix.llvm-version }}"
 
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push image
-        run: docker push "${IMAGE_NAME}"
+        run: docker push "${ARCH_IMAGE}"
+
+  # Combines the per-arch tags into a multi-arch manifest under `-dev:latest`.
+  # Consumers (root Dockerfile, scripts/klee/Dockerfile, prerelease.yml, ci.yml)
+  # can keep referencing `-dev:latest` and Docker resolves the correct arch on
+  # pull.
+  merge-manifest:
+    needs: build-per-arch
+    strategy:
+      matrix:
+        llvm-version: [20]
+        image-version: [22.04]
+    runs-on: ubuntu-${{ matrix.image-version }}
+
+    permissions:
+      packages: write
+
+    env:
+      DEV_IMAGE_BASE: "ghcr.io/lifting-bits/patchestry-ubuntu-${{ matrix.image-version }}-llvm-${{ matrix.llvm-version }}-dev"
+
+    steps:
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Create and push multi-arch manifest
+        run: |
+          docker manifest create "${DEV_IMAGE_BASE}:latest" \
+            "${DEV_IMAGE_BASE}:amd64" \
+            "${DEV_IMAGE_BASE}:arm64"
+          docker manifest push "${DEV_IMAGE_BASE}:latest"

--- a/.github/workflows/klee-image.yml
+++ b/.github/workflows/klee-image.yml
@@ -7,6 +7,11 @@
 
 name: Build KLEE Image
 
+# KLEE's POSIX runtime depends on klee-uclibc, which supports x86/x86_64 only.
+# The image is therefore amd64-only; the CI `llvm-build-and-test` job gates
+# the KLEE test step off on arm64 runners. If klee-uclibc ever gains aarch64
+# support (or we migrate to a different runtime), add an arm64 matrix here.
+
 on:
   workflow_dispatch:
     inputs:

--- a/build.sh
+++ b/build.sh
@@ -23,7 +23,7 @@ docker build \
     "${script_dir}"
 
 echo "Building patchestry inside Docker container..."
-docker run --rm --platform linux/amd64 \
+docker run --rm \
     --memory="${DOCKER_MEMORY_GB}g" \
     --memory-swap="${DOCKER_MEMORY_GB}g" \
     --cpus="${DOCKER_CPUS}" \


### PR DESCRIPTION
Adds arm64 to CI so Patchestry builds and tests run on `ubuntu-22.04-arm` alongside amd64. Motivated by M-series dev parity — the dev container takes ~3-4× longer under emulation.

Patchestry itself is already arch-clean; no source, CMake, or tool changes. The diff is entirely in `.github/workflows/` plus:

- `.devcontainer/install-cross-headers.sh` (new) — installs x86_64 glibc headers on arm64 hosts so LIT tests can cross-compile to x86_64 for Ghidra to decompile
- `build.sh` — drops `--platform linux/amd64` so it runs natively on arm64 hosts

`-dev:latest` is now published as a multi-arch manifest list from `devcontainer.yml`. All consumers (`ci.yml`, root `Dockerfile`, `build.sh`, `scripts/klee/Dockerfile`, `prerelease.yml`) reference the tag unchanged — Docker resolves the correct platform on pull.

## Validation (local, native arm64)

| Stage | Result |
|---|---|
| Dev container build | ~46 min (LLVM+Clang+MLIR from source) |
| Patchestry source build | all 6 tools as aarch64 ELFs |
| \`build.sh\` end-to-end | all 6 tools as aarch64 ELFs |
| \`lit test/patchir-decomp\` | 68/68 |
| \`lit test/patchir-transform\` | 36/36 |
| \`lit test/ghidra\` (DinD + Ghidra headless) | 21/21 |
| Ghidra headless + firmware images | build clean |
| \`test/decompile-test\` image + JUnit (\`gradle build\`) | 45 passed / 0 failed / 61 skipped |

## Rollout

\`devcontainer.yml\` already dispatched and completed against this branch ([run 24738456295](https://github.com/lifting-bits/patchestry/actions/runs/24738456295)) — \`-dev:latest\` in GHCR is now a multi-arch manifest (verified via \`docker manifest inspect\`). Safe to merge; \`ci.yml\`'s first run will pull the correct arch automatically.

## Known gaps

- **KLEE stays amd64-only** — \`klee-uclibc\` has no aarch64 port; the test step is gated off on arm64.
- **\`prerelease.yml\` stays amd64-only** — arm64 release packaging can follow later.

## Test plan

- [x] \`devcontainer.yml\` publishes \`-dev:latest\` as multi-arch manifest
- [ ] PR merge triggers \`ci.yml\`; all non-KLEE steps pass on both arches
- [ ] KLEE step is visibly skipped on arm64 matrix entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)