### PR TITLE
ci: rename prerelease tag from latest to nightly

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Publish Pre-Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2.6.2
         with:
-          tag_name: "latest"
+          tag_name: "nightly"
           prerelease: true
           generate_release_notes: true
           files: |


### PR DESCRIPTION
`Publish Pre-Release` has failed on every run since 2024-08-09 (13+ consecutive) with:

```
(1) pre_receive Repository rule violations found
(2) tag_name was used by an immutable release
```

GitHub permanently reserves a tag name once used by an immutable release — deleting the release does not free it (verified today). Renaming to `nightly` sidesteps both errors.

No in-repo consumers reference the old `latest` download URL.