### PR TITLE
seahorn: add missing Dockerfile for building seahorn image

### DIFF
--- a/.github/workflows/seahorn-image.yml
+++ b/.github/workflows/seahorn-image.yml
@@ -1,0 +1,98 @@
+#
+# Copyright (c) 2024, Trail of Bits, Inc.
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+#
+
+name: Build SeaHorn Image
+
+# SeaHorn pulls prebuilt z3 and yices2 binaries that ship x86_64 only, so the
+# image is amd64-only. If/when arm64 builds of those dependencies are wired up,
+# add an arm64 matrix here.
+
+on:
+  workflow_dispatch:
+    inputs:
+      llvm-version:
+        description: 'LLVM version for the base image'
+        required: false
+        default: '20'
+      image-version:
+        description: 'Ubuntu version for the base image'
+        required: false
+        default: '22.04'
+      no-cache:
+        description: 'Build without Docker cache'
+        required: false
+        type: boolean
+        default: false
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    permissions:
+      packages: write
+      contents: read
+
+    env:
+      LLVM_VER: ${{ inputs.llvm-version || '20' }}
+      IMAGE_VER: ${{ inputs.image-version || '22.04' }}
+      NO_CACHE: ${{ inputs.no-cache || 'false' }}
+
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          docker system prune -af
+          df -h
+
+      - name: Clone the Patchestry repository
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+          fetch-depth: 1
+
+      - name: Set derived image names
+        run: |
+          echo "IMAGE_NAME=ghcr.io/lifting-bits/patchestry-seahorn-ubuntu-${IMAGE_VER}-llvm-${LLVM_VER}:latest" >> "$GITHUB_ENV"
+          echo "BASE_IMAGE=ghcr.io/lifting-bits/patchestry-ubuntu-${IMAGE_VER}-llvm-${LLVM_VER}-dev:latest" >> "$GITHUB_ENV"
+
+      - name: Pull base image
+        run: docker pull "${BASE_IMAGE}"
+
+      - name: Build SeaHorn image
+        working-directory: scripts/seahorn
+        run: |
+          CACHE_FLAG=""
+          if [ "${NO_CACHE}" = "true" ]; then
+            CACHE_FLAG="--no-cache"
+          fi
+          DOCKER_BUILDKIT=1 docker build \
+            --platform linux/amd64 \
+            ${CACHE_FLAG} \
+            --build-arg IMAGE_VERSION="${IMAGE_VER}" \
+            --build-arg LLVM_VERSION="${LLVM_VER}" \
+            -t "${IMAGE_NAME}" \
+            -f Dockerfile \
+            .
+
+      - name: Verify SeaHorn installation
+        run: |
+          docker run --rm --platform linux/amd64 --entrypoint sea "${IMAGE_NAME}" --help
+
+      - name: Log in to registry
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Push image
+        if: github.event_name == 'workflow_dispatch'
+        run: docker push "${IMAGE_NAME}"
+
+      - name: Print image details
+        run: |
+          echo "Image: ${IMAGE_NAME}"
+          docker images "${IMAGE_NAME}" --format "Size: {{.Size}}"

--- a/.github/workflows/seahorn-image.yml
+++ b/.github/workflows/seahorn-image.yml
@@ -99,15 +99,15 @@ jobs:
 
       - name: Solver-backed smoke test
         run: |
-          # Tiny SV-COMP-style program: the error branch is unreachable, so
-          # `sea pf` should report the program safe (unsat). This actually
-          # exercises the LLVM front-end, sea-dsa, crab, and z3 — proving the
-          # solver wiring isn't broken (which `sea --help` cannot).
+          # Use __VERIFIER_nondet_int so clang/seapp can't constant-fold the
+          # branch away; the assertion must survive to z3 for this to prove
+          # the solver wiring (LLVM front-end → sea-dsa → crab → z3) works.
           mkdir -p smoke && cat > smoke/safe.c <<'EOF'
+          extern int __VERIFIER_nondet_int(void);
           extern void __VERIFIER_error(void) __attribute__((__noreturn__));
           int main(void) {
-              int x = 0;
-              if (x != 0) __VERIFIER_error();
+              int x = __VERIFIER_nondet_int();
+              if (x > 10 && x < 5) __VERIFIER_error();
               return 0;
           }
           EOF
@@ -115,8 +115,12 @@ jobs:
               -v "${PWD}/smoke:/smoke:ro" \
               --entrypoint sea "${IMAGE_NAME}" pf /smoke/safe.c \
               | tee smoke.log
-          grep -q "BRUNCH_STAT Result TRUE" smoke.log \
-              || { echo "Solver smoke test did not report TRUE"; exit 1; }
+          if grep -q "no assertion was found" smoke.log; then
+              echo "Smoke test is vacuous: the frontend discharged the assertion before z3 ran." >&2
+              exit 1
+          fi
+          grep -qx "unsat" smoke.log \
+              || { echo "Solver smoke test did not report unsat"; exit 1; }
 
       - name: Log in to registry
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/seahorn-image.yml
+++ b/.github/workflows/seahorn-image.yml
@@ -84,6 +84,27 @@ jobs:
         run: |
           docker run --rm --platform linux/amd64 --entrypoint sea "${IMAGE_NAME}" --help
 
+      - name: Solver-backed smoke test
+        run: |
+          # Tiny SV-COMP-style program: the error branch is unreachable, so
+          # `sea pf` should report the program safe (unsat). This actually
+          # exercises the LLVM front-end, sea-dsa, crab, and z3 — proving the
+          # solver wiring isn't broken (which `sea --help` cannot).
+          mkdir -p smoke && cat > smoke/safe.c <<'EOF'
+          extern void __VERIFIER_error(void) __attribute__((__noreturn__));
+          int main(void) {
+              int x = 0;
+              if (x != 0) __VERIFIER_error();
+              return 0;
+          }
+          EOF
+          docker run --rm --platform linux/amd64 \
+              -v "${PWD}/smoke:/smoke:ro" \
+              --entrypoint sea "${IMAGE_NAME}" pf /smoke/safe.c \
+              | tee smoke.log
+          grep -q "BRUNCH_STAT Result TRUE" smoke.log \
+              || { echo "Solver smoke test did not report TRUE"; exit 1; }
+
       - name: Log in to registry
         if: github.event_name == 'workflow_dispatch'
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin

--- a/.github/workflows/seahorn-image.yml
+++ b/.github/workflows/seahorn-image.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024, Trail of Bits, Inc.
+# Copyright (c) 2026, Trail of Bits, Inc.
 #
 # This source code is licensed in accordance with the terms specified in
 # the LICENSE file found in the root directory of this source tree.

--- a/.github/workflows/seahorn-image.yml
+++ b/.github/workflows/seahorn-image.yml
@@ -7,10 +7,6 @@
 
 name: Build SeaHorn Image
 
-# SeaHorn pulls prebuilt z3 and yices2 binaries that ship x86_64 only, so the
-# image is amd64-only. If/when arm64 builds of those dependencies are wired up,
-# add an arm64 matrix here.
-
 on:
   workflow_dispatch:
     inputs:
@@ -27,19 +23,6 @@ on:
         required: false
         type: boolean
         default: false
-  # Trigger on pushes to the SeaHorn image dev branch so we can iterate
-  # without merging to main first. Paths-filtered to avoid burning a
-  # 1-2h image build on unrelated edits.
-  push:
-    branches:
-      - kumarak/seahorn_image
-    paths:
-      - 'scripts/seahorn/**'
-      - '.github/workflows/seahorn-image.yml'
-  pull_request:
-    paths:
-      - 'scripts/seahorn/**'
-      - '.github/workflows/seahorn-image.yml'
 
 permissions: read-all
 
@@ -99,13 +82,6 @@ jobs:
 
       - name: Solver-backed smoke test
         run: |
-          # __VERIFIER_assume is declared but has no visible body, so clang
-          # can't merge the assumption into later branches the way it folds
-          # `if (x > 10 && x < 5)`. The constraint only gets resolved by
-          # SeaHorn on the way to z3 — which is exactly what we want to
-          # exercise. The post-run guard rejects the vacuous "no assertion
-          # was found" case so a future optimizer change can't silently
-          # turn this back into a no-op.
           mkdir -p smoke && cat > smoke/safe.c <<'EOF'
           extern int __VERIFIER_nondet_int(void);
           extern void __VERIFIER_assume(int);

--- a/.github/workflows/seahorn-image.yml
+++ b/.github/workflows/seahorn-image.yml
@@ -27,6 +27,19 @@ on:
         required: false
         type: boolean
         default: false
+  # Trigger on pushes to the SeaHorn image dev branch so we can iterate
+  # without merging to main first. Paths-filtered to avoid burning a
+  # 1-2h image build on unrelated edits.
+  push:
+    branches:
+      - kumarak/seahorn_image
+    paths:
+      - 'scripts/seahorn/**'
+      - '.github/workflows/seahorn-image.yml'
+  pull_request:
+    paths:
+      - 'scripts/seahorn/**'
+      - '.github/workflows/seahorn-image.yml'
 
 permissions: read-all
 

--- a/.github/workflows/seahorn-image.yml
+++ b/.github/workflows/seahorn-image.yml
@@ -99,15 +99,22 @@ jobs:
 
       - name: Solver-backed smoke test
         run: |
-          # Use __VERIFIER_nondet_int so clang/seapp can't constant-fold the
-          # branch away; the assertion must survive to z3 for this to prove
-          # the solver wiring (LLVM front-end → sea-dsa → crab → z3) works.
+          # __VERIFIER_assume is declared but has no visible body, so clang
+          # can't merge the assumption into later branches the way it folds
+          # `if (x > 10 && x < 5)`. The constraint only gets resolved by
+          # SeaHorn on the way to z3 — which is exactly what we want to
+          # exercise. The post-run guard rejects the vacuous "no assertion
+          # was found" case so a future optimizer change can't silently
+          # turn this back into a no-op.
           mkdir -p smoke && cat > smoke/safe.c <<'EOF'
           extern int __VERIFIER_nondet_int(void);
+          extern void __VERIFIER_assume(int);
           extern void __VERIFIER_error(void) __attribute__((__noreturn__));
           int main(void) {
-              int x = __VERIFIER_nondet_int();
-              if (x > 10 && x < 5) __VERIFIER_error();
+              int a = __VERIFIER_nondet_int();
+              int b = __VERIFIER_nondet_int();
+              __VERIFIER_assume(a == b);
+              if (a != b) __VERIFIER_error();
               return 0;
           }
           EOF

--- a/scripts/seahorn/Dockerfile
+++ b/scripts/seahorn/Dockerfile
@@ -10,9 +10,9 @@
 ARG IMAGE_VERSION=22.04
 ARG LLVM_VERSION=20
 ARG SEAHORN_REPO=https://github.com/trail-of-forks/seahorn.git
-ARG SEAHORN_BRANCH=dev20
 # Commit pin for trail-of-forks/seahorn dev20. Bump intentionally; the
 # branch tip is mutable, so the pin is what makes the image reproducible.
+# Accepts any git-resolvable ref (commit SHA, branch, or tag).
 ARG SEAHORN_REF=0f5ad78bc6a9d0ed5340b1ed19996151b27f54cf
 ARG BUILD_TYPE=RelWithDebInfo
 
@@ -28,7 +28,6 @@ FROM ghcr.io/lifting-bits/patchestry-ubuntu-${IMAGE_VERSION}-llvm-${LLVM_VERSION
 
 ARG LLVM_VERSION
 ARG SEAHORN_REPO
-ARG SEAHORN_BRANCH
 ARG SEAHORN_REF
 ARG BUILD_TYPE
 ARG Z3_SHA256
@@ -67,9 +66,9 @@ RUN curl -sSOL https://yices.csl.sri.com/releases/2.6.1/yices-2.6.1-x86_64-pc-li
     && cd yices-2.6.1 && ./install-yices /opt/yices-2.6.1 \
     && cd /tmp && rm -rf yices-2.6.1 yices-2.6.1-x86_64-pc-linux-gnu-static-gmp.tar.gz
 
-# Clone SeaHorn and check out the pinned commit. Branch is used to seed
-# the clone; SEAHORN_REF is what we actually build, so retagging dev20
-# upstream cannot silently change the published image.
+# Clone SeaHorn and check out the pinned ref. SEAHORN_REF is what we
+# actually build, so retagging dev20 upstream cannot silently change the
+# published image. Accepts a SHA, branch, or tag.
 WORKDIR /seahorn
 RUN git clone "${SEAHORN_REPO}" /seahorn/src \
     && cd /seahorn/src \

--- a/scripts/seahorn/Dockerfile
+++ b/scripts/seahorn/Dockerfile
@@ -1,0 +1,99 @@
+# Build SeaHorn on top of the patchestry LLVM-20 dev image.
+#
+#   docker build -t seahorn:dev20 -f analysis/seahorn/Dockerfile .
+#
+# The base image already provides LLVM 20, Clang 20, lld, CMake and Ninja.
+# This Dockerfile layers SeaHorn's extra runtime/build dependencies (z3,
+# yices2, boost, gmp/mpfr, graphviz) and compiles SeaHorn from
+# trail-of-forks/seahorn (dev20 branch) using the in-tree LLVM toolchain.
+
+ARG IMAGE_VERSION=22.04
+ARG LLVM_VERSION=20
+ARG SEAHORN_REPO=https://github.com/trail-of-forks/seahorn.git
+ARG SEAHORN_BRANCH=dev20
+ARG BUILD_TYPE=RelWithDebInfo
+
+############################################################
+# Stage 1: builder
+############################################################
+FROM ghcr.io/lifting-bits/patchestry-ubuntu-${IMAGE_VERSION}-llvm-${LLVM_VERSION}-dev:latest AS builder
+
+ARG LLVM_VERSION
+ARG SEAHORN_REPO
+ARG SEAHORN_BRANCH
+ARG BUILD_TYPE
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV LLVM_VERSION=${LLVM_VERSION}
+
+# SeaHorn build/runtime deps not guaranteed to be in the base image.
+RUN apt-get update && apt-get install -yqq --no-install-recommends \
+        ca-certificates curl wget unzip git \
+        zlib1g-dev libzstd-dev \
+        libgmp-dev libmpfr-dev \
+        libboost1.74-dev \
+        libgraphviz-dev graphviz python3-pygraphviz \
+        python3 python3-pip \
+        lcov gcovr rsync sudo \
+    && if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
+         apt-get install -yqq --no-install-recommends gcc-multilib; \
+       fi \
+    && pip3 install --no-cache-dir lit OutputCheck networkx \
+    && rm -rf /var/lib/apt/lists/*
+
+# Z3 4.8.9 (matches seahorn dev20 expectations).
+WORKDIR /tmp
+RUN wget -q https://github.com/Z3Prover/z3/releases/download/z3-4.8.9/z3-4.8.9-x64-ubuntu-16.04.zip \
+    && unzip -q z3-4.8.9-x64-ubuntu-16.04.zip \
+    && mv z3-4.8.9-x64-ubuntu-16.04 /opt/z3-4.8.9 \
+    && rm z3-4.8.9-x64-ubuntu-16.04.zip
+
+# Yices2 2.6.1.
+RUN curl -sSOL https://yices.csl.sri.com/releases/2.6.1/yices-2.6.1-x86_64-pc-linux-gnu-static-gmp.tar.gz \
+    && tar xf yices-2.6.1-x86_64-pc-linux-gnu-static-gmp.tar.gz \
+    && cd yices-2.6.1 && ./install-yices /opt/yices-2.6.1 \
+    && cd /tmp && rm -rf yices-2.6.1 yices-2.6.1-x86_64-pc-linux-gnu-static-gmp.tar.gz
+
+# Clone and build SeaHorn.
+WORKDIR /seahorn
+RUN git clone --depth 1 --branch "${SEAHORN_BRANCH}" "${SEAHORN_REPO}" /seahorn/src
+WORKDIR /seahorn/src/build
+RUN cmake .. -GNinja \
+        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+        -DZ3_ROOT=/opt/z3-4.8.9 \
+        -DYICES2_HOME=/opt/yices-2.6.1 \
+        -DCMAKE_INSTALL_PREFIX=/opt/seahorn \
+        -DCMAKE_C_COMPILER=/usr/local/bin/clang \
+        -DCMAKE_CXX_COMPILER=/usr/local/bin/clang++ \
+        -DSEA_ENABLE_LLD=ON \
+        -DLLVM_DIR=/usr/local/lib/cmake/llvm \
+        -DCPACK_GENERATOR=TGZ \
+        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+    && cmake --build . --target extra  && cmake .. \
+    && cmake --build . --target crab   && cmake .. \
+    && cmake --build . --target install
+
+############################################################
+# Stage 2: runtime
+############################################################
+FROM ghcr.io/lifting-bits/patchestry-ubuntu-${IMAGE_VERSION}-llvm-${LLVM_VERSION}-dev:latest
+
+ARG LLVM_VERSION
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV LLVM_VERSION=${LLVM_VERSION} \
+    PATH=/opt/seahorn/bin:${PATH}
+
+RUN apt-get update && apt-get install -yqq --no-install-recommends \
+        libgmp10 libmpfr6 libboost1.74-dev \
+        libgraphviz-dev graphviz \
+        python3 python3-pip \
+    && pip3 install --no-cache-dir networkx \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /opt/z3-4.8.9   /opt/z3-4.8.9
+COPY --from=builder /opt/yices-2.6.1 /opt/yices-2.6.1
+COPY --from=builder /opt/seahorn    /opt/seahorn
+
+WORKDIR /workspace
+CMD ["/bin/bash"]

--- a/scripts/seahorn/Dockerfile
+++ b/scripts/seahorn/Dockerfile
@@ -11,7 +11,15 @@ ARG IMAGE_VERSION=22.04
 ARG LLVM_VERSION=20
 ARG SEAHORN_REPO=https://github.com/trail-of-forks/seahorn.git
 ARG SEAHORN_BRANCH=dev20
+# Commit pin for trail-of-forks/seahorn dev20. Bump intentionally; the
+# branch tip is mutable, so the pin is what makes the image reproducible.
+ARG SEAHORN_REF=0f5ad78bc6a9d0ed5340b1ed19996151b27f54cf
 ARG BUILD_TYPE=RelWithDebInfo
+
+# SHA256s of the prebuilt solver archives. Pinned so a swapped upstream
+# artifact fails the build instead of being silently published.
+ARG Z3_SHA256=42f1644d79596718bf56944365900df8ef261c3150dddbb7687b5d3797d55c2d
+ARG YICES_SHA256=d75b70473b8178d4f19bc760d6d0f92284709482a4b8f26dd426adf65f22b081
 
 ############################################################
 # Stage 1: builder
@@ -21,7 +29,10 @@ FROM ghcr.io/lifting-bits/patchestry-ubuntu-${IMAGE_VERSION}-llvm-${LLVM_VERSION
 ARG LLVM_VERSION
 ARG SEAHORN_REPO
 ARG SEAHORN_BRANCH
+ARG SEAHORN_REF
 ARG BUILD_TYPE
+ARG Z3_SHA256
+ARG YICES_SHA256
 ARG DEBIAN_FRONTEND=noninteractive
 
 ENV LLVM_VERSION=${LLVM_VERSION}
@@ -41,22 +52,28 @@ RUN apt-get update && apt-get install -yqq --no-install-recommends \
     && pip3 install --no-cache-dir lit OutputCheck networkx \
     && rm -rf /var/lib/apt/lists/*
 
-# Z3 4.8.9 (matches seahorn dev20 expectations).
+# Z3 4.8.9 (matches seahorn dev20 expectations). Verified against pinned SHA256.
 WORKDIR /tmp
 RUN wget -q https://github.com/Z3Prover/z3/releases/download/z3-4.8.9/z3-4.8.9-x64-ubuntu-16.04.zip \
+    && echo "${Z3_SHA256}  z3-4.8.9-x64-ubuntu-16.04.zip" | sha256sum -c - \
     && unzip -q z3-4.8.9-x64-ubuntu-16.04.zip \
     && mv z3-4.8.9-x64-ubuntu-16.04 /opt/z3-4.8.9 \
     && rm z3-4.8.9-x64-ubuntu-16.04.zip
 
-# Yices2 2.6.1.
+# Yices2 2.6.1. Verified against pinned SHA256.
 RUN curl -sSOL https://yices.csl.sri.com/releases/2.6.1/yices-2.6.1-x86_64-pc-linux-gnu-static-gmp.tar.gz \
+    && echo "${YICES_SHA256}  yices-2.6.1-x86_64-pc-linux-gnu-static-gmp.tar.gz" | sha256sum -c - \
     && tar xf yices-2.6.1-x86_64-pc-linux-gnu-static-gmp.tar.gz \
     && cd yices-2.6.1 && ./install-yices /opt/yices-2.6.1 \
     && cd /tmp && rm -rf yices-2.6.1 yices-2.6.1-x86_64-pc-linux-gnu-static-gmp.tar.gz
 
-# Clone and build SeaHorn.
+# Clone SeaHorn and check out the pinned commit. Branch is used to seed
+# the clone; SEAHORN_REF is what we actually build, so retagging dev20
+# upstream cannot silently change the published image.
 WORKDIR /seahorn
-RUN git clone --depth 1 --branch "${SEAHORN_BRANCH}" "${SEAHORN_REPO}" /seahorn/src
+RUN git clone "${SEAHORN_REPO}" /seahorn/src \
+    && cd /seahorn/src \
+    && git checkout "${SEAHORN_REF}"
 WORKDIR /seahorn/src/build
 RUN cmake .. -GNinja \
         -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \

--- a/scripts/seahorn/build_seahorn_docker_image.sh
+++ b/scripts/seahorn/build_seahorn_docker_image.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# Build the SeaHorn Docker image from scripts/seahorn/Dockerfile.
+#
+# The Dockerfile layers SeaHorn on top of the patchestry LLVM-20 dev image
+# and clones/builds SeaHorn internally, so this script only needs to invoke
+# `docker build` with the right build args and tags.
+#
+
+set -euo pipefail
+
+# Defaults match scripts/seahorn/Dockerfile and .github/workflows/seahorn-image.yml.
+LLVM_VERSION="${LLVM_VERSION:-20}"
+IMAGE_VERSION="${IMAGE_VERSION:-22.04}"
+SEAHORN_REPO="${SEAHORN_REPO:-https://github.com/trail-of-forks/seahorn.git}"
+SEAHORN_BRANCH="${SEAHORN_BRANCH:-dev20}"
+BUILD_TYPE="${BUILD_TYPE:-RelWithDebInfo}"
+NO_CACHE="${NO_CACHE:-false}"
+
+IMAGE_NAME="${IMAGE_NAME:-ghcr.io/lifting-bits/patchestry-seahorn-ubuntu-${IMAGE_VERSION}-llvm-${LLVM_VERSION}}"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+BASE_IMAGE="ghcr.io/lifting-bits/patchestry-ubuntu-${IMAGE_VERSION}-llvm-${LLVM_VERSION}-dev:latest"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [--no-cache] [--pull-base] [--help]
+
+Environment overrides:
+  LLVM_VERSION     LLVM version for the base image (default: ${LLVM_VERSION})
+  IMAGE_VERSION    Ubuntu version for the base image (default: ${IMAGE_VERSION})
+  SEAHORN_REPO     SeaHorn git repo URL (default: ${SEAHORN_REPO})
+  SEAHORN_BRANCH   SeaHorn branch (default: ${SEAHORN_BRANCH})
+  BUILD_TYPE       CMake build type (default: ${BUILD_TYPE})
+  IMAGE_NAME       Output image name (default: ${IMAGE_NAME})
+  IMAGE_TAG        Output image tag (default: ${IMAGE_TAG})
+EOF
+}
+
+PULL_BASE=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --no-cache) NO_CACHE=true ;;
+        --pull-base) PULL_BASE=true ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Error: unknown argument: $1" >&2; usage; exit 1 ;;
+    esac
+    shift
+done
+
+ARCH="$(uname -m)"
+if [[ "${ARCH}" != "x86_64" ]]; then
+    echo "Error: SeaHorn ships x86_64-only z3/yices2 binaries; build is amd64-only." >&2
+    echo "Current architecture: ${ARCH}" >&2
+    exit 1
+fi
+
+if ! command -v docker &> /dev/null; then
+    echo "Error: docker is not installed or not in PATH" >&2
+    exit 1
+fi
+if ! docker info &> /dev/null; then
+    echo "Error: Docker daemon is not running" >&2
+    exit 1
+fi
+
+echo "=== SeaHorn Docker build ==="
+echo "  Base image:    ${BASE_IMAGE}"
+echo "  Output image:  ${IMAGE_NAME}:${IMAGE_TAG}"
+echo "  SeaHorn:       ${SEAHORN_REPO} @ ${SEAHORN_BRANCH}"
+echo "  Build type:    ${BUILD_TYPE}"
+echo "  No cache:      ${NO_CACHE}"
+echo ""
+
+if [[ "${PULL_BASE}" == "true" ]]; then
+    echo "Pulling base image ${BASE_IMAGE}..."
+    docker pull --platform linux/amd64 "${BASE_IMAGE}"
+fi
+
+CACHE_FLAG=()
+if [[ "${NO_CACHE}" == "true" ]]; then
+    CACHE_FLAG=(--no-cache)
+fi
+
+DOCKER_BUILDKIT=1 docker build \
+    --platform linux/amd64 \
+    "${CACHE_FLAG[@]}" \
+    --build-arg IMAGE_VERSION="${IMAGE_VERSION}" \
+    --build-arg LLVM_VERSION="${LLVM_VERSION}" \
+    --build-arg SEAHORN_REPO="${SEAHORN_REPO}" \
+    --build-arg SEAHORN_BRANCH="${SEAHORN_BRANCH}" \
+    --build-arg BUILD_TYPE="${BUILD_TYPE}" \
+    -t "${IMAGE_NAME}:${IMAGE_TAG}" \
+    -f "${SCRIPT_DIR}/Dockerfile" \
+    "${SCRIPT_DIR}"
+
+echo ""
+echo "=== Build complete: ${IMAGE_NAME}:${IMAGE_TAG} ==="
+docker images "${IMAGE_NAME}" --format "table {{.Repository}}\t{{.Tag}}\t{{.Size}}\t{{.CreatedAt}}"
+
+echo ""
+echo "Verify SeaHorn:"
+echo "  docker run --rm --platform linux/amd64 --entrypoint sea ${IMAGE_NAME}:${IMAGE_TAG} --help"

--- a/scripts/seahorn/build_seahorn_docker_image.sh
+++ b/scripts/seahorn/build_seahorn_docker_image.sh
@@ -14,6 +14,7 @@ LLVM_VERSION="${LLVM_VERSION:-20}"
 IMAGE_VERSION="${IMAGE_VERSION:-22.04}"
 SEAHORN_REPO="${SEAHORN_REPO:-https://github.com/trail-of-forks/seahorn.git}"
 SEAHORN_BRANCH="${SEAHORN_BRANCH:-dev20}"
+SEAHORN_REF="${SEAHORN_REF:-}"
 BUILD_TYPE="${BUILD_TYPE:-RelWithDebInfo}"
 NO_CACHE="${NO_CACHE:-false}"
 
@@ -32,6 +33,7 @@ Environment overrides:
   IMAGE_VERSION    Ubuntu version for the base image (default: ${IMAGE_VERSION})
   SEAHORN_REPO     SeaHorn git repo URL (default: ${SEAHORN_REPO})
   SEAHORN_BRANCH   SeaHorn branch (default: ${SEAHORN_BRANCH})
+  SEAHORN_REF      SeaHorn commit SHA to check out (default: Dockerfile pin)
   BUILD_TYPE       CMake build type (default: ${BUILD_TYPE})
   IMAGE_NAME       Output image name (default: ${IMAGE_NAME})
   IMAGE_TAG        Output image tag (default: ${IMAGE_TAG})
@@ -68,7 +70,7 @@ fi
 echo "=== SeaHorn Docker build ==="
 echo "  Base image:    ${BASE_IMAGE}"
 echo "  Output image:  ${IMAGE_NAME}:${IMAGE_TAG}"
-echo "  SeaHorn:       ${SEAHORN_REPO} @ ${SEAHORN_BRANCH}"
+echo "  SeaHorn:       ${SEAHORN_REPO} @ ${SEAHORN_BRANCH}${SEAHORN_REF:+ (ref: ${SEAHORN_REF})}"
 echo "  Build type:    ${BUILD_TYPE}"
 echo "  No cache:      ${NO_CACHE}"
 echo ""
@@ -83,6 +85,11 @@ if [[ "${NO_CACHE}" == "true" ]]; then
     CACHE_FLAG=(--no-cache)
 fi
 
+REF_ARG=()
+if [[ -n "${SEAHORN_REF}" ]]; then
+    REF_ARG=(--build-arg SEAHORN_REF="${SEAHORN_REF}")
+fi
+
 DOCKER_BUILDKIT=1 docker build \
     --platform linux/amd64 \
     "${CACHE_FLAG[@]}" \
@@ -90,6 +97,7 @@ DOCKER_BUILDKIT=1 docker build \
     --build-arg LLVM_VERSION="${LLVM_VERSION}" \
     --build-arg SEAHORN_REPO="${SEAHORN_REPO}" \
     --build-arg SEAHORN_BRANCH="${SEAHORN_BRANCH}" \
+    "${REF_ARG[@]}" \
     --build-arg BUILD_TYPE="${BUILD_TYPE}" \
     -t "${IMAGE_NAME}:${IMAGE_TAG}" \
     -f "${SCRIPT_DIR}/Dockerfile" \

--- a/scripts/seahorn/build_seahorn_docker_image.sh
+++ b/scripts/seahorn/build_seahorn_docker_image.sh
@@ -13,7 +13,6 @@ set -euo pipefail
 LLVM_VERSION="${LLVM_VERSION:-20}"
 IMAGE_VERSION="${IMAGE_VERSION:-22.04}"
 SEAHORN_REPO="${SEAHORN_REPO:-https://github.com/trail-of-forks/seahorn.git}"
-SEAHORN_BRANCH="${SEAHORN_BRANCH:-dev20}"
 SEAHORN_REF="${SEAHORN_REF:-}"
 BUILD_TYPE="${BUILD_TYPE:-RelWithDebInfo}"
 NO_CACHE="${NO_CACHE:-false}"
@@ -32,8 +31,7 @@ Environment overrides:
   LLVM_VERSION     LLVM version for the base image (default: ${LLVM_VERSION})
   IMAGE_VERSION    Ubuntu version for the base image (default: ${IMAGE_VERSION})
   SEAHORN_REPO     SeaHorn git repo URL (default: ${SEAHORN_REPO})
-  SEAHORN_BRANCH   SeaHorn branch (default: ${SEAHORN_BRANCH})
-  SEAHORN_REF      SeaHorn commit SHA to check out (default: Dockerfile pin)
+  SEAHORN_REF      Git ref (SHA, branch, or tag) to check out (default: Dockerfile pin)
   BUILD_TYPE       CMake build type (default: ${BUILD_TYPE})
   IMAGE_NAME       Output image name (default: ${IMAGE_NAME})
   IMAGE_TAG        Output image tag (default: ${IMAGE_TAG})
@@ -70,7 +68,7 @@ fi
 echo "=== SeaHorn Docker build ==="
 echo "  Base image:    ${BASE_IMAGE}"
 echo "  Output image:  ${IMAGE_NAME}:${IMAGE_TAG}"
-echo "  SeaHorn:       ${SEAHORN_REPO} @ ${SEAHORN_BRANCH}${SEAHORN_REF:+ (ref: ${SEAHORN_REF})}"
+echo "  SeaHorn:       ${SEAHORN_REPO}${SEAHORN_REF:+ @ ${SEAHORN_REF}}"
 echo "  Build type:    ${BUILD_TYPE}"
 echo "  No cache:      ${NO_CACHE}"
 echo ""
@@ -96,7 +94,6 @@ DOCKER_BUILDKIT=1 docker build \
     --build-arg IMAGE_VERSION="${IMAGE_VERSION}" \
     --build-arg LLVM_VERSION="${LLVM_VERSION}" \
     --build-arg SEAHORN_REPO="${SEAHORN_REPO}" \
-    --build-arg SEAHORN_BRANCH="${SEAHORN_BRANCH}" \
     "${REF_ARG[@]}" \
     --build-arg BUILD_TYPE="${BUILD_TYPE}" \
     -t "${IMAGE_NAME}:${IMAGE_TAG}" \


### PR DESCRIPTION
Adds a CI-friendly Docker workflow to build and publish a SeaHorn image on LLVM 20. Includes a reusable GitHub Actions workflow, a multi-stage Dockerfile (builder + minimal runtime), and a local build script for consistent, parameterized builds.