### PR TITLE
decomp: valid source location on CIR lowering for operation not mapped to pcode

### DIFF
--- a/include/patchestry/AST/Utils.hpp
+++ b/include/patchestry/AST/Utils.hpp
@@ -45,8 +45,11 @@ namespace patchestry::ast {
     
     clang::SourceLocation SourceLocation(clang::SourceManager &sm, std::string key);
 
-    /// Returns a single cached valid SourceLocation backed by a virtual
-    /// "<patchestry-virtual>" buffer in the given context's SourceManager.
+    /// Returns a valid SourceLocation backed by a virtual "<patchestry-virtual>"
+    /// buffer in the given context's SourceManager.  Idempotent: subsequent
+    /// calls with the same SourceManager reuse the same FileID via
+    /// FileManager::getVirtualFileRef + SourceManager::translateFile, so the
+    /// SM owns the location's lifetime and there is no cross-SM aliasing.
     /// Use this anywhere a default-constructed clang::SourceLocation() would
     /// otherwise be passed to an AST node constructor — CIRGen asserts every
     /// location is valid, and synthetic locations satisfy that invariant

--- a/include/patchestry/AST/Utils.hpp
+++ b/include/patchestry/AST/Utils.hpp
@@ -45,6 +45,14 @@ namespace patchestry::ast {
     
     clang::SourceLocation SourceLocation(clang::SourceManager &sm, std::string key);
 
+    /// Returns a single cached valid SourceLocation backed by a virtual
+    /// "<patchestry-virtual>" buffer in the given context's SourceManager.
+    /// Use this anywhere a default-constructed clang::SourceLocation() would
+    /// otherwise be passed to an AST node constructor — CIRGen asserts every
+    /// location is valid, and synthetic locations satisfy that invariant
+    /// without claiming any real source mapping.
+    clang::SourceLocation VirtualLoc(clang::ASTContext &ctx);
+
     clang::QualType
     GetTypeFromSize(clang::ASTContext &ctx, unsigned bit_size, bool is_signed, bool is_integer);
 

--- a/lib/patchestry/AST/ASTConsumer.cpp
+++ b/lib/patchestry/AST/ASTConsumer.cpp
@@ -250,7 +250,7 @@ namespace patchestry::ast {
                                         llvm::APInt(case_width,
                                                     static_cast<uint64_t>(sc.value),
                                                     true),
-                                        case_type, clang::SourceLocation());
+                                        case_type, VirtualLoc(ctx));
                                     SNode *body = nullptr;
                                     if (sc.succ_index < node.succs.size()) {
                                         auto &tn = flow_graph.Node(
@@ -353,6 +353,7 @@ namespace patchestry::ast {
                 &ctx.Idents.get(sanitized_name), var_type,
                 ctx.getTrivialTypeSourceInfo(var_type), clang::SC_Extern
             );
+            var_decl->setIsUsed();
             var_decl->setDeclContext(ctx.getTranslationUnitDecl());
             ctx.getTranslationUnitDecl()->addDecl(var_decl);
             global_variable_declarations.emplace(variable.key, var_decl);

--- a/lib/patchestry/AST/CFGStructure.cpp
+++ b/lib/patchestry/AST/CFGStructure.cpp
@@ -914,7 +914,7 @@ namespace patchestry::ast {
                         EnsureRValue(ctx_, outer_cond),
                         EnsureRValue(ctx_, inner_cond),
                         clang::BO_LOr, ctx_.BoolTy, clang::VK_PRValue,
-                        clang::OK_Ordinary, clang::SourceLocation(),
+                        clang::OK_Ordinary, VirtualLoc(ctx_),
                         clang::FPOptionsOverride());
 
                     auto *if_goto = factory_.Make<SIfThenElse>(
@@ -944,7 +944,7 @@ namespace patchestry::ast {
                         EnsureRValue(ctx_, outer_cond),
                         EnsureRValue(ctx_, inner_cond),
                         clang::BO_LAnd, ctx_.BoolTy, clang::VK_PRValue,
-                        clang::OK_Ordinary, clang::SourceLocation(),
+                        clang::OK_Ordinary, VirtualLoc(ctx_),
                         clang::FPOptionsOverride());
 
                     auto *if_goto = factory_.Make<SIfThenElse>(
@@ -1020,7 +1020,7 @@ namespace patchestry::ast {
                         EnsureRValue(ctx_, outer_cond),
                         EnsureRValue(ctx_, inner_cond),
                         clang::BO_LOr, ctx_.BoolTy, clang::VK_PRValue,
-                        clang::OK_Ordinary, clang::SourceLocation(),
+                        clang::OK_Ordinary, VirtualLoc(ctx_),
                         clang::FPOptionsOverride());
 
                     auto *if_goto = factory_.Make<SIfThenElse>(
@@ -1049,7 +1049,7 @@ namespace patchestry::ast {
                         EnsureRValue(ctx_, outer_cond),
                         EnsureRValue(ctx_, inner_cond),
                         clang::BO_LAnd, ctx_.BoolTy, clang::VK_PRValue,
-                        clang::OK_Ordinary, clang::SourceLocation(),
+                        clang::OK_Ordinary, VirtualLoc(ctx_),
                         clang::FPOptionsOverride());
 
                     auto *if_goto = factory_.Make<SIfThenElse>(
@@ -2055,7 +2055,7 @@ namespace patchestry::ast {
                     auto *val = clang::IntegerLiteral::Create(
                         ctx_,
                         llvm::APInt(case_width, static_cast<uint64_t>(sc.value), true),
-                        case_type, clang::SourceLocation());
+                        case_type, VirtualLoc(ctx_));
                     sw->AddCase(val, case_body);
                 }
                 continue;
@@ -2230,7 +2230,7 @@ namespace patchestry::ast {
                 auto *val = clang::IntegerLiteral::Create(
                     ctx_,
                     llvm::APInt(case_width, static_cast<uint64_t>(sc.value), true),
-                    case_type, clang::SourceLocation());
+                    case_type, VirtualLoc(ctx_));
                 sw->AddCase(val, case_body);
             }
         }
@@ -4007,8 +4007,7 @@ namespace patchestry::ast {
 
         /// Build a clang::ReturnStmt from an SReturn.
         clang::ReturnStmt *MakeReturn(clang::ASTContext &ctx, SReturn *sr) {
-            auto loc = clang::SourceLocation();
-            return clang::ReturnStmt::Create(ctx, loc, sr->Value(), nullptr);
+            return clang::ReturnStmt::Create(ctx, VirtualLoc(ctx), sr->Value(), nullptr);
         }
 
         /// Try to flatten a terminating SNode body into clang::Stmts.
@@ -4081,7 +4080,7 @@ namespace patchestry::ast {
                     if (then_stmts.size() == 1)
                         then_body = then_stmts[0];
                     else {
-                        auto loc = clang::SourceLocation();
+                        auto loc = VirtualLoc(ctx);
                         then_body = clang::CompoundStmt::Create(
                             ctx, then_stmts, clang::FPOptionsOverride(),
                             loc, loc);
@@ -4094,13 +4093,13 @@ namespace patchestry::ast {
                         if (else_stmts.size() == 1)
                             else_body = else_stmts[0];
                         else {
-                            auto loc = clang::SourceLocation();
+                            auto loc = VirtualLoc(ctx);
                             else_body = clang::CompoundStmt::Create(
                                 ctx, else_stmts, clang::FPOptionsOverride(),
                                 loc, loc);
                         }
                     }
-                    auto loc = clang::SourceLocation();
+                    auto loc = VirtualLoc(ctx);
                     auto *new_if = clang::IfStmt::Create(
                         ctx, loc, clang::IfStatementKind::Ordinary,
                         nullptr, nullptr, ite->Cond(), loc, loc,
@@ -4327,7 +4326,7 @@ namespace patchestry::ast {
             }
             for (auto *s : label_body)
                 stmts.push_back(s);
-            auto loc = clang::SourceLocation();
+            auto loc = VirtualLoc(ctx);
             return clang::CompoundStmt::Create(
                 ctx, stmts, clang::FPOptionsOverride(), loc, loc);
         }

--- a/lib/patchestry/AST/ClangEmitter.cpp
+++ b/lib/patchestry/AST/ClangEmitter.cpp
@@ -22,10 +22,9 @@ namespace patchestry::ast {
 
     namespace detail {
         static clang::CompoundStmt *MakeCompound(
-            clang::ASTContext &ctx, const std::vector< clang::Stmt * > &stmts,
-            clang::SourceLocation l = clang::SourceLocation(),
-            clang::SourceLocation r = clang::SourceLocation()) {
-            return clang::CompoundStmt::Create(ctx, stmts, clang::FPOptionsOverride(), l, r);
+            clang::ASTContext &ctx, const std::vector< clang::Stmt * > &stmts) {
+            auto loc = VirtualLoc(ctx);
+            return clang::CompoundStmt::Create(ctx, stmts, clang::FPOptionsOverride(), loc, loc);
         }
     } // namespace detail
 
@@ -86,7 +85,7 @@ namespace patchestry::ast {
         class Emitter {
           public:
             Emitter(clang::ASTContext &ctx, clang::FunctionDecl *fn)
-                : ctx_(ctx), fn_(fn) {}
+                : ctx_(ctx), fn_(fn), loc_(VirtualLoc(ctx)) {}
 
             clang::Stmt *Emit(const SNode *node) {
                 if (!node) return nullptr;
@@ -123,7 +122,7 @@ namespace patchestry::ast {
             // After emitting, add LabelStmt for any goto targets that don't have
             // corresponding label definitions. This prevents CIR goto/label mismatch.
           private:
-            clang::SourceLocation Loc() const { return clang::SourceLocation(); }
+            clang::SourceLocation Loc() const { return loc_; }
 
             clang::Stmt *EmitSeq(const SSeq *seq) {
                 std::vector< clang::Stmt * > stmts;
@@ -350,6 +349,7 @@ namespace patchestry::ast {
 
             clang::ASTContext &ctx_;
             clang::FunctionDecl *fn_;
+            clang::SourceLocation loc_;
             std::unordered_map< std::string, clang::LabelDecl * > labels_;
             std::unordered_map< std::string, clang::LabelDecl * > goto_labels_;
             std::unordered_set< std::string > emitted_labels_;
@@ -426,7 +426,7 @@ namespace patchestry::ast {
 
         // Guarantee a non-null Stmt* for set* methods that require one.
         auto safe = [&](clang::Stmt *r) -> clang::Stmt * {
-            return r ? r : new (ctx) clang::NullStmt(clang::SourceLocation());
+            return r ? r : new (ctx) clang::NullStmt(VirtualLoc(ctx));
         };
 
         // Recurse into structured statement bodies
@@ -527,9 +527,9 @@ namespace patchestry::ast {
                 // Skip file-scope / extern globals — CIR asserts isLocalVarDecl()
                 if (!vd->isLocalVarDecl()) continue;
                 // Synthesize a DeclStmt for this missing variable
+                auto loc = VirtualLoc(ctx);
                 auto *ds = new (ctx) clang::DeclStmt(
-                    clang::DeclGroupRef(vd),
-                    clang::SourceLocation(), clang::SourceLocation()
+                    clang::DeclGroupRef(vd), loc, loc
                 );
                 decl_stmts.push_back(ds);
             }

--- a/lib/patchestry/AST/ClangEmitterCleanup.cpp
+++ b/lib/patchestry/AST/ClangEmitterCleanup.cpp
@@ -22,10 +22,9 @@ namespace patchestry::ast {
 
 namespace detail {
     static clang::CompoundStmt *MakeCompound(
-        clang::ASTContext &ctx, const std::vector< clang::Stmt * > &stmts,
-        clang::SourceLocation l = clang::SourceLocation(),
-        clang::SourceLocation r = clang::SourceLocation()) {
-        return clang::CompoundStmt::Create(ctx, stmts, clang::FPOptionsOverride(), l, r);
+        clang::ASTContext &ctx, const std::vector< clang::Stmt * > &stmts) {
+        auto loc = VirtualLoc(ctx);
+        return clang::CompoundStmt::Create(ctx, stmts, clang::FPOptionsOverride(), loc, loc);
     }
 } // namespace detail
 
@@ -74,9 +73,9 @@ namespace detail {
             if (auto *gs = llvm::dyn_cast< clang::GotoStmt >(s)) {
                 std::string name = gs->getLabel()->getName().str();
                 if (!break_label.empty() && name == break_label)
-                    return new (ctx) clang::BreakStmt(clang::SourceLocation());
+                    return new (ctx) clang::BreakStmt(VirtualLoc(ctx));
                 if (!continue_label.empty() && name == continue_label)
-                    return new (ctx) clang::ContinueStmt(clang::SourceLocation());
+                    return new (ctx) clang::ContinueStmt(VirtualLoc(ctx));
                 return s;
             }
 
@@ -298,7 +297,7 @@ namespace detail {
                             // Scan the entire children vector for the label
                             for (auto *c : children) findLabel(c);
                             if (target_decl) {
-                                auto loc = clang::SourceLocation();
+                                auto loc = VirtualLoc(ctx);
                                 auto *hoisted_goto = new (ctx) clang::GotoStmt(
                                     target_decl, loc, loc);
                                 children.insert(children.begin() + static_cast< long >(i) + 1,
@@ -324,7 +323,7 @@ namespace detail {
 
         // Guarantee a non-null Stmt* for set* methods that require one.
         auto safe = [&](clang::Stmt *r) -> clang::Stmt * {
-            return r ? r : new (ctx) clang::NullStmt(clang::SourceLocation());
+            return r ? r : new (ctx) clang::NullStmt(VirtualLoc(ctx));
         };
 
         if (auto *ls = llvm::dyn_cast< clang::LabelStmt >(s)) {
@@ -444,7 +443,7 @@ namespace detail {
         }
 
         auto safe = [&](clang::Stmt *r) -> clang::Stmt * {
-            return r ? r : new (ctx) clang::NullStmt(clang::SourceLocation());
+            return r ? r : new (ctx) clang::NullStmt(VirtualLoc(ctx));
         };
 
         if (auto *cs = llvm::dyn_cast< clang::CompoundStmt >(s)) {
@@ -483,7 +482,7 @@ namespace detail {
                     auto *merged = clang::BinaryOperator::Create(
                         ctx, EnsureRValue(ctx, c1), EnsureRValue(ctx, c2),
                         clang::BO_LOr, ctx.BoolTy, clang::VK_PRValue,
-                        clang::OK_Ordinary, clang::SourceLocation(),
+                        clang::OK_Ordinary, VirtualLoc(ctx),
                         clang::FPOptionsOverride()
                     );
                     llvm::cast< clang::IfStmt >(children[i])->setCond(merged);
@@ -657,7 +656,7 @@ namespace detail {
                                     );
                                     if (b.empty()) {
                                         return new (ctx)
-                                            clang::NullStmt(clang::SourceLocation());
+                                            clang::NullStmt(VirtualLoc(ctx));
                                     }
                                     return detail::MakeCompound(ctx, b);
                                 }
@@ -672,7 +671,7 @@ namespace detail {
                                 return st;
                             }
                             // Reached the goto itself — replace with NullStmt
-                            return new (ctx) clang::NullStmt(clang::SourceLocation());
+                            return new (ctx) clang::NullStmt(VirtualLoc(ctx));
                         };
                         body[i] = strip_tail(body[i]);
                         changed = true;
@@ -790,7 +789,7 @@ namespace detail {
                     if (auto *gs = llvm::dyn_cast< clang::GotoStmt >(st)) {
                         if (gs->getLabel()->getName() == next_label) {
                             sw_changed = true;
-                            return new (ctx) clang::BreakStmt(clang::SourceLocation());
+                            return new (ctx) clang::BreakStmt(VirtualLoc(ctx));
                         }
                         return st;
                     }

--- a/lib/patchestry/AST/FunctionBuilder.cpp
+++ b/lib/patchestry/AST/FunctionBuilder.cpp
@@ -137,7 +137,7 @@ namespace patchestry::ast {
             return {};
         }
 
-        auto location   = clang::SourceLocation();
+        auto location   = SourceLocation(ctx.getSourceManager(), function.get().key);
         auto *func_decl = clang::FunctionDecl::Create(
             ctx, ctx.getTranslationUnitDecl(), location, location,
             &ctx.Idents.get(c_name), function_type,
@@ -206,6 +206,7 @@ namespace patchestry::ast {
                 ctx, func_decl, location, location, &ctx.Idents.get(*param_op->name),
                 param_type, nullptr, clang::SC_None, nullptr
             );
+            param_decl->setIsUsed();
             parameter_vec.push_back(param_decl);
 
             // If this is for definition
@@ -323,14 +324,15 @@ namespace patchestry::ast {
                 continue;
             }
 
+            auto param_loc = SourceLocation(ctx.getSourceManager(), param_key);
             auto *param_decl = clang::ParmVarDecl::Create(
-                ctx, func_decl, SourceLocation(ctx.getSourceManager(), param_key),
-                SourceLocation(ctx.getSourceManager(), param_key),
+                ctx, func_decl, param_loc, param_loc,
                 &ctx.Idents.get(parameter_name(index++)), param_type,
-                ctx.getTrivialTypeSourceInfo(param_type, clang::SourceLocation()),
+                ctx.getTrivialTypeSourceInfo(param_type, param_loc),
                 clang::SC_None, nullptr
             );
             assert(param_decl != nullptr);
+            param_decl->setIsUsed();
 
             parameter_vec.emplace_back(param_decl);
         }

--- a/lib/patchestry/AST/OperationBuilder.cpp
+++ b/lib/patchestry/AST/OperationBuilder.cpp
@@ -55,6 +55,7 @@ namespace patchestry::ast {
         clang::ASTContext &ctx, const Function &function, const Varnode &vnode,
         clang::SourceLocation loc
     ) {
+        if (loc.isInvalid()) loc = VirtualLoc(ctx);
         auto varnode_operation = [&](clang::ASTContext &ctx, const Function &function,
                                      const Varnode &vnode) -> clang::Stmt * {
             switch (vnode.kind) {
@@ -103,7 +104,7 @@ namespace patchestry::ast {
         auto *param_decl = function_builder().local_variables.at(*vnode.operation);
         return clang::DeclRefExpr::Create(
             ctx, clang::NestedNameSpecifierLoc(), clang::SourceLocation(), param_decl, false,
-            clang::SourceLocation(), param_decl->getType(), clang::VK_LValue
+            VirtualLoc(ctx), param_decl->getType(), clang::VK_LValue
         );
     }
 
@@ -120,7 +121,7 @@ namespace patchestry::ast {
         auto *var_decl = function_builder().global_var_list.get().at(*vnode.global);
         return clang::DeclRefExpr::Create(
             ctx, clang::NestedNameSpecifierLoc(), clang::SourceLocation(), var_decl, false,
-            clang::SourceLocation(), var_decl->getType(), clang::VK_LValue
+            VirtualLoc(ctx), var_decl->getType(), clang::VK_LValue
         );
     }
 
@@ -137,7 +138,7 @@ namespace patchestry::ast {
             auto *var_decl = function_builder().local_variables.at(*vnode.operation);
             return clang::DeclRefExpr::Create(
                 ctx, clang::NestedNameSpecifierLoc(), clang::SourceLocation(), var_decl, false,
-                clang::SourceLocation(), var_decl->getType(), clang::VK_LValue
+                VirtualLoc(ctx), var_decl->getType(), clang::VK_LValue
             );
         }
 
@@ -397,7 +398,7 @@ namespace patchestry::ast {
             ctx,
             *vnode.string_value, // Use the string value directly
             is_wide ? clang::StringLiteralKind::Wide : clang::StringLiteralKind::Ordinary,
-            false, string_array, clang::SourceLocation()
+            false, string_array, VirtualLoc(ctx)
         );
     }
 

--- a/lib/patchestry/AST/OperationStmt.cpp
+++ b/lib/patchestry/AST/OperationStmt.cpp
@@ -64,10 +64,14 @@ namespace patchestry::ast {
             clang::ASTContext &ctx, clang::DeclContext *dc, const std::string &name,
             clang::QualType type, clang::SourceLocation loc
         ) {
-            return clang::VarDecl::Create(
+            auto *vd = clang::VarDecl::Create(
                 ctx, dc, loc, loc, &ctx.Idents.get(name), type,
                 ctx.getTrivialTypeSourceInfo(type), clang::SC_None
             );
+            // CIRGen asserts every VarDecl referenced by a DeclRefExpr is
+            // marked used. Patchestry bypasses Sema, so we mark it here.
+            vd->setIsUsed();
+            return vd;
         }
 
         clang::DeclStmt *create_decl_stmt( // NOLINT
@@ -86,21 +90,21 @@ namespace patchestry::ast {
             if (param_type->isIntegerType()) {
                 return new (ctx) clang::IntegerLiteral(
                     ctx, llvm::APInt(ctx.getIntWidth(param_type), 0), param_type,
-                    clang::SourceLocation()
+                    VirtualLoc(ctx)
                 );
             } else if (param_type->isFloatingType()) {
                 llvm::APFloat value(llvm::APFloat::IEEEsingle(), "0.0");
                 return clang::FloatingLiteral::Create(
-                    ctx, value, false, param_type, clang::SourceLocation()
+                    ctx, value, false, param_type, VirtualLoc(ctx)
                 );
             } else if (param_type->isPointerType()) {
                 return new (ctx) clang::IntegerLiteral(
                     ctx, llvm::APInt(ctx.getIntWidth(param_type), 0), param_type,
-                    clang::SourceLocation()
+                    VirtualLoc(ctx)
                 );
             } else if (param_type->isBooleanType()) {
                 return new (ctx)
-                    clang::CXXBoolLiteralExpr(true, param_type, clang::SourceLocation());
+                    clang::CXXBoolLiteralExpr(true, param_type, VirtualLoc(ctx));
             } else {
                 LOG(ERROR) << "Failed to create default value for paramer\n";
                 return nullptr;
@@ -130,9 +134,11 @@ namespace patchestry::ast {
             // Create the builtin declaration
             auto *builtin_decl = sema.CreateBuiltin(II, ty, builtin_id, loc);
 
-            // Create a DeclRefExpr for the builtin
+            // Create a DeclRefExpr for the builtin. ctx is const here, so we
+            // can't allocate a virtual buffer; reuse the caller-provided loc
+            // which is already valid by contract.
             auto *decl_ref = clang::DeclRefExpr::Create(
-                ctx, clang::NestedNameSpecifierLoc(), clang::SourceLocation(), builtin_decl,
+                ctx, clang::NestedNameSpecifierLoc(), loc, builtin_decl,
                 false, loc, builtin_decl->getType(), clang::VK_PRValue
             );
 
@@ -445,6 +451,7 @@ namespace patchestry::ast {
         if ((input_expr == nullptr) || (output_expr == nullptr)) {
             return {};
         }
+        if (loc.isInvalid()) loc = VirtualLoc(ctx);
 
         clang::QualType input_type  = input_expr->getType();
         clang::QualType output_type = output_expr->getType();
@@ -496,6 +503,7 @@ namespace patchestry::ast {
         if ((input_expr == nullptr) || (output_expr == nullptr)) {
             return nullptr;
         }
+        if (loc.isInvalid()) loc = VirtualLoc(ctx);
 
         auto to_type      = output_expr->getType();
         auto *elem_type   = to_type->getPointeeOrArrayElementType();
@@ -506,6 +514,7 @@ namespace patchestry::ast {
             ctx, sema().CurContext, loc, loc, &ctx.Idents.get("i"), ctx.IntTy, nullptr,
             clang::SC_None
         );
+        index->setIsUsed();
 
         auto *index_init = clang::IntegerLiteral::Create(
             ctx, llvm::APInt(static_cast< unsigned >(ctx.getTypeSize(ctx.IntTy)), 0), ctx.IntTy,
@@ -516,7 +525,7 @@ namespace patchestry::ast {
 
         auto *index_ref = clang::DeclRefExpr::Create(
             ctx, clang::NestedNameSpecifierLoc(), clang::SourceLocation(), index, false,
-            clang::SourceLocation(), index->getType(), clang::VK_LValue
+            VirtualLoc(ctx), index->getType(), clang::VK_LValue
         );
 
         auto *cond_expr = sema()
@@ -1213,10 +1222,11 @@ namespace patchestry::ast {
                     for (unsigned i = 0; i < new_param_types.size(); ++i) {
                         std::string pname = "param_" + std::to_string(i);
                         auto *pd = clang::ParmVarDecl::Create(
-                            ctx, callee, clang::SourceLocation(),
-                            clang::SourceLocation(), &ctx.Idents.get(pname),
+                            ctx, callee, VirtualLoc(ctx),
+                            VirtualLoc(ctx), &ctx.Idents.get(pname),
                             new_param_types[i], nullptr, clang::SC_None, nullptr
                         );
+                        pd->setIsUsed();
                         new_params.push_back(pd);
                     }
                     callee->setParams(new_params);
@@ -1413,7 +1423,7 @@ namespace patchestry::ast {
             auto *var_decl = function_builder().global_var_list.get().at(*op.target->global);
             fn_ptr_expr    = clang::DeclRefExpr::Create(
                 ctx, clang::NestedNameSpecifierLoc(), clang::SourceLocation(), var_decl, false,
-                clang::SourceLocation(), var_decl->getType(), clang::VK_LValue
+                VirtualLoc(ctx), var_decl->getType(), clang::VK_LValue
             );
         } else if (op.target->operation) {
             // Target is a computed expression — resolve via create_varnode for varnode
@@ -2539,7 +2549,7 @@ namespace patchestry::ast {
 
         auto nan_value = llvm::APFloat::getQNaN(llvm::APFloat::IEEEsingle());
         auto *nan_expr = clang::FloatingLiteral::Create(
-            ctx, nan_value, true, ctx.FloatTy, clang::SourceLocation()
+            ctx, nan_value, true, ctx.FloatTy, VirtualLoc(ctx)
         );
 
         auto op_loc = SourceLocation(ctx.getSourceManager(), op.key);
@@ -2645,6 +2655,7 @@ namespace patchestry::ast {
             LOG(ERROR) << "Can't make member expre, base type is not pointer of record decl!\n";
             return nullptr;
         }
+        if (loc.isInvalid()) loc = VirtualLoc(ctx);
 
         auto find_field_decl = [&](clang::ASTContext &ctx, clang::RecordDecl *decl,
                                    unsigned int target_offset) -> clang::FieldDecl * {
@@ -2709,7 +2720,7 @@ namespace patchestry::ast {
         clang::DeclarationNameInfo member_name_info(field->getDeclName(), loc);
         return sema().BuildMemberExpr(
             convert_rvalue(ctx, base), true, loc, clang::NestedNameSpecifierLoc(),
-            clang::SourceLocation(), field,
+            VirtualLoc(ctx), field,
             clang::DeclAccessPair::make(field, clang::AS_public), false, member_name_info,
             field->getType(), clang::VK_LValue, clang::OK_Ordinary
         );
@@ -2974,7 +2985,7 @@ namespace patchestry::ast {
         }
 
         // Create a new intrinsic function declaration
-        auto loc = clang::SourceLocation();
+        auto loc = VirtualLoc(ctx);
 
         // Create function type with variadic signature if requested.
         // Note: Variadic prototypes must have at least one non-variadic parameter
@@ -3107,8 +3118,8 @@ namespace patchestry::ast {
             auto func_type = ctx.getFunctionType(ret_type, param_types, epi);
 
             fn_decl = clang::FunctionDecl::Create(
-                ctx, ctx.getTranslationUnitDecl(), clang::SourceLocation(),
-                clang::SourceLocation(), &ctx.Idents.get(func_name), func_type,
+                ctx, ctx.getTranslationUnitDecl(), VirtualLoc(ctx),
+                VirtualLoc(ctx), &ctx.Idents.get(func_name), func_type,
                 ctx.getTrivialTypeSourceInfo(func_type), clang::SC_Extern
             );
 
@@ -3125,6 +3136,7 @@ namespace patchestry::ast {
                     ctx, fn_decl, op_loc, op_loc, nullptr, param_types[i], nullptr,
                     clang::SC_None, nullptr
                 );
+                param->setIsUsed();
                 param_decls.push_back(param);
             }
             fn_decl->setParams(param_decls);

--- a/lib/patchestry/AST/Utils.cpp
+++ b/lib/patchestry/AST/Utils.cpp
@@ -7,7 +7,6 @@
 
 #include <cassert>
 #include <cctype>
-#include <unordered_map>
 
 #include <clang/AST/ASTContext.h>
 #include <clang/AST/Expr.h>
@@ -33,15 +32,27 @@ namespace patchestry::ast {
     }
 
     clang::SourceLocation VirtualLoc(clang::ASTContext &ctx) {
-        static std::unordered_map< clang::SourceManager *, clang::SourceLocation > cache;
-        auto *sm = &ctx.getSourceManager();
-        auto it  = cache.find(sm);
-        if (it != cache.end()) {
-            return it->second;
+        // Idempotent per SourceManager: FileManager::getVirtualFileRef is
+        // a get-or-create on the virtual name, and SourceManager::translateFile
+        // returns the existing FileID for that entry (or invalid on first use).
+        // We avoid a global pointer-keyed cache because SourceManagers come
+        // and go (Passes/Compiler.cpp builds a fresh one per compilation),
+        // a stale cache entry could outlive its owner and the heap may reuse
+        // the same address for a later SM, vending a SourceLocation whose
+        // FileID belongs to a destroyed table.
+        static constexpr llvm::StringLiteral kVirtualName = "<patchestry-virtual>";
+        auto &sm = ctx.getSourceManager();
+        auto &fm = sm.getFileManager();
+
+        auto fe = fm.getVirtualFileRef(
+            kVirtualName, static_cast< int >(kVirtualName.size()), 0
+        );
+        clang::FileID fid = sm.translateFile(&fe.getFileEntry());
+        if (fid.isInvalid()) {
+            sm.overrideFileContents(fe, llvm::MemoryBuffer::getMemBufferCopy(kVirtualName));
+            fid = sm.createFileID(fe, clang::SourceLocation(), clang::SrcMgr::C_User, 0);
         }
-        auto loc  = SourceLocation(*sm, "<patchestry-virtual>");
-        cache[sm] = loc;
-        return loc;
+        return sm.getLocForStartOfFile(fid);
     }
 
     clang::QualType GetTypeFromSize(

--- a/lib/patchestry/AST/Utils.cpp
+++ b/lib/patchestry/AST/Utils.cpp
@@ -7,6 +7,7 @@
 
 #include <cassert>
 #include <cctype>
+#include <unordered_map>
 
 #include <clang/AST/ASTContext.h>
 #include <clang/AST/Expr.h>
@@ -29,6 +30,18 @@ namespace patchestry::ast {
         sm.overrideFileContents(fe, std::move(buffer));
         auto fid = sm.createFileID(fe, clang::SourceLocation(), clang::SrcMgr::C_User, 0);
         return sm.getLocForStartOfFile(fid);
+    }
+
+    clang::SourceLocation VirtualLoc(clang::ASTContext &ctx) {
+        static std::unordered_map< clang::SourceManager *, clang::SourceLocation > cache;
+        auto *sm = &ctx.getSourceManager();
+        auto it  = cache.find(sm);
+        if (it != cache.end()) {
+            return it->second;
+        }
+        auto loc  = SourceLocation(*sm, "<patchestry-virtual>");
+        cache[sm] = loc;
+        return loc;
     }
 
     clang::QualType GetTypeFromSize(


### PR DESCRIPTION
Standardizes clang::SourceLocation usage by replacing invalid default locations with a synthetic VirtualLoc. Ensures all AST nodes have valid locations, fixing downstream assertions (e.g., CIRGen) and improving the correctness of AST construction.