### PR TITLE
transform: add mode: replace_definition for whole-function body swap.

### DIFF
--- a/docs/GettingStarted/patch_specifications.md
+++ b/docs/GettingStarted/patch_specifications.md
@@ -299,7 +299,7 @@ The action fields live under each entry's nested `action:` mapping
 
 | Field | Required | Description | Example |
 |-------|----------|-------------|---------|
-| `mode` | Yes | Patching or contract mode to apply. Shared modes: `apply_before`, `apply_after`. Patch-only modes: `apply_at_entrypoint`, `replace`, `erase` | `"apply_before"` |
+| `mode` | Yes | Patching or contract mode to apply. Shared modes: `apply_before`, `apply_after`. Patch-only modes: `apply_at_entrypoint`, `replace`, `replace_definition`, `erase` | `"apply_before"` |
 | `patch` | Under `patches:` (unless `mode: erase`) | Reference to the patch implementation `name:` in a library | `"usb_endpoint_write_validation_after"` |
 | `contract` | Under `contracts:` | Reference to the static contract `name:` in a library | `"usb_msg_nonnull"` |
 | `arguments` | No | List of arguments to pass to patch function (ignored for contracts) | See [Argument Specification](#argument-specification) |
@@ -647,12 +647,13 @@ Examples:
 
 ## Patch Modes
 
-The specification supports five modes:
+The specification supports six modes:
 
 - `apply_before`: Apply patch or contract before the matched function or operation
 - `apply_after`: Apply patch or contract after the matched function or operation completes
 - `apply_at_entrypoint`: Insert a patch at the entry point of the **caller** function (patches only — see [Apply At Entrypoint Mode](#apply-at-entrypoint-mode))
 - `replace`: Completely replace the matched function call or operation (patches only)
+- `replace_definition`: Swap the matched function's **body** in place; symbol and signature are preserved, callers stay byte-identical (patches only — see [Replace Definition Mode](#replace-definition-mode))
 - `erase`: Delete the matched op without inserting any patch code (patches only — see [Erase Mode](#erase-mode))
 
 ### Apply Before Mode
@@ -765,6 +766,62 @@ patches:
 Use ERASE for removing debug/logging calls, stripping unused cleanup
 paths, or deleting obsolete instrumentation. For replacing a call with
 a different function, use `replace` instead.
+
+### Replace Definition Mode
+
+Where `replace` rewrites individual call sites or operations,
+`replace_definition` swaps the matched function's body wholesale — the
+symbol and signature are preserved, so every caller stays
+byte-identical. The patch function takes over `target`'s
+implementation; callers are not touched.
+
+Use this mode when you want to change *what a function does* rather
+than *what a specific call site invokes*. Common cases:
+
+- Callers cannot be lifted (so call-site `replace` cannot reach them).
+- Cooperating patches need to share `static` state across multiple
+  methods.
+- The transformation logically belongs at the callee, not per call site
+  (e.g., reimplementing a parser, hardening a privileged operation).
+
+The patch function's CIR type must match the target's exactly: same
+parameter types, same return type. Type mismatches are loud failures
+named in the diagnostic so the spec author can fix the patch C source
+without a debugger.
+
+```yaml
+patches:
+  - name: "sclv0_state_machine_parser"
+    id: "MAKAIR-BODY-001"
+    description: "Swap serial_control_loop_v0's body with a state-machine parser"
+    match:
+      name: "_ZL22serial_control_loop_v0v"
+      kind: "function"
+    action:
+      mode: "replace_definition"
+      patch: "serial_control_loop_v0_repl"
+```
+
+**Parser-time validation** rejects fields that have no meaning for a
+whole-definition swap, so misconfiguration surfaces at spec load
+instead of failing silently or deep inside the pass:
+
+| Field | Why it is rejected |
+|---|---|
+| `arguments:` | The wrapper inherits the callee signature 1:1. Use `mode: replace` if you want per-operand plumbing per call site. |
+| `match.captures:` | Captures bind at match sites; there is no site here, only the function definition. |
+| `match.kind: operation` | The operation-kind dispatch has no notion of a function definition to swap. |
+| `op_kind:` | Kinded-generic-op filter is meaningless for a function definition. |
+| `operand_matches:` | Operand filters apply to call sites, not definitions. |
+| `context:` | Caller context is meaningless for a callee-definition swap. Use `mode: replace` to scope by caller. |
+
+The pass also refuses to replace declarations (functions with no body)
+— there is nothing to swap, and silently upgrading a declaration to a
+definition would be a surprising semantic shift.
+
+When the swap completes, the target carries a
+`patchestry_definition_replaced_by` attribute naming the patch function
+so downstream tools can identify body-swapped functions.
 
 ### Apply At Entrypoint Mode
 

--- a/docs/GettingStarted/patch_specifications.md
+++ b/docs/GettingStarted/patch_specifications.md
@@ -769,31 +769,19 @@ a different function, use `replace` instead.
 
 ### Replace Definition Mode
 
-Where `replace` rewrites individual call sites or operations,
-`replace_definition` swaps the matched function's body wholesale — the
-symbol and signature are preserved, so every caller stays
-byte-identical. The patch function takes over `target`'s
-implementation; callers are not touched.
+`replace_definition` swaps the matched function's body wholesale. The
+symbol and signature are preserved; callers stay byte-identical. Use it
+when callers cannot be lifted, when cooperating patches need shared
+`static` state, or when the change logically belongs at the callee.
 
-Use this mode when you want to change *what a function does* rather
-than *what a specific call site invokes*. Common cases:
-
-- Callers cannot be lifted (so call-site `replace` cannot reach them).
-- Cooperating patches need to share `static` state across multiple
-  methods.
-- The transformation logically belongs at the callee, not per call site
-  (e.g., reimplementing a parser, hardening a privileged operation).
-
-The patch function's CIR type must match the target's exactly: same
-parameter types, same return type. Type mismatches are loud failures
-named in the diagnostic so the spec author can fix the patch C source
-without a debugger.
+The patch function's CIR type must match the target's exactly; mismatches
+are rejected with both types named in the diagnostic. Declarations cannot
+be replaced (there is no body to swap).
 
 ```yaml
 patches:
   - name: "sclv0_state_machine_parser"
     id: "MAKAIR-BODY-001"
-    description: "Swap serial_control_loop_v0's body with a state-machine parser"
     match:
       name: "_ZL22serial_control_loop_v0v"
       kind: "function"
@@ -802,26 +790,11 @@ patches:
       patch: "serial_control_loop_v0_repl"
 ```
 
-**Parser-time validation** rejects fields that have no meaning for a
-whole-definition swap, so misconfiguration surfaces at spec load
-instead of failing silently or deep inside the pass:
-
-| Field | Why it is rejected |
-|---|---|
-| `arguments:` | The wrapper inherits the callee signature 1:1. Use `mode: replace` if you want per-operand plumbing per call site. |
-| `match.captures:` | Captures bind at match sites; there is no site here, only the function definition. |
-| `match.kind: operation` | The operation-kind dispatch has no notion of a function definition to swap. |
-| `op_kind:` | Kinded-generic-op filter is meaningless for a function definition. |
-| `operand_matches:` | Operand filters apply to call sites, not definitions. |
-| `context:` | Caller context is meaningless for a callee-definition swap. Use `mode: replace` to scope by caller. |
-
-The pass also refuses to replace declarations (functions with no body)
-— there is nothing to swap, and silently upgrading a declaration to a
-definition would be a surprising semantic shift.
-
-When the swap completes, the target carries a
-`patchestry_definition_replaced_by` attribute naming the patch function
-so downstream tools can identify body-swapped functions.
+`arguments:`, `match.captures:`, `match.kind: operation`, `op_kind:`,
+`operand_matches:`, and `context:` are all rejected at parse time — the
+wrapper inherits the callee signature 1:1, so per-site fields have no
+meaning. The swapped target carries a `patchestry_definition_replaced_by`
+attribute naming the patch function.
 
 ### Apply At Entrypoint Mode
 

--- a/include/patchestry/Passes/InstrumentationPass.hpp
+++ b/include/patchestry/Passes/InstrumentationPass.hpp
@@ -433,6 +433,16 @@ namespace patchestry::passes { // NOLINT
         void set_instrumentation_call_attributes(
             cir::CallOp instr_call_op, mlir::Operation *target_op
         );
+
+        /**
+         * @brief Marks `target` as having had its definition replaced by
+         *        the patch function, so downstream tools can identify
+         *        body-swapped functions. Counterpart to
+         *        `set_instrumentation_call_attributes` for body replace.
+         */
+        void set_instrumentation_func_attributes(
+            cir::FuncOp target, llvm::StringRef patch_function_name
+        );
     };
 
 } // namespace patchestry::passes

--- a/include/patchestry/Passes/OperationMatcher.hpp
+++ b/include/patchestry/Passes/OperationMatcher.hpp
@@ -101,6 +101,20 @@ namespace patchestry::passes {
          */
         static std::string extract_callee_name(cir::CallOp call_op); // NOLINT
 
+        /**
+         * @brief Matches a `cir::FuncOp`'s definition against a
+         *        `MatchConfig` (name + function-context). Used by
+         *        REPLACE_DEFINITION dispatch, which targets function
+         *        definitions rather than call sites.
+         *
+         * @return true if `func`'s symbol name matches `match.name` and
+         *         `func`'s name satisfies the (possibly empty)
+         *         `function_context` list.
+         */
+        static bool function_definition_matches( // NOLINT
+            cir::FuncOp func, const patch::MatchConfig &match
+        );
+
       private:
         /**
          * @brief Match-only primitive. Internal helper for the capture-populating

--- a/include/patchestry/YAML/BaseSpec.hpp
+++ b/include/patchestry/YAML/BaseSpec.hpp
@@ -23,8 +23,9 @@ namespace patchestry::passes {
         APPLY_BEFORE,
         APPLY_AFTER,
         APPLY_AT_ENTRYPOINT, // Insert patch call at caller's entry block
-        REPLACE,
-        ERASE // Delete matched op, no patch function
+        REPLACE,             // Rewrite a matched call site / op site
+        ERASE,               // Delete matched op, no patch function
+        REPLACE_DEFINITION   // Swap a matched cir.func's body wholesale
     };
 
     enum class ArgumentSourceType : uint8_t {
@@ -47,6 +48,7 @@ namespace patchestry::passes {
     static_assert(static_cast< uint8_t >(InstrumentationMode::APPLY_AT_ENTRYPOINT) == 3);
     static_assert(static_cast< uint8_t >(InstrumentationMode::REPLACE) == 4);
     static_assert(static_cast< uint8_t >(InstrumentationMode::ERASE) == 5);
+    static_assert(static_cast< uint8_t >(InstrumentationMode::REPLACE_DEFINITION) == 6);
 
     static_assert(static_cast< uint8_t >(ArgumentSourceType::OPERAND) == 0);
     static_assert(static_cast< uint8_t >(ArgumentSourceType::VARIABLE) == 1);

--- a/include/patchestry/YAML/PatchSpec.hpp
+++ b/include/patchestry/YAML/PatchSpec.hpp
@@ -106,6 +106,8 @@ namespace patchestry::passes {
                     return "REPLACE";
                 case InstrumentationMode::ERASE:
                     return "ERASE";
+                case InstrumentationMode::REPLACE_DEFINITION:
+                    return "REPLACE_DEFINITION";
             }
             return "UNKNOWN";
         }
@@ -268,10 +270,13 @@ namespace llvm::yaml {
         if (mode_str == "Erase" || mode_str == "erase") {
             return InstrumentationMode::ERASE;
         }
+        if (mode_str == "ReplaceDefinition" || mode_str == "replace_definition") {
+            return InstrumentationMode::REPLACE_DEFINITION;
+        }
         io.setError(
             "Unknown patch mode: '" + mode_str
             + "'. Valid modes: ApplyBefore, ApplyAfter, "
-              "ApplyAtEntrypoint, Replace, Erase"
+              "ApplyAtEntrypoint, Replace, Erase, ReplaceDefinition"
         );
         return InstrumentationMode::NONE;
     }
@@ -661,6 +666,57 @@ namespace llvm::yaml {
                         );
                         break;
                     }
+                }
+            }
+
+            // `replace_definition` swaps the callee's body wholesale; the
+            // wrapper inherits its signature 1:1, so match-site / per-operand
+            // knobs are meaningless. Reject at parse for a clear diagnostic.
+            if (action_obj.mode == InstrumentationMode::REPLACE_DEFINITION) {
+                if (match_obj.kind != MatchKind::FUNCTION) {
+                    io.setError(
+                        "'mode: replace_definition' requires 'match.kind: "
+                        "function'; the operation-kind dispatch has no "
+                        "notion of a function definition to swap."
+                    );
+                }
+                if (!action_obj.arguments.empty()) {
+                    io.setError(
+                        "'mode: replace_definition' inherits the matched "
+                        "function's signature 1:1; remove 'arguments:'. Use "
+                        "'mode: replace' if you want per-operand plumbing "
+                        "at each call site instead."
+                    );
+                }
+                if (!match_obj.captures.empty()) {
+                    io.setError(
+                        "'mode: replace_definition' does not accept "
+                        "'match.captures'; captures are bound at match "
+                        "sites and have no meaning for a whole-definition "
+                        "swap."
+                    );
+                }
+                if (match_obj.op_kind.has_value()) {
+                    io.setError(
+                        "'mode: replace_definition' does not accept "
+                        "'op_kind:'; op_kind filters kinded generic ops and "
+                        "is meaningless when matching a function definition."
+                    );
+                }
+                if (!match_obj.operand_matches.empty()) {
+                    io.setError(
+                        "'mode: replace_definition' does not accept "
+                        "'operand_matches:'; operand filters apply to "
+                        "match sites, not to function definitions."
+                    );
+                }
+                if (!match_obj.context.empty()) {
+                    io.setError(
+                        "'mode: replace_definition' does not accept "
+                        "'context:'; caller context is meaningless for a "
+                        "callee-definition swap. Use 'mode: replace' if you "
+                        "want to scope rewriting by caller."
+                    );
                 }
             }
         }

--- a/include/patchestry/YAML/PatchSpec.hpp
+++ b/include/patchestry/YAML/PatchSpec.hpp
@@ -673,12 +673,16 @@ namespace llvm::yaml {
             // wrapper inherits its signature 1:1, so match-site / per-operand
             // knobs are meaningless. Reject at parse for a clear diagnostic.
             if (action_obj.mode == InstrumentationMode::REPLACE_DEFINITION) {
+                // `setError` is first-caller-wins; `return` after each so a
+                // multi-violation spec doesn't chase down the same diagnostic
+                // multiple times and matches the `PatchMatchObject` pattern.
                 if (match_obj.kind != MatchKind::FUNCTION) {
                     io.setError(
                         "'mode: replace_definition' requires 'match.kind: "
                         "function'; the operation-kind dispatch has no "
                         "notion of a function definition to swap."
                     );
+                    return;
                 }
                 if (!action_obj.arguments.empty()) {
                     io.setError(
@@ -687,6 +691,7 @@ namespace llvm::yaml {
                         "'mode: replace' if you want per-operand plumbing "
                         "at each call site instead."
                     );
+                    return;
                 }
                 if (!match_obj.captures.empty()) {
                     io.setError(
@@ -695,6 +700,7 @@ namespace llvm::yaml {
                         "sites and have no meaning for a whole-definition "
                         "swap."
                     );
+                    return;
                 }
                 if (match_obj.op_kind.has_value()) {
                     io.setError(
@@ -702,6 +708,7 @@ namespace llvm::yaml {
                         "'op_kind:'; op_kind filters kinded generic ops and "
                         "is meaningless when matching a function definition."
                     );
+                    return;
                 }
                 if (!match_obj.operand_matches.empty()) {
                     io.setError(
@@ -709,6 +716,7 @@ namespace llvm::yaml {
                         "'operand_matches:'; operand filters apply to "
                         "match sites, not to function definitions."
                     );
+                    return;
                 }
                 if (!match_obj.context.empty()) {
                     io.setError(
@@ -717,6 +725,7 @@ namespace llvm::yaml {
                         "callee-definition swap. Use 'mode: replace' if you "
                         "want to scope rewriting by caller."
                     );
+                    return;
                 }
             }
         }

--- a/lib/patchestry/Passes/InstrumentationPass.cpp
+++ b/lib/patchestry/Passes/InstrumentationPass.cpp
@@ -512,6 +512,35 @@ namespace patchestry::passes {
         if (match.kind == MatchKind::FUNCTION) {
             // Apply to function calls
             for (auto func : function_worklist) {
+                // REPLACE_DEFINITION targets the cir.func definition, not
+                // its call sites — short-circuit the per-call walk.
+                if (action.mode == InstrumentationMode::REPLACE_DEFINITION) {
+                    if (!OperationMatcher::function_definition_matches(
+                            func, match
+                        ))
+                    {
+                        continue;
+                    }
+
+                    auto patch_module = load_code_module(
+                        *func->getContext(), *patch_to_apply.spec->patch_module
+                    );
+                    if (!patch_module) {
+                        LOG(ERROR)
+                            << "Failed to load patch module for function: "
+                            << func.getSymName().str() << "\n";
+                        continue;
+                    }
+
+                    LOG(INFO) << "Replacing definition of '"
+                              << func.getSymName().str() << "' with patch '"
+                              << patch_to_apply.spec->name << "'\n";
+                    PatchOperationImpl::replaceFunctionDefinition(
+                        *this, func, patch_to_apply, patch_module.get()
+                    );
+                    continue;
+                }
+
                 // ERASE collects matched ops first, then erases after walk
                 // to avoid invalidating walk iterators.
                 llvm::SmallVector< mlir::Operation *, 8 > to_erase;
@@ -1429,6 +1458,15 @@ namespace patchestry::passes {
         instr_call_op->setAttr(
             "patchestry_operation",
             mlir::StringAttr::get(target_op->getContext(), target_op->getName().getStringRef())
+        );
+    }
+
+    void InstrumentationPass::set_instrumentation_func_attributes(
+        cir::FuncOp target, llvm::StringRef patch_function_name
+    ) {
+        target->setAttr(
+            "patchestry_definition_replaced_by",
+            mlir::StringAttr::get(target->getContext(), patch_function_name)
         );
     }
 

--- a/lib/patchestry/Passes/OperationMatcher.cpp
+++ b/lib/patchestry/Passes/OperationMatcher.cpp
@@ -609,6 +609,20 @@ namespace patchestry::passes {
         return "";
     }
 
+    bool OperationMatcher::function_definition_matches(
+        cir::FuncOp func, const patch::MatchConfig &match
+    ) {
+        if (match.name.empty() || match.kind != MatchKind::FUNCTION) {
+            LOG(DEBUG)
+                << "function_definition_matches: match.name empty or kind != FUNCTION\n";
+            return false;
+        }
+        if (!matches_pattern(func.getSymName().str(), match.name)) {
+            return false;
+        }
+        return matches_function_context(func, match.function_context);
+    }
+
     bool
     OperationMatcher::matches_pattern(const std::string &text, const std::string &pattern) {
         // If no pattern, match all (this is intentionally different from matches_operation_name

--- a/lib/patchestry/Passes/OperationMatcher.cpp
+++ b/lib/patchestry/Passes/OperationMatcher.cpp
@@ -612,9 +612,9 @@ namespace patchestry::passes {
     bool OperationMatcher::function_definition_matches(
         cir::FuncOp func, const patch::MatchConfig &match
     ) {
+        // Kind guard is defensive (current callers already filter on
+        // MatchKind::FUNCTION) and mirrors patch_action_matches_function_call.
         if (match.name.empty() || match.kind != MatchKind::FUNCTION) {
-            LOG(DEBUG)
-                << "function_definition_matches: match.name empty or kind != FUNCTION\n";
             return false;
         }
         if (!matches_pattern(func.getSymName().str(), match.name)) {

--- a/lib/patchestry/Passes/PatchOperationImpl.cpp
+++ b/lib/patchestry/Passes/PatchOperationImpl.cpp
@@ -7,6 +7,7 @@
 
  #include <mlir/IR/Builders.h>
  #include <mlir/IR/Dominance.h>
+ #include <mlir/IR/IRMapping.h>
  #include <mlir/IR/SymbolTable.h>
  
  #include <clang/CIR/Dialect/IR/CIRDialect.h>
@@ -458,6 +459,80 @@ namespace patchestry {
             if (should_inline) {
                 pass.inline_worklists.insert(patch_call_op);
             }
+        }
+
+        void PatchOperationImpl::replaceFunctionDefinition(
+            InstrumentationPass &pass, cir::FuncOp target,
+            const PatchInformation &patch, mlir::ModuleOp patch_module
+        ) {
+            if (!target) {
+                LOG(ERROR) << "Replace definition: target function is null\n";
+                pass.signal_failure();
+                return;
+            }
+            if (!patch.spec.has_value()) {
+                LOG(ERROR) << "Replace definition: patch.spec is empty\n";
+                pass.signal_failure();
+                return;
+            }
+
+            // Refuse declarations: cloning a body into one would silently
+            // promote it to a definition.
+            if (target.getBody().empty()) {
+                LOG(ERROR) << "Replace definition: target '"
+                           << target.getSymName().str()
+                           << "' is a declaration, not a definition. "
+                              "replace_definition only swaps existing bodies.\n";
+                pass.signal_failure();
+                return;
+            }
+
+            auto module = target->getParentOfType< mlir::ModuleOp >();
+            assert(module && "Replace definition: no module found");
+
+            const auto &patch_spec = patch.spec.value();
+            std::string patch_function_name = namifyFunction(patch_spec.function_name);
+
+            auto patch_func = ensurePatchFunctionAvailable(
+                pass, module, patch_module, patch_function_name,
+                "Replace definition"
+            );
+            if (!patch_func) {
+                pass.signal_failure();
+                return;
+            }
+
+            // Signature gate before any IR mutation so a mismatch leaves
+            // target untouched. Diagnostic names both types for the author.
+            auto target_type = target.getFunctionType();
+            auto patch_type  = patch_func.getFunctionType();
+            if (target_type != patch_type) {
+                std::string target_type_str;
+                llvm::raw_string_ostream tos(target_type_str);
+                tos << target_type;
+                std::string patch_type_str;
+                llvm::raw_string_ostream pos(patch_type_str);
+                pos << patch_type;
+                LOG(ERROR) << "Replace definition: signature mismatch — "
+                              "target '"
+                           << target.getSymName().str() << "' has type "
+                           << tos.str() << " but patch '"
+                           << patch_function_name << "' has type "
+                           << pos.str()
+                           << ". replace_definition is strict; the patch "
+                              "must declare the same parameter and return "
+                              "types as the target.\n";
+                pass.signal_failure();
+                return;
+            }
+
+            // cloneInto creates fresh block args; the signature gate above
+            // guarantees their types match the target's declared parameters.
+            target.getBody().getBlocks().clear();
+            mlir::IRMapping mapper;
+            patch_func.getBody().cloneInto(&target.getBody(), mapper);
+
+            pass.set_instrumentation_func_attributes(target, patch_function_name);
         }
 
         namespace {

--- a/lib/patchestry/Passes/PatchOperationImpl.cpp
+++ b/lib/patchestry/Passes/PatchOperationImpl.cpp
@@ -532,6 +532,13 @@ namespace patchestry {
             mlir::IRMapping mapper;
             patch_func.getBody().cloneInto(&target.getBody(), mapper);
 
+            // The patch func's body has been donated to target and it has no
+            // remaining callers; demote to internal so downstream globaldce
+            // can strip it. `merge_module_symbol` already does this for the
+            // first-merge path; the explicit call covers the already-present
+            // path and documents intent.
+            patch_func.setLinkage(cir::GlobalLinkageKind::InternalLinkage);
+
             pass.set_instrumentation_func_attributes(target, patch_function_name);
         }
 

--- a/lib/patchestry/Passes/PatchOperationImpl.hpp
+++ b/lib/patchestry/Passes/PatchOperationImpl.hpp
@@ -132,6 +132,29 @@ namespace patchestry::passes {
         );
 
         /**
+         * @brief Replaces the body region of the matched `cir.func`
+         *        with the body of the patch function, leaving every
+         *        caller and the symbol/signature of `target` untouched.
+         *
+         * The patch function's type must match `target.getFunctionType()`
+         * exactly (strict signature gate); on mismatch the pass signals
+         * failure and `target` is left unchanged. The target must be a
+         * definition, not a declaration. The patch FuncOp remains in
+         * the module as a private definition after replacement
+         * (parity with `replaceCallWithPatch`).
+         *
+         * @param pass The instrumentation pass instance
+         * @param target The `cir.func` whose body will be replaced
+         * @param patch The patch information containing the patch
+         *              function details
+         * @param patch_module The module containing the patch function
+         */
+        static void replaceFunctionDefinition(
+            InstrumentationPass &pass, cir::FuncOp target,
+            const PatchInformation &patch, mlir::ModuleOp patch_module
+        );
+
+        /**
          * @brief Erases the target operation without inserting any patch.
          *
          * Used by ERASE mode. If the op has live result uses, each used

--- a/test/patchir-transform/replace_definition_operation_kind_reject.yaml
+++ b/test/patchir-transform/replace_definition_operation_kind_reject.yaml
@@ -1,0 +1,18 @@
+apiVersion: patchestry.io/v1
+metadata:
+  name: replace-definition-operation-kind-reject
+  kind: PatchSpec
+target:
+  binary: x.bin
+  arch: ARM:LE:32
+libraries:
+- patches/measurement_update_patch.yaml
+patches:
+- name: bogus_replace_definition_operation_kind
+  id: REPLACE-DEF-OPKIND-REJECT-001
+  match:
+    name: cir.call
+    kind: operation
+  action:
+    mode: replace_definition
+    patch: measurement_update_replace_patch

--- a/test/patchir-transform/replace_definition_valid.yaml
+++ b/test/patchir-transform/replace_definition_valid.yaml
@@ -1,0 +1,20 @@
+apiVersion: patchestry.io/v1
+metadata:
+  name: replace-definition-valid
+  description: Minimal valid replace_definition spec; parser-only positive test
+  kind: PatchSpec
+target:
+  binary: x.bin
+  arch: ARM:LE:32
+libraries:
+- patches/measurement_update_patch.yaml
+patches:
+- name: minimal_replace_definition
+  id: REPLACE-DEF-VALID-001
+  description: Swap measurement_update's body wholesale
+  match:
+    name: measurement_update
+    kind: function
+  action:
+    mode: replace_definition
+    patch: measurement_update_replace_patch

--- a/test/patchir-transform/replace_definition_with_arguments_reject.yaml
+++ b/test/patchir-transform/replace_definition_with_arguments_reject.yaml
@@ -1,0 +1,21 @@
+apiVersion: patchestry.io/v1
+metadata:
+  name: replace-definition-with-arguments-reject
+  kind: PatchSpec
+target:
+  binary: x.bin
+  arch: ARM:LE:32
+libraries:
+- patches/measurement_update_patch.yaml
+patches:
+- name: bogus_replace_definition_with_arguments
+  id: REPLACE-DEF-ARGS-REJECT-001
+  match:
+    name: measurement_update
+    kind: function
+  action:
+    mode: replace_definition
+    patch: measurement_update_replace_patch
+    arguments:
+    - source: operand
+      index: 0

--- a/test/patchir-transform/replace_definition_with_captures_reject.yaml
+++ b/test/patchir-transform/replace_definition_with_captures_reject.yaml
@@ -1,0 +1,21 @@
+apiVersion: patchestry.io/v1
+metadata:
+  name: replace-definition-with-captures-reject
+  kind: PatchSpec
+target:
+  binary: x.bin
+  arch: ARM:LE:32
+libraries:
+- patches/measurement_update_patch.yaml
+patches:
+- name: bogus_replace_definition_with_captures
+  id: REPLACE-DEF-CAPTURES-REJECT-001
+  match:
+    name: measurement_update
+    kind: function
+    captures:
+    - name: A
+      operand: 0
+  action:
+    mode: replace_definition
+    patch: measurement_update_replace_patch

--- a/test/patchir-transform/replace_definition_with_context_reject.yaml
+++ b/test/patchir-transform/replace_definition_with_context_reject.yaml
@@ -1,0 +1,20 @@
+apiVersion: patchestry.io/v1
+metadata:
+  name: replace-definition-with-context-reject
+  kind: PatchSpec
+target:
+  binary: x.bin
+  arch: ARM:LE:32
+libraries:
+- patches/measurement_update_patch.yaml
+patches:
+- name: bogus_replace_definition_with_context
+  id: REPLACE-DEF-CONTEXT-REJECT-001
+  match:
+    name: measurement_update
+    kind: function
+    context:
+    - some_caller
+  action:
+    mode: replace_definition
+    patch: measurement_update_replace_patch

--- a/test/patchir-transform/replace_definition_with_op_kind_reject.yaml
+++ b/test/patchir-transform/replace_definition_with_op_kind_reject.yaml
@@ -1,0 +1,19 @@
+apiVersion: patchestry.io/v1
+metadata:
+  name: replace-definition-with-op-kind-reject
+  kind: PatchSpec
+target:
+  binary: x.bin
+  arch: ARM:LE:32
+libraries:
+- patches/measurement_update_patch.yaml
+patches:
+- name: bogus_replace_definition_with_op_kind
+  id: REPLACE-DEF-OPKIND-FIELD-REJECT-001
+  match:
+    name: cir.binop
+    kind: function
+    op_kind: mul
+  action:
+    mode: replace_definition
+    patch: measurement_update_replace_patch

--- a/test/patchir-transform/replace_definition_with_operand_matches_reject.yaml
+++ b/test/patchir-transform/replace_definition_with_operand_matches_reject.yaml
@@ -1,0 +1,21 @@
+apiVersion: patchestry.io/v1
+metadata:
+  name: replace-definition-with-operand-matches-reject
+  kind: PatchSpec
+target:
+  binary: x.bin
+  arch: ARM:LE:32
+libraries:
+- patches/measurement_update_patch.yaml
+patches:
+- name: bogus_replace_definition_with_operand_matches
+  id: REPLACE-DEF-OPMATCH-REJECT-001
+  match:
+    name: measurement_update
+    kind: function
+    operand_matches:
+    - index: 0
+      type: float
+  action:
+    mode: replace_definition
+    patch: measurement_update_replace_patch

--- a/test/patchir-transform/yaml_parser_validation.json
+++ b/test/patchir-transform/yaml_parser_validation.json
@@ -109,4 +109,45 @@
 // RUN: not %patchir-yaml-parser %S/op_kind_unsupported_reject.yaml 2>&1 | \
 // RUN:   %file-check -check-prefix=OPKIND_UNSUPPORTED_ERR %s
 // OPKIND_UNSUPPORTED_ERR: 'op_kind:' is only meaningful for 'cir.binop' and 'cir.cmp'
+//
+// `mode: replace_definition` swaps a matched cir.func's body wholesale.
+// The wrapper inherits the callee's signature 1:1, so every match-site /
+// per-operand field is meaningless. Reject the combinations at parse so
+// a misconfiguration surfaces with a clear hint, not a silent no-op
+// transform (no operation-kind dispatch case exists) or a confusing
+// signature-mismatch failure deep in the pass.
+//
+// Minimal valid spec must parse.
+// RUN: %patchir-yaml-parser %S/replace_definition_valid.yaml 2>&1 | \
+// RUN:   %file-check -check-prefix=OK %s
+//
+// `arguments:` is forbidden — wrapper inherits signature.
+// RUN: not %patchir-yaml-parser %S/replace_definition_with_arguments_reject.yaml 2>&1 | \
+// RUN:   %file-check -check-prefix=REPLACE_DEF_ARGS_ERR %s
+// REPLACE_DEF_ARGS_ERR: replace_definition{{.*}}signature 1:1{{.*}}remove 'arguments:'
+//
+// `match.captures:` is forbidden — captures are bound at match sites.
+// RUN: not %patchir-yaml-parser %S/replace_definition_with_captures_reject.yaml 2>&1 | \
+// RUN:   %file-check -check-prefix=REPLACE_DEF_CAPS_ERR %s
+// REPLACE_DEF_CAPS_ERR: replace_definition{{.*}}match.captures
+//
+// `context:` is forbidden — caller context is meaningless for a callee swap.
+// RUN: not %patchir-yaml-parser %S/replace_definition_with_context_reject.yaml 2>&1 | \
+// RUN:   %file-check -check-prefix=REPLACE_DEF_CONTEXT_ERR %s
+// REPLACE_DEF_CONTEXT_ERR: replace_definition{{.*}}context
+//
+// `kind: operation` is forbidden — replace_definition needs kind: function.
+// RUN: not %patchir-yaml-parser %S/replace_definition_operation_kind_reject.yaml 2>&1 | \
+// RUN:   %file-check -check-prefix=REPLACE_DEF_KIND_ERR %s
+// REPLACE_DEF_KIND_ERR: replace_definition{{.*}}match.kind: function
+//
+// `op_kind:` is forbidden — kinded-generic-op filter is meaningless here.
+// RUN: not %patchir-yaml-parser %S/replace_definition_with_op_kind_reject.yaml 2>&1 | \
+// RUN:   %file-check -check-prefix=REPLACE_DEF_OPKIND_ERR %s
+// REPLACE_DEF_OPKIND_ERR: replace_definition{{.*}}op_kind
+//
+// `operand_matches:` is forbidden — operand filters apply to match sites.
+// RUN: not %patchir-yaml-parser %S/replace_definition_with_operand_matches_reject.yaml 2>&1 | \
+// RUN:   %file-check -check-prefix=REPLACE_DEF_OPMATCH_ERR %s
+// REPLACE_DEF_OPMATCH_ERR: replace_definition{{.*}}operand_matches
 {}

--- a/tools/patchir-cir2llvm/CMakeLists.txt
+++ b/tools/patchir-cir2llvm/CMakeLists.txt
@@ -20,6 +20,8 @@ target_link_libraries(patchir-cir2llvm
         MLIRX86VectorToLLVMIRTranslation
         MLIROpenACCToLLVMIRTranslation
         MLIRContracts
+        LLVMipo
+        LLVMPasses
 )
 
 if(PATCHESTRY_INSTALL)

--- a/tools/patchir-cir2llvm/main.cpp
+++ b/tools/patchir-cir2llvm/main.cpp
@@ -531,6 +531,27 @@ namespace {
         }
         return llvm::success();
     }
+
+    // Strip dead internal-linkage globals (notably the patch FuncOps that
+    // `mode: replace_definition` donates a body from, and any patch funcs
+    // left unused after `inline-patches`). External-linkage symbols are
+    // preserved so caller-visible entry points stay intact.
+    void stripDeadInternalGlobals(llvm::Module &module) {
+        llvm::LoopAnalysisManager lam;
+        llvm::FunctionAnalysisManager fam;
+        llvm::CGSCCAnalysisManager cgam;
+        llvm::ModuleAnalysisManager mam;
+        llvm::PassBuilder pb;
+        pb.registerModuleAnalyses(mam);
+        pb.registerCGSCCAnalyses(cgam);
+        pb.registerFunctionAnalyses(fam);
+        pb.registerLoopAnalyses(lam);
+        pb.crossRegisterProxies(lam, fam, cgam, mam);
+
+        llvm::ModulePassManager mpm;
+        mpm.addPass(llvm::GlobalDCEPass());
+        mpm.run(module, mam);
+    }
 } // namespace
 
 // Main function for the patchir-cir2llvm tool
@@ -578,26 +599,7 @@ int main(int argc, char **argv) {
         return EXIT_FAILURE;
     }
 
-    // Strip dead internal-linkage globals (notably the patch FuncOps that
-    // `mode: replace_definition` donates a body from, and any patch funcs
-    // left unused after `inline-patches`). External-linkage symbols are
-    // preserved so caller-visible entry points stay intact.
-    {
-        llvm::LoopAnalysisManager lam;
-        llvm::FunctionAnalysisManager fam;
-        llvm::CGSCCAnalysisManager cgam;
-        llvm::ModuleAnalysisManager mam;
-        llvm::PassBuilder pb;
-        pb.registerModuleAnalyses(mam);
-        pb.registerCGSCCAnalyses(cgam);
-        pb.registerFunctionAnalyses(fam);
-        pb.registerLoopAnalyses(lam);
-        pb.crossRegisterProxies(lam, fam, cgam, mam);
-
-        llvm::ModulePassManager mpm;
-        mpm.addPass(llvm::GlobalDCEPass());
-        mpm.run(*llvm_module, mam);
-    }
+    stripDeadInternalGlobals(*llvm_module);
 
     // Embed collected string attributes as debug information in LLVM IR
     LOG(INFO) << "Embedding string attributes as debug information\n";

--- a/tools/patchir-cir2llvm/main.cpp
+++ b/tools/patchir-cir2llvm/main.cpp
@@ -15,12 +15,15 @@
 #include <llvm/IR/DIBuilder.h>
 #include <llvm/IR/DebugInfoMetadata.h>
 #include <llvm/IR/Instructions.h>
+#include <llvm/IR/PassManager.h>
+#include <llvm/Passes/PassBuilder.h>
 #include <llvm/Support/CommandLine.h>
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/InitLLVM.h>
 #include <llvm/Support/LogicalResult.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/raw_ostream.h>
+#include <llvm/Transforms/IPO/GlobalDCE.h>
 #include <mlir/Dialect/LLVMIR/Transforms/Passes.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/MLIRContext.h>
@@ -573,6 +576,27 @@ int main(int argc, char **argv) {
     if (!llvm_module) {
         LOG(ERROR) << "Failed to lower cir to llvm\n";
         return EXIT_FAILURE;
+    }
+
+    // Strip dead internal-linkage globals (notably the patch FuncOps that
+    // `mode: replace_definition` donates a body from, and any patch funcs
+    // left unused after `inline-patches`). External-linkage symbols are
+    // preserved so caller-visible entry points stay intact.
+    {
+        llvm::LoopAnalysisManager lam;
+        llvm::FunctionAnalysisManager fam;
+        llvm::CGSCCAnalysisManager cgam;
+        llvm::ModuleAnalysisManager mam;
+        llvm::PassBuilder pb;
+        pb.registerModuleAnalyses(mam);
+        pb.registerCGSCCAnalyses(cgam);
+        pb.registerFunctionAnalyses(fam);
+        pb.registerLoopAnalyses(lam);
+        pb.crossRegisterProxies(lam, fam, cgam, mam);
+
+        llvm::ModulePassManager mpm;
+        mpm.addPass(llvm::GlobalDCEPass());
+        mpm.run(*llvm_module, mam);
     }
 
     // Embed collected string attributes as debug information in LLVM IR


### PR DESCRIPTION
This pull request adds a new replace_definition patch mode that replaces an entire matched function body while preserving its symbol and signature. The PR updates the YAML schema, validation rules, pass implementation, and documentation, and adds tests covering valid and invalid replacement scenarios.