### PR TITLE
fix: function/global symbol collisions from Ghidra global emission 

### DIFF
--- a/lib/patchestry/AST/ASTConsumer.cpp
+++ b/lib/patchestry/AST/ASTConsumer.cpp
@@ -322,9 +322,20 @@ namespace patchestry::ast {
     void PcodeASTConsumer::create_globals(
         clang::ASTContext &ctx, VariableMap &serialized_variables
     ) {
+        const auto &fns = get_program().serialized_functions;
         for (auto &[key, variable] : serialized_variables) {
             if (variable.name.empty() || variable.type.empty()) {
                 continue;
+            }
+
+            // Stale JSON without the #226 producer fix would trip CIRGen's
+            // FuncOp assertion deep in vendor code — refuse loudly here.
+            if (fns.find(key) != fns.end()) {
+                LOG_FATAL("create_globals: global '{0}' at {1} collides with a "
+                          "function entry of the same address — pcode.json is "
+                          "malformed.  Regenerate it with a PcodeSerializer "
+                          "that includes the #226 fix.",
+                          variable.name, key);
             }
 
             auto var_type       = type_builder->GetSerializedType(variable.type);

--- a/lib/patchestry/AST/OperationBuilder.cpp
+++ b/lib/patchestry/AST/OperationBuilder.cpp
@@ -141,15 +141,26 @@ namespace patchestry::ast {
             return {};
         }
 
-        if (!function_builder().global_var_list.get().contains(*vnode.global)) {
-            return {};
+        if (function_builder().global_var_list.get().contains(*vnode.global)) {
+            auto *var_decl = function_builder().global_var_list.get().at(*vnode.global);
+            return clang::DeclRefExpr::Create(
+                ctx, clang::NestedNameSpecifierLoc(), clang::SourceLocation(), var_decl, false,
+                VirtualLoc(ctx), var_decl->getType(), clang::VK_LValue
+            );
         }
 
-        auto *var_decl = function_builder().global_var_list.get().at(*vnode.global);
-        return clang::DeclRefExpr::Create(
-            ctx, clang::NestedNameSpecifierLoc(), clang::SourceLocation(), var_decl, false,
-            VirtualLoc(ctx), var_decl->getType(), clang::VK_LValue
-        );
+        // #226: producer strips globals at function-entry addresses but ops
+        // can still reference them via kind:"global"; resolve as function.
+        if (function_builder().function_list.get().contains(*vnode.global)) {
+            auto *fn_decl = function_builder().function_list.get().at(*vnode.global);
+            auto location = SourceLocation(ctx.getSourceManager(), *vnode.global);
+            return clang::DeclRefExpr::Create(
+                ctx, clang::NestedNameSpecifierLoc(), location, fn_decl, false,
+                location, fn_decl->getType(), clang::VK_PRValue
+            );
+        }
+
+        return {};
     }
 
     clang::Stmt *OpBuilder::create_temporary(

--- a/lib/patchestry/AST/OperationStmt.cpp
+++ b/lib/patchestry/AST/OperationStmt.cpp
@@ -98,9 +98,16 @@ namespace patchestry::ast {
                     ctx, value, false, param_type, VirtualLoc(ctx)
                 );
             } else if (param_type->isPointerType()) {
-                return new (ctx) clang::IntegerLiteral(
-                    ctx, llvm::APInt(ctx.getIntWidth(param_type), 0), param_type,
+                // IntegerLiteral asserts on non-integer types; emit (T*)0 as
+                // CK_NullToPointer over an int-typed 0 instead.  #226.
+                auto *zero = new (ctx) clang::IntegerLiteral(
+                    ctx, llvm::APInt(ctx.getIntWidth(ctx.IntTy), 0), ctx.IntTy,
                     VirtualLoc(ctx)
+                );
+                return clang::ImplicitCastExpr::Create(
+                    ctx, param_type, clang::CK_NullToPointer, zero,
+                    /*BasePath=*/nullptr, clang::VK_PRValue,
+                    clang::FPOptionsOverride()
                 );
             } else if (param_type->isBooleanType()) {
                 return new (ctx)

--- a/scripts/ghidra/util/PcodeSerializer.java
+++ b/scripts/ghidra/util/PcodeSerializer.java
@@ -4459,12 +4459,22 @@ public class PcodeSerializer {
 			writer.endArray();
 		}
 		
-		// Serialize the global variable declarations.
+		// Skip entries at function-entry addresses — emitting both as
+		// function and global trips the lifter's CIRGen FuncOp assertion (#226).
 		void serializeGlobals() throws Exception {
+			FunctionManager fm = currentProgram.getFunctionManager();
+			int emittedGlobals = 0;
+			int skippedFnEntryCollisions = 0;
+
 			for (Map.Entry<Address, HighVariable> entry : seenGlobalsMap.entrySet()) {
 				Address address = entry.getKey();
 				HighVariable globalHighVariable = entry.getValue();
-				
+
+				if (fm.getFunctionAt(address) != null) {
+					skippedFnEntryCollisions++;
+					continue;
+				}
+
 				// Try to get the global's name.
 				String globalVariableName = globalHighVariable.getName();
 				if (globalVariableName == null || (globalVariableName.equals("UNNAMED") && globalHighVariable.getOffset() == -1)) {
@@ -4484,11 +4494,18 @@ public class PcodeSerializer {
 				writer.name("size").value(Integer.toString(globalHighVariable.getSize()));
 				writer.name("type").value(label(globalHighVariable.getDataType()));
 				writer.endObject();
+				emittedGlobals++;
 			}
 
 			for (Map.Entry<Address, Data> entry : seenDataMap.entrySet()) {
 				Address address = entry.getKey();
 				Data datavar = entry.getValue();
+
+				if (fm.getFunctionAt(address) != null) {
+					skippedFnEntryCollisions++;
+					continue;
+				}
+
 				String name = datavar.getDefaultLabelPrefix(null) + "_"
 					+ SymbolUtilities.replaceInvalidChars(datavar.getDefaultValueRepresentation(), false)
 					+ "_" + datavar.getMinAddress().toString();
@@ -4498,11 +4515,12 @@ public class PcodeSerializer {
 				writer.name("size").value(Integer.toString(datavar.getDataType().getLength()));
 				writer.name("type").value(label(datavar.getDataType()));
 				writer.endObject();
-
-
+				emittedGlobals++;
 			}
 
-			System.out.println("Total serialized globals: " + Integer.toString(seenGlobalsMap.size()));
+			System.out.println("Total serialized globals: " + Integer.toString(emittedGlobals)
+				+ " (skipped " + Integer.toString(skippedFnEntryCollisions)
+				+ " function-entry collisions; see #226)");
 		}
 
 		// Don't try to decompile some functions.

--- a/test/ghidra/global_function_addrtaken.c
+++ b/test/ghidra/global_function_addrtaken.c
@@ -1,0 +1,31 @@
+// UNSUPPORTED: system-windows
+// RUN: %cc-x86_64 %s -g -c -o %t.o
+// RUN: %decompile-headless --input %t.o --output %t %ci_output_folder
+// RUN: %file-check -vv --check-prefix=CONTRACT %s --input-file %t
+//
+// #226 contract: a function's address never appears in globals[] under
+// the same name.  Take the address of a local function and confirm the
+// name appears in functions[] only.  Functions: comes before globals:
+// in the JSON layout, so CHECK-NOT after the SAME match catches any
+// globals[] alias.
+//
+// CONTRACT:           "functions":
+// CONTRACT-SAME:      "name":"{{_?leaf_226}}"
+// CONTRACT-NOT:       "name":"{{_?leaf_226}}"
+
+static void leaf_226(int x) {
+    (void)x;
+}
+
+typedef void (*fp_t)(int);
+
+fp_t take_addr_of_leaf_226(void) {
+    return &leaf_226;
+}
+
+int main(int argc, char **argv) {
+    (void)argv;
+    fp_t fp = take_addr_of_leaf_226();
+    fp(argc);
+    return 0;
+}


### PR DESCRIPTION
This pull request fixes symbol collisions caused by PcodeSerializer emitting globals[] entries at function-entry addresses, which produced overlapping names between functions[] and globals[] during lifting.

The fix:

- skips function-entry globals during serialization,
- adds explicit collision diagnostics in ASTConsumer,
- resolves function-address globals through FunctionDecl fallback handling,
- fixes default pointer argument emission to use proper null-pointer casts instead of invalid pointer-typed integer literals.

Together, these changes prevent CIR symbol-table assertion failures and improve robustness when lifting address-taken functions and PLT-related globals.