### PR TITLE
ghidra: add C-source emission helper for patchir-decomp debugging

### DIFF
--- a/scripts/ghidra/PatchestryDecompileCFunction.java
+++ b/scripts/ghidra/PatchestryDecompileCFunction.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2026, Trail of Bits, Inc.
+ *
+ * This source code is licensed in accordance with the terms specified in
+ * the LICENSE file found in the root directory of this source tree.
+ *
+ * PatchestryDecompileCFunction
+ * ----------------------------
+ * Headless Ghidra postscript that decompiles a single function to plain C
+ * source and writes it to the supplied output path. Designed as a debugging
+ * companion to PatchestryDecompileFunctions (which emits P-Code JSON):
+ * when patchir-decomp fails to lift a function, this script lets you see
+ * what Ghidra's own decompiler produced for the same body so you can
+ * compare expectations.
+ *
+ * Usage (headless): single positional arg form, mirrors
+ *   PatchestryDecompileFunctions single mode.
+ *
+ *   postScript PatchestryDecompileCFunction <function-or-address> <output-file>
+ *
+ * `<function-or-address>` accepts: a global function name, a hex address
+ * (e.g. 0x0000f69c), or any address inside a function body — the latter
+ * resolves via getFunctionContaining so op keys from failure logs work
+ * directly.
+ */
+
+import ghidra.app.script.GhidraScript;
+
+import ghidra.app.decompiler.DecompInterface;
+import ghidra.app.decompiler.DecompileOptions;
+import ghidra.app.decompiler.DecompileResults;
+import ghidra.app.decompiler.DecompiledFunction;
+import ghidra.app.decompiler.component.DecompilerUtils;
+
+import ghidra.program.model.address.Address;
+import ghidra.program.model.address.AddressFactory;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.listing.FunctionManager;
+import ghidra.program.model.listing.Program;
+import ghidra.program.model.symbol.Symbol;
+import ghidra.program.model.symbol.SymbolTable;
+import ghidra.program.model.symbol.SymbolType;
+
+import java.io.BufferedWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class PatchestryDecompileCFunction extends GhidraScript {
+
+    // Matches the timeout used by PcodeSerializer for parity with the
+    // P-Code JSON path. 60 s is plenty for any single function.
+    private static final int DECOMPILATION_TIMEOUT_SECONDS = 60;
+
+    // Test setup hook (parity with sibling scripts) — keep package-private.
+    protected void setProgram(Program program) throws RuntimeException {
+        if (program != null && getCurrentProgram() == null) {
+            currentProgram = program;
+        } else {
+            currentProgram = getCurrentProgram();
+        }
+    }
+
+    private String getLanguageID() {
+        if (currentProgram.getLanguage() == null
+                || currentProgram.getLanguage().getLanguageDescription() == null) {
+            return "unknown";
+        }
+        return currentProgram.getLanguage().getLanguageDescription().getLanguageID().toString();
+    }
+
+    private DecompInterface openDecompiler() throws Exception {
+        if (currentProgram == null) {
+            throw new IllegalStateException(
+                "Unable to initialize decompiler: invalid current program.");
+        }
+        DecompileOptions options =
+            DecompilerUtils.getDecompileOptions(state.getTool(), currentProgram);
+        DecompInterface decompiler = new DecompInterface();
+        decompiler.setOptions(options);
+        // Enable C-code emission — this is the whole point of this script
+        // and is the only material difference from
+        // PatchestryDecompileFunctions.getDecompilerInterface().
+        decompiler.toggleCCode(true);
+        decompiler.toggleSyntaxTree(true);
+        decompiler.toggleJumpLoads(true);
+        decompiler.toggleParamMeasures(false);
+        decompiler.setSimplificationStyle("decompile");
+        if (!decompiler.openProgram(currentProgram)) {
+            throw new IllegalStateException(
+                "Unable to initialize decompiler: " + decompiler.getLastMessage());
+        }
+        return decompiler;
+    }
+
+    // Multi-strategy lookup: global name → hex address → enclosing-function
+    // resolution → symbol/label → namespace-qualified name. Mirrors the
+    // chain in PatchestryDecompileFunctions.resolveFunction but additionally
+    // honours getFunctionContaining so any address inside the body (e.g.
+    // an op key like ram:0000f728) resolves to the enclosing function.
+    Function resolveFunction(String name) throws Exception {
+        FunctionManager fm = currentProgram.getFunctionManager();
+        SymbolTable symTable = currentProgram.getSymbolTable();
+        AddressFactory addrFactory = currentProgram.getAddressFactory();
+
+        // 1. Global name lookup.
+        for (Function fn : currentProgram.getListing().getGlobalFunctions(name)) {
+            return fn;
+        }
+
+        // 2. Address lookup. Accepts 0x-prefixed hex or bare hex.
+        Address addr = null;
+        try {
+            String addrStr = name;
+            if (addrStr.startsWith("0x") || addrStr.startsWith("0X")) {
+                addrStr = addrStr.substring(2);
+            }
+            addr = addrFactory.getDefaultAddressSpace().getAddress(addrStr);
+        } catch (Exception ignored) {
+            // Not an address; fall through.
+        }
+        if (addr != null) {
+            Function fn = fm.getFunctionAt(addr);
+            if (fn != null) {
+                return fn;
+            }
+            fn = fm.getFunctionContaining(addr);
+            if (fn != null) {
+                println("Resolved '" + name + "' to enclosing function: "
+                    + fn.getName(true) + " @ " + fn.getEntryPoint());
+                return fn;
+            }
+        }
+
+        // 3. Symbol/label lookup (mangled C++ names attached as labels).
+        for (Symbol sym : symTable.getSymbols(name)) {
+            Function fn = fm.getFunctionAt(sym.getAddress());
+            if (fn != null) {
+                return fn;
+            }
+        }
+
+        // 4. Namespace-qualified name (e.g. Foo::Bar::method).
+        if (name.contains("::")) {
+            String[] parts = name.split("::");
+            String localName = parts[parts.length - 1];
+            for (Symbol sym : symTable.getSymbols(localName)) {
+                if (sym.getSymbolType() == SymbolType.FUNCTION
+                        && sym.getName(true).equals(name)) {
+                    Function fn = fm.getFunctionAt(sym.getAddress());
+                    if (fn != null) {
+                        return fn;
+                    }
+                }
+            }
+        }
+
+        throw new IllegalArgumentException(
+            "Function not found: '" + name + "'. Tried: global name, address, "
+            + "enclosing-function, symbol/label, namespace path.");
+    }
+
+    private String renderHeader(Function fn) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("// function:  ").append(fn.getName(true)).append('\n');
+        sb.append("// entry:     ").append(fn.getEntryPoint()).append('\n');
+        sb.append("// signature: ").append(fn.getSignature()).append('\n');
+        sb.append("// arch:      ").append(getLanguageID()).append('\n');
+        sb.append("// (decompiled by Ghidra DecompInterface for debugging)\n");
+        return sb.toString();
+    }
+
+    void runHeadless() throws Exception {
+        String[] args = getScriptArgs();
+        if (args.length < 2) {
+            throw new IllegalArgumentException(
+                "Insufficient arguments. Expected: <function-or-address> <output-file>");
+        }
+        String target = args[0];
+        Path outputPath = Path.of(args[1]);
+
+        Function fn = resolveFunction(target);
+        println("Decompiling " + fn.getName(true) + " @ " + fn.getEntryPoint()
+            + " -> " + outputPath);
+
+        DecompInterface decompiler = openDecompiler();
+        try {
+            DecompileResults results = decompiler.decompileFunction(
+                fn, DECOMPILATION_TIMEOUT_SECONDS, monitor);
+            if (results == null || !results.decompileCompleted()) {
+                String reason = results == null
+                    ? "<null results>" : results.getErrorMessage();
+                throw new RuntimeException(
+                    "Decompilation did not complete for "
+                    + fn.getName(true) + ": " + reason);
+            }
+            DecompiledFunction decompiled = results.getDecompiledFunction();
+            String cSource = decompiled == null ? null : decompiled.getC();
+            if (cSource == null) {
+                throw new RuntimeException(
+                    "Ghidra produced no C output for " + fn.getName(true));
+            }
+            try (BufferedWriter writer = Files.newBufferedWriter(outputPath)) {
+                writer.write(renderHeader(fn));
+                writer.write(cSource);
+                if (!cSource.endsWith("\n")) {
+                    writer.write('\n');
+                }
+            }
+        } finally {
+            decompiler.dispose();
+        }
+    }
+
+    @Override
+    public void run() throws Exception {
+        // Headless-only. The script is meant to be invoked via the
+        // decompile-headless.sh wrapper; GUI mode would just need an
+        // askString prompt, which we intentionally skip to keep the
+        // entrypoint minimal.
+        runHeadless();
+    }
+}

--- a/scripts/ghidra/PatchestryDecompileCFunction.java
+++ b/scripts/ghidra/PatchestryDecompileCFunction.java
@@ -13,6 +13,10 @@
  * what Ghidra's own decompiler produced for the same body so you can
  * compare expectations.
  *
+ * The output is preceded by C declarations for every type the function
+ * references (return type, parameters, locals, and their transitive
+ * dependencies), so the emitted .c is self-contained for inspection.
+ *
  * Usage (headless): single positional arg form, mirrors
  *   PatchestryDecompileFunctions single mode.
  *
@@ -34,9 +38,15 @@ import ghidra.app.decompiler.component.DecompilerUtils;
 
 import ghidra.program.model.address.Address;
 import ghidra.program.model.address.AddressFactory;
+import ghidra.program.model.data.DataType;
+import ghidra.program.model.data.DataTypeWriter;
 import ghidra.program.model.listing.Function;
 import ghidra.program.model.listing.FunctionManager;
+import ghidra.program.model.listing.Parameter;
 import ghidra.program.model.listing.Program;
+import ghidra.program.model.pcode.HighFunction;
+import ghidra.program.model.pcode.HighSymbol;
+import ghidra.program.model.pcode.LocalSymbolMap;
 import ghidra.program.model.symbol.Symbol;
 import ghidra.program.model.symbol.SymbolTable;
 import ghidra.program.model.symbol.SymbolType;
@@ -44,6 +54,11 @@ import ghidra.program.model.symbol.SymbolType;
 import java.io.BufferedWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 public class PatchestryDecompileCFunction extends GhidraScript {
 
@@ -159,13 +174,79 @@ public class PatchestryDecompileCFunction extends GhidraScript {
             + "enclosing-function, symbol/label, namespace path.");
     }
 
+    // Collect the data types the function references at the surface: its
+    // return type, parameters, and decompiler-recovered locals. DataTypeWriter
+    // expands these transitively (struct fields, pointee types, typedef
+    // targets), so seeding it with the top-level types is sufficient.
+    private List<DataType> collectReferencedTypes(Function fn, DecompileResults results) {
+        // LinkedHashSet: dedup while keeping a stable, reproducible order.
+        Set<DataType> seeds = new LinkedHashSet<>();
+
+        DataType returnType = fn.getReturnType();
+        if (returnType != null) {
+            seeds.add(returnType);
+        }
+        for (Parameter param : fn.getParameters()) {
+            DataType paramType = param.getDataType();
+            if (paramType != null) {
+                seeds.add(paramType);
+            }
+        }
+
+        // Locals come from the decompiler's HighFunction, which is available
+        // because openDecompiler() enables toggleSyntaxTree(true). It may
+        // still be null if the syntax tree failed to build — emit the body
+        // anyway in that case.
+        HighFunction highFn = results.getHighFunction();
+        if (highFn != null) {
+            LocalSymbolMap localSymbols = highFn.getLocalSymbolMap();
+            Iterator<HighSymbol> it = localSymbols.getSymbols();
+            while (it.hasNext()) {
+                DataType localType = it.next().getDataType();
+                if (localType != null) {
+                    seeds.add(localType);
+                }
+            }
+        }
+
+        return new ArrayList<>(seeds);
+    }
+
+    // Emit C declarations for `types` (and their transitive dependencies) as a
+    // preamble ahead of the function body. DataTypeWriter orders dependencies
+    // before dependents and flushes the writer itself; it never closes the
+    // underlying Writer, so the caller's try-with-resources keeps ownership.
+    // Type emission is best-effort: a failure here must not suppress the C
+    // body, which is the primary debugging artifact.
+    private void writeTypeDefinitions(BufferedWriter writer, List<DataType> types) {
+        if (types.isEmpty()) {
+            return;
+        }
+        try {
+            // Write the marker before constructing DataTypeWriter: its
+            // constructor immediately emits the standard builtin typedefs,
+            // so the marker must precede it to head the whole type block.
+            writer.write("// --- referenced type definitions ---\n");
+            DataTypeWriter typeWriter =
+                new DataTypeWriter(currentProgram.getDataTypeManager(), writer);
+            // throwExceptionOnInvalidType=false: skip a malformed type rather
+            // than aborting the whole preamble.
+            typeWriter.write(types, monitor, false);
+            writer.write('\n');
+        } catch (Exception e) {
+            println("Warning: failed to emit type definitions for "
+                + "decompile-c output: " + e.getMessage());
+        }
+    }
+
     private String renderHeader(Function fn) {
         StringBuilder sb = new StringBuilder();
         sb.append("// function:  ").append(fn.getName(true)).append('\n');
         sb.append("// entry:     ").append(fn.getEntryPoint()).append('\n');
         sb.append("// signature: ").append(fn.getSignature()).append('\n');
         sb.append("// arch:      ").append(getLanguageID()).append('\n');
-        sb.append("// (decompiled by Ghidra DecompInterface for debugging)\n");
+        sb.append("// (decompiled by Ghidra DecompInterface for debugging;\n");
+        sb.append("//  referenced type definitions are emitted below)\n");
         return sb.toString();
     }
 
@@ -199,8 +280,11 @@ public class PatchestryDecompileCFunction extends GhidraScript {
                 throw new RuntimeException(
                     "Ghidra produced no C output for " + fn.getName(true));
             }
+            List<DataType> referencedTypes = collectReferencedTypes(fn, results);
             try (BufferedWriter writer = Files.newBufferedWriter(outputPath)) {
                 writer.write(renderHeader(fn));
+                writer.write('\n');
+                writeTypeDefinitions(writer, referencedTypes);
                 writer.write(cSource);
                 if (!cSource.endsWith("\n")) {
                     writer.write('\n');

--- a/scripts/ghidra/PatchestryDecompileCFunction.java
+++ b/scripts/ghidra/PatchestryDecompileCFunction.java
@@ -219,9 +219,6 @@ public class PatchestryDecompileCFunction extends GhidraScript {
     // Type emission is best-effort: a failure here must not suppress the C
     // body, which is the primary debugging artifact.
     private void writeTypeDefinitions(BufferedWriter writer, List<DataType> types) {
-        if (types.isEmpty()) {
-            return;
-        }
         try {
             // Write the marker before constructing DataTypeWriter: its
             // constructor immediately emits the standard builtin typedefs,

--- a/scripts/ghidra/PatchestryDecompileCFunction.java
+++ b/scripts/ghidra/PatchestryDecompileCFunction.java
@@ -129,7 +129,7 @@ public class PatchestryDecompileCFunction extends GhidraScript {
             if (addrStr.startsWith("0x") || addrStr.startsWith("0X")) {
                 addrStr = addrStr.substring(2);
             }
-            addr = addrFactory.getDefaultAddressSpace().getAddress(addrStr);
+            addr = addrFactory.getAddress(addrStr);
         } catch (Exception ignored) {
             // Not an address; fall through.
         }

--- a/scripts/ghidra/decompile-entrypoint.sh
+++ b/scripts/ghidra/decompile-entrypoint.sh
@@ -342,10 +342,12 @@ function run_decompile_c {
 
     # Ghidra's analyzeHeadless exits 0 even when a postScript throws, so the
     # $? check below is necessary but not sufficient. PatchestryDecompileCFunction
-    # writes the output file only on success; remove any stale or pre-created
-    # (empty) file first so that a non-empty file afterwards is a reliable
-    # success signal.
-    rm -f "${OUTPUT_FILE}"
+    # writes the output file only on success; truncate any stale or pre-created
+    # file first so that a non-empty file afterwards is a reliable success
+    # signal. Truncation (not unlink) is required: OUTPUT_FILE may be a Docker
+    # bind-mounted single file, which cannot be removed (EBUSY) but can be
+    # truncated in place.
+    : > "${OUTPUT_FILE}" 2>/dev/null || true
 
     ${GHIDRA_HEADLESS} ${GHIDRA_PROJECTS} patchestry-decompilation \
         -readOnly \

--- a/scripts/ghidra/decompile-entrypoint.sh
+++ b/scripts/ghidra/decompile-entrypoint.sh
@@ -340,6 +340,13 @@ function run_decompile_c {
         guess_architecture="-processor ${ARCHITECTURE}"
     fi
 
+    # Ghidra's analyzeHeadless exits 0 even when a postScript throws, so the
+    # $? check below is necessary but not sufficient. PatchestryDecompileCFunction
+    # writes the output file only on success; remove any stale or pre-created
+    # (empty) file first so that a non-empty file afterwards is a reliable
+    # success signal.
+    rm -f "${OUTPUT_FILE}"
+
     ${GHIDRA_HEADLESS} ${GHIDRA_PROJECTS} patchestry-decompilation \
         -readOnly \
         -deleteProject \
@@ -349,9 +356,14 @@ function run_decompile_c {
         -postScript "PatchestryDecompileCFunction" \
         ${FUNCTION_NAME} \
         ${OUTPUT_FILE}
+    local status=$?
 
-    if [ $? -ne 0 ]; then
+    if [ $status -ne 0 ]; then
         die "Decompilation to C failed"
+    fi
+
+    if [ ! -s "${OUTPUT_FILE}" ]; then
+        die "Decompilation to C produced no output; PatchestryDecompileCFunction failed (see Ghidra log above)."
     fi
 }
 

--- a/scripts/ghidra/decompile-entrypoint.sh
+++ b/scripts/ghidra/decompile-entrypoint.sh
@@ -35,9 +35,14 @@ Options:
     - list-functions: List all functions in the binary.
     - decompile: Decompile a single function.
     - decompile-all: Decompile all functions in the binary.
+    - decompile-c: Emit Ghidra's plain-C decompilation for a single function
+      (debugging companion to 'decompile'; output is a .c file, not JSON).
 
   --function <FUNCTION_NAME>
-      Decompile a specific function to extract pcode. This option is required when using the 'decompile' command.
+      Decompile a specific function to extract pcode. This option is required
+      when using the 'decompile' or 'decompile-c' command. For 'decompile-c'
+      this may also be an address (e.g. 0x0000f69c) — including any address
+      inside the function body, which will resolve to the enclosing function.
 
   --output <OUTPUT_FILE>
       Specify the output file to write the results.
@@ -163,6 +168,10 @@ function validate_args {
 
     if [[ "$COMMAND" == "decompile" && -z "$FUNCTION_NAME" ]]; then
         die "--function is required when --command decompile is specified."
+    fi
+
+    if [[ "$COMMAND" == "decompile-c" && -z "$FUNCTION_NAME" ]]; then
+        die "--function is required when --command decompile-c is specified."
     fi
 
     if [[ -z "$OUTPUT_FILE" ]]; then
@@ -321,6 +330,31 @@ function run_list_functions {
     fi
 }
 
+# Run the C-source companion script. Mirrors run_decompile_single but
+# targets PatchestryDecompileCFunction, which writes plain C (not JSON).
+function run_decompile_c {
+    echo "Running Ghidra headless script to decompile '$FUNCTION_NAME' to C..."
+
+    local guess_architecture=""
+    if [[ -n "$ARCHITECTURE" ]]; then
+        guess_architecture="-processor ${ARCHITECTURE}"
+    fi
+
+    ${GHIDRA_HEADLESS} ${GHIDRA_PROJECTS} patchestry-decompilation \
+        -readOnly \
+        -deleteProject \
+        -import ${INPUT_FILE} \
+        ${guess_architecture}\
+        -scriptPath ${GHIDRA_SCRIPTS} \
+        -postScript "PatchestryDecompileCFunction" \
+        ${FUNCTION_NAME} \
+        ${OUTPUT_FILE}
+
+    if [ $? -ne 0 ]; then
+        die "Decompilation to C failed"
+    fi
+}
+
 # Function to run Ghidra headless script for decompiling
 function run_decompile_single {
     echo "Running Ghidra headless script to decompile the single function '$FUNCTION_NAME'..."
@@ -414,6 +448,9 @@ function main {
             ;;
         decompile-all)
             run_decompile_all
+            ;;
+        decompile-c)
+            run_decompile_c
             ;;
         *)
             die "Unknown command '$COMMAND'."

--- a/scripts/ghidra/decompile-headless.dockerfile
+++ b/scripts/ghidra/decompile-headless.dockerfile
@@ -72,6 +72,7 @@ COPY --chown=user:user domain/ domain/
 COPY --chown=user:user util/ util/
 COPY --chown=user:user PatchestryDecompileFunctions.java .
 COPY --chown=user:user PatchestryListFunctions.java .
+COPY --chown=user:user PatchestryDecompileCFunction.java .
 COPY --chown=user:user build.gradle .
 # since we have a class structure, we need to externally trigger the Ghidra build
 RUN gradle build

--- a/scripts/ghidra/decompile-headless.sh
+++ b/scripts/ghidra/decompile-headless.sh
@@ -216,17 +216,26 @@ validate_paths() {
     fi
 }
 
+# Assemble the `docker run` invocation in the DOCKER_CMD array rather than a
+# string. The array is executed directly as "${DOCKER_CMD[@]}", so no element
+# is ever re-parsed by a shell — a FUNCTION_NAME or path containing shell
+# metacharacters ($(...), backticks, ';') is passed through as inert data
+# instead of being evaluated. (Building a string and running it with `eval`
+# would execute such metacharacters on the caller's machine.)
 build_docker_command() {
-    CI=""
+    DOCKER_CMD=(docker run --rm)
+
     if [ -n "$CI_OUTPUT_FOLDER" ]; then
         # Translate to host path for Docker-in-Docker scenarios
-        local HOST_CI_OUTPUT_FOLDER=$(translate_to_host_path "$CI_OUTPUT_FOLDER")
+        local HOST_CI_OUTPUT_FOLDER
+        HOST_CI_OUTPUT_FOLDER=$(translate_to_host_path "$CI_OUTPUT_FOLDER")
         # Make directory writable by container user (for DinD scenarios)
         chmod 1777 "$CI_OUTPUT_FOLDER" 2>/dev/null || true
-        CI="-v $HOST_CI_OUTPUT_FOLDER:/mnt/output:rw"
+        DOCKER_CMD+=(-v "$HOST_CI_OUTPUT_FOLDER:/mnt/output:rw")
     fi
 
-    local ARGS=
+    # Build the entrypoint script arguments (command mode, function, flags).
+    local SCRIPT_ARGS=()
     if [ -n "$C_SOURCE" ]; then
         if [ -z "$FUNCTION_NAME" ]; then
             echo "Error: --c-source requires --function"
@@ -243,44 +252,47 @@ build_docker_command() {
                 *) FUNCTION_NAME="_$FUNCTION_NAME" ;;
             esac
         fi
-        ARGS="--command decompile-c --function \"$FUNCTION_NAME\" $ARGS"
-    elif [  -n "$LIST_FUNCTIONS" ]; then
-        ARGS="--command list-functions $ARGS"
+        SCRIPT_ARGS=(--command decompile-c --function "$FUNCTION_NAME")
+    elif [ -n "$LIST_FUNCTIONS" ]; then
+        SCRIPT_ARGS=(--command list-functions)
     elif [ -n "$FUNCTION_NAME" ]; then
         if file "$INPUT_PATH" | grep -q "Mach-O"; then
             FUNCTION_NAME="_$FUNCTION_NAME"
         fi
-        ARGS="--command decompile --function \"$FUNCTION_NAME\" $ARGS"
+        SCRIPT_ARGS=(--command decompile --function "$FUNCTION_NAME")
     else
-        ARGS="--command decompile-all $ARGS"
+        SCRIPT_ARGS=(--command decompile-all)
     fi
 
-    # Append sanitizer flags (quoted individually so values survive eval).
-    for extra in "${SANITIZER_ARGS[@]}"; do
-        ARGS="$ARGS \"$extra\""
-    done
+    # Sanitizer flags are forwarded verbatim.
+    SCRIPT_ARGS+=("${SANITIZER_ARGS[@]}")
 
     if [ -n "$CI_OUTPUT_FOLDER" ]; then
-        INPUT_PATH=$(basename "$INPUT_PATH")
-        OUTPUT_PATH=$(basename "$OUTPUT_PATH")
-        RUN="docker run --rm \
-            $CI \
-            trailofbits/patchestry-decompilation:latest \
-            --input /mnt/output/$INPUT_PATH \
-            $ARGS --output /mnt/output/$OUTPUT_PATH"
-        echo "CMD: ${RUN}"
-
+        local input_base output_base
+        input_base=$(basename "$INPUT_PATH")
+        output_base=$(basename "$OUTPUT_PATH")
+        DOCKER_CMD+=(
+            trailofbits/patchestry-decompilation:latest
+            --input "/mnt/output/$input_base"
+            "${SCRIPT_ARGS[@]}"
+            --output "/mnt/output/$output_base"
+        )
+        echo "CMD: ${DOCKER_CMD[*]}"
     else
-        RUN="docker run --rm \
-            -v \"$INPUT_PATH:/input.o\" \
-            -v \"$OUTPUT_PATH:/output.json\" \
-            trailofbits/patchestry-decompilation:latest"
+        DOCKER_CMD+=(
+            -v "$INPUT_PATH:/input.o"
+            -v "$OUTPUT_PATH:/output.json"
+            trailofbits/patchestry-decompilation:latest
+        )
 
         if [ "$INTERACTIVE" = true ]; then
-            RUN="${RUN} --entrypoint /bin/bash"
+            DOCKER_CMD+=(--entrypoint /bin/bash)
         else
-            RUN="${RUN} --input /input.o \
-                ${ARGS} --output /output.json"
+            DOCKER_CMD+=(
+                --input /input.o
+                "${SCRIPT_ARGS[@]}"
+                --output /output.json
+            )
         fi
     fi
 }
@@ -305,10 +317,10 @@ main() {
 
     if [ "$VERBOSE" = true ]; then
         echo "Running Docker container with the following command:"
-        echo "$RUN"
+        echo "${DOCKER_CMD[*]}"
     fi
 
-    eval "$RUN"
+    "${DOCKER_CMD[@]}"
 }
 
 main "$@"

--- a/scripts/ghidra/decompile-headless.sh
+++ b/scripts/ghidra/decompile-headless.sh
@@ -232,8 +232,16 @@ build_docker_command() {
             echo "Error: --c-source requires --function"
             exit 1
         fi
+        # --c-source also accepts an address (0x...) or a Ghidra auto-name
+        # (FUN_...) in addition to a real C symbol. Only a C symbol gets the
+        # Mach-O leading-underscore treatment; addresses and FUN_ names must be
+        # passed through verbatim so PatchestryDecompileCFunction can resolve
+        # them (prefixing them with '_' yields an unresolvable target).
         if file "$INPUT_PATH" | grep -q "Mach-O"; then
-            FUNCTION_NAME="_$FUNCTION_NAME"
+            case "$FUNCTION_NAME" in
+                0x*|0X*|FUN_*) ;;
+                *) FUNCTION_NAME="_$FUNCTION_NAME" ;;
+            esac
         fi
         ARGS="--command decompile-c --function \"$FUNCTION_NAME\" $ARGS"
     elif [  -n "$LIST_FUNCTIONS" ]; then

--- a/scripts/ghidra/decompile-headless.sh
+++ b/scripts/ghidra/decompile-headless.sh
@@ -14,7 +14,14 @@ Options:
   -h, --help                           Show this help message and exit
   -i, --input                          Path to the input file
   -f, --function                       Name of the function to decompile
+                                       (with --c-source, may also be an
+                                       address e.g. 0x0000f69c, including
+                                       any address inside the function body)
   -l, --list-functions                 List all functions from input file
+      --c-source                       Emit Ghidra's plain-C decompilation
+                                       for the function selected by --function
+                                       (debugging aid; output is a .c file,
+                                       not JSON). Requires --function.
   -o, --output                         Path to the output file where results will be saved
   -v, --verbose                        Enable verbose output
   -t, --interactive                    Start Docker container in interactive mode
@@ -42,6 +49,8 @@ Examples:
   ./decompile-headless.sh --input /path/to/file --list-functions --output /path/to/output.json // List all functions from binary
   ./decompile-headless.sh --input /path/to/file --function bl_usb__send_message \\
       --output /tmp/out.json --sanitize-extraout
+  ./decompile-headless.sh --input /path/to/file --c-source --function FUN_0000f69c \\
+      --output /tmp/FUN_0000f69c.c // Ghidra C decompilation of one function
 EOF
 }
 
@@ -76,6 +85,10 @@ parse_args() {
                 ;;
             -l|--list-functions)
                 LIST_FUNCTIONS="true"
+                shift
+                ;;
+            --c-source)
+                C_SOURCE="true"
                 shift
                 ;;
             -o|--output)
@@ -214,7 +227,16 @@ build_docker_command() {
     fi
 
     local ARGS=
-    if [  -n "$LIST_FUNCTIONS" ]; then
+    if [ -n "$C_SOURCE" ]; then
+        if [ -z "$FUNCTION_NAME" ]; then
+            echo "Error: --c-source requires --function"
+            exit 1
+        fi
+        if file "$INPUT_PATH" | grep -q "Mach-O"; then
+            FUNCTION_NAME="_$FUNCTION_NAME"
+        fi
+        ARGS="--command decompile-c --function \"$FUNCTION_NAME\" $ARGS"
+    elif [  -n "$LIST_FUNCTIONS" ]; then
         ARGS="--command list-functions $ARGS"
     elif [ -n "$FUNCTION_NAME" ]; then
         if file "$INPUT_PATH" | grep -q "Mach-O"; then


### PR DESCRIPTION
This pull request adds a debugging companion script to PatchestryDecompileFunctions that emits Ghidra’s native decompiled C output for a target function. This helps compare Ghidra’s recovered source against patchir-decomp output when lifting failures occur.

```
bash ./scripts/ghidra/decompile-headless.sh --c-source \
    --input binary --function FUN_0000f69c --output out.c --ci dir
```