### PR TITLE
decomp: refactor structured AST to vector-based SNode representation

### DIFF
--- a/include/patchestry/AST/CFGStructure.hpp
+++ b/include/patchestry/AST/CFGStructure.hpp
@@ -106,11 +106,12 @@ namespace patchestry::ast {
         // Helpers
         // ---------------------------------------------------------------
 
-        /// Wrap a single CNode's stmts + label in an SBlock (+ optional SLabel).
+        /// Spill a single CNode's stmts into SStmt siblings, optionally
+        /// wrapped in an SLabel if the node has a label.
         /// When \p include_terminal is false the node's terminal stmt (goto /
         /// if-goto) is omitted — used for non-tail nodes in a sequential merge
         /// where the edge is absorbed by the merge.
-        /// Returns a single-element sequence (or the node's existing
+        /// Returns the resulting SNode sequence (or the node's existing
         /// structured sequence if it was already structured).
         std::vector< SNode * > BuildLeafSNode(size_t id,
                                               bool include_terminal = true);
@@ -133,8 +134,8 @@ namespace patchestry::ast {
     };
 
     /// Eliminate gotos whose target label immediately follows in the
-    /// same SSeq.  Chases through SLabel→SSeq→SBlock nesting to find
-    /// deeply buried gotos (DeepTrailingStmt pattern).
+    /// same sibling sequence.  Chases through SLabel→SStmt nesting to
+    /// find deeply buried gotos (DeepTrailingStmt pattern).
     bool EliminateGotoToNextLabel(std::vector< SNode * > &root,
                                   SNodeFactory &factory,
                                   clang::ASTContext &ctx);
@@ -171,11 +172,11 @@ namespace patchestry::ast {
     bool ConvertGotoToBreakContinue(std::vector< SNode * > &root,
                                     SNodeFactory &factory);
 
-    /// Replace goto-to-return: when a trailing clang::GotoStmt in an SBlock
+    /// Replace goto-to-return: when an SStmt holding a clang::GotoStmt
     /// (or an SGoto SNode) targets a label whose body ends with a
     /// clang::ReturnStmt, replace the goto with the label's return stmts.
-    /// Also handles non-trailing gotos inside clang::IfStmt arms within
-    /// SBlocks — the most common residual pattern.
+    /// Also handles gotos inside clang::IfStmt arms held by SStmt nodes
+    /// — the most common residual pattern.
     /// Dead labels are cleaned up by a subsequent InlineResidualGotos pass.
     ///
     /// Returns true if any replacement was performed.

--- a/include/patchestry/AST/CFGStructure.hpp
+++ b/include/patchestry/AST/CFGStructure.hpp
@@ -92,7 +92,8 @@ namespace patchestry::ast {
 
         /// Wrap child SNode with node's prior content (structured or stmts)
         /// and label.  Used by all if/if-else/if-return rules.
-        SNode *WrapWithPriorContent(size_t id, SNode *child);
+        /// Returns the resulting SNode sequence.
+        std::vector< SNode * > WrapWithPriorContent(size_t id, SNode *child);
 
         /// Check if node d is dominated by node root via idom_ chain.
         bool IsDominatedBy(size_t d, size_t root) const;
@@ -109,16 +110,20 @@ namespace patchestry::ast {
         /// When \p include_terminal is false the node's terminal stmt (goto /
         /// if-goto) is omitted — used for non-tail nodes in a sequential merge
         /// where the edge is absorbed by the merge.
-        SNode *BuildLeafSNode(size_t id, bool include_terminal = true);
+        /// Returns a single-element sequence (or the node's existing
+        /// structured sequence if it was already structured).
+        std::vector< SNode * > BuildLeafSNode(size_t id,
+                                              bool include_terminal = true);
 
-        /// Build an SSeq from multiple node ids (each wrapped via BuildLeafSNode).
-        SNode *BuildBodySNode(const std::vector<size_t> &ids);
+        /// Build a sequence from multiple node ids (each via BuildLeafSNode).
+        std::vector< SNode * > BuildBodySNode(const std::vector<size_t> &ids);
 
-        /// Build the body SNode for a loop, excluding the header.
+        /// Build the body SNode sequence for a loop, excluding the header.
         /// Interior node terminals are stripped (edges absorbed by loop).
         /// Conditional interior nodes with exits outside the body get
         /// an if-goto to preserve the exit path.
-        SNode *BuildLoopBodySNode(const std::vector<size_t> &body,
+        std::vector< SNode * > BuildLoopBodySNode(
+                                  const std::vector<size_t> &body,
                                   size_t header_id,
                                   const std::unordered_set<size_t> &bodyset);
 
@@ -130,19 +135,21 @@ namespace patchestry::ast {
     /// Eliminate gotos whose target label immediately follows in the
     /// same SSeq.  Chases through SLabel→SSeq→SBlock nesting to find
     /// deeply buried gotos (DeepTrailingStmt pattern).
-    bool EliminateGotoToNextLabel(SNode *root, SNodeFactory &factory,
+    bool EliminateGotoToNextLabel(std::vector< SNode * > &root,
+                                  SNodeFactory &factory,
                                   clang::ASTContext &ctx);
 
     /// Absorb unreferenced SLabel siblings after if-then (no else) into
     /// the else branch.  Prevents spurious fallthrough from the false path
     /// into code that was goto-only in the original CFG.
-    bool AbsorbFallthroughIntoElse(SNode *root, SNodeFactory &factory);
+    bool AbsorbFallthroughIntoElse(std::vector< SNode * > &root,
+                                   SNodeFactory &factory);
 
     /// Convert if(cond) goto L; stmts; L: patterns into if(!cond) { stmts }
     /// within SSeq nodes.  Only fires when label L has a single goto
     /// reference and no intermediate SLabel nodes exist between the goto
     /// and its target.  Recurses into all nested SNode bodies.
-    bool ScopeifyIfGotos(SNode *root, SNodeFactory &factory,
+    bool ScopeifyIfGotos(std::vector< SNode * > &root, SNodeFactory &factory,
                          clang::ASTContext &ctx);
 
     /// Post-structuring cleanup: inline residual goto-to-label pairs.
@@ -154,14 +161,15 @@ namespace patchestry::ast {
     /// from structuring.
     ///
     /// Returns true if any inlining was performed.
-    bool InlineResidualGotos(SNode *root, SNodeFactory &factory);
+    bool InlineResidualGotos(std::vector< SNode * > &root, SNodeFactory &factory);
 
     /// Replace goto-to-break/continue: when a trailing clang::GotoStmt or
     /// SGoto targets an enclosing loop's exit label (→ break) or header
     /// label (→ continue), replace it with the structured equivalent.
     ///
     /// Returns true if any replacement was performed.
-    bool ConvertGotoToBreakContinue(SNode *root, SNodeFactory &factory);
+    bool ConvertGotoToBreakContinue(std::vector< SNode * > &root,
+                                    SNodeFactory &factory);
 
     /// Replace goto-to-return: when a trailing clang::GotoStmt in an SBlock
     /// (or an SGoto SNode) targets a label whose body ends with a
@@ -171,13 +179,14 @@ namespace patchestry::ast {
     /// Dead labels are cleaned up by a subsequent InlineResidualGotos pass.
     ///
     /// Returns true if any replacement was performed.
-    bool ConvertGotoToReturn(SNode *root, SNodeFactory &factory,
+    bool ConvertGotoToReturn(std::vector< SNode * > &root, SNodeFactory &factory,
                              clang::ASTContext &ctx);
 
     /// Remove SLabel nodes from SSeq whose label has zero references
     /// (no SGoto and no clang::GotoStmt targets it).  The label's body
     /// is dropped — it is dead code reachable only via the removed label.
-    bool RemoveUnreferencedLabels(SNode *root, SNodeFactory &factory);
+    bool RemoveUnreferencedLabels(std::vector< SNode * > &root,
+                                  SNodeFactory &factory);
 
     /// Duplicate small, side-effect-contained label targets into switch
     /// case arms that end in `SGoto L`, making the case bodies goto-free.
@@ -187,7 +196,8 @@ namespace patchestry::ast {
     /// cloning, dead labels are reclaimed by RemoveUnreferencedLabels.
     ///
     /// Returns true if any duplication was performed.
-    bool DuplicateSwitchCaseTargets(SNode *root, SNodeFactory &factory);
+    bool DuplicateSwitchCaseTargets(std::vector< SNode * > &root,
+                                    SNodeFactory &factory);
 
     /// Cross-scope version of InlineResidualGotos: for each goto whose
     /// target label has exactly one reference, the label's body always
@@ -203,11 +213,12 @@ namespace patchestry::ast {
     /// matters.
     ///
     /// Returns true if any label was inlined.
-    bool InlineCrossScopeSingleRef(SNode *root, SNodeFactory &factory);
+    bool InlineCrossScopeSingleRef(std::vector< SNode * > &root,
+                                   SNodeFactory &factory);
 
     /// Remove unreachable SSeq children that follow a terminating
     /// sibling.  Preserves SLabel children (may be goto targets from
     /// other scopes).  Bottom-up recursive.
-    bool RemoveDeadSSeqChildren(SNode *root);
+    bool RemoveDeadSSeqChildren(std::vector< SNode * > &root);
 
 } // namespace patchestry::ast

--- a/include/patchestry/AST/CFGStructure.hpp
+++ b/include/patchestry/AST/CFGStructure.hpp
@@ -147,20 +147,15 @@ namespace patchestry::ast {
                                    SNodeFactory &factory);
 
     /// Convert if(cond) goto L; stmts; L: patterns into if(!cond) { stmts }
-    /// within SSeq nodes.  Only fires when label L has a single goto
-    /// reference and no intermediate SLabel nodes exist between the goto
-    /// and its target.  Recurses into all nested SNode bodies.
+    /// within a sibling sequence.  Only fires when label L has a single
+    /// goto reference and no intermediate SLabel nodes exist between the
+    /// goto and its target.  Recurses into all nested SNode bodies.
     bool ScopeifyIfGotos(std::vector< SNode * > &root, SNodeFactory &factory,
                          clang::ASTContext &ctx);
 
     /// Post-structuring cleanup: inline residual goto-to-label pairs.
-    ///
-    /// Walks the SNode tree looking for SGoto nodes whose target SLabel
-    /// appears in the same parent SSeq and is only referenced by that one
-    /// goto.  When found, the goto is replaced with the label's body and
-    /// the label is removed.  This eliminates trivial gotos left over
-    /// from structuring.
-    ///
+    /// When an SGoto's target SLabel is a sibling referenced only by that
+    /// goto, replace the goto with the label's body and drop the label.
     /// Returns true if any inlining was performed.
     bool InlineResidualGotos(std::vector< SNode * > &root, SNodeFactory &factory);
 
@@ -183,9 +178,9 @@ namespace patchestry::ast {
     bool ConvertGotoToReturn(std::vector< SNode * > &root, SNodeFactory &factory,
                              clang::ASTContext &ctx);
 
-    /// Remove SLabel nodes from SSeq whose label has zero references
-    /// (no SGoto and no clang::GotoStmt targets it).  The label's body
-    /// is dropped — it is dead code reachable only via the removed label.
+    /// Remove SLabel siblings whose label has zero references (no SGoto
+    /// and no clang::GotoStmt targets it).  The label's body is dropped —
+    /// it is dead code reachable only via the removed label.
     bool RemoveUnreferencedLabels(std::vector< SNode * > &root,
                                   SNodeFactory &factory);
 
@@ -200,26 +195,19 @@ namespace patchestry::ast {
     bool DuplicateSwitchCaseTargets(std::vector< SNode * > &root,
                                     SNodeFactory &factory);
 
-    /// Cross-scope version of InlineResidualGotos: for each goto whose
-    /// target label has exactly one reference, the label's body always
-    /// terminates (every path ends in return/break/continue/unconditional
-    /// goto), the label sits as a direct child of some SSeq, and the
-    /// label's preceding sibling in that SSeq also terminates (so no
-    /// fallthrough reaches the label), splice the body into the goto's
-    /// slot by *move* — no cloning.  Removes the now-dead label.
-    ///
-    /// This is safe because: (a) refs==1 means no other goto observes the
-    /// label; (b) no fallthrough reaches the label; (c) the moved body
-    /// terminates, so there is no post-body continuation whose location
-    /// matters.
-    ///
+    /// Cross-scope version of InlineResidualGotos: when a goto's target
+    /// label has exactly one reference, the label's body always terminates,
+    /// and the label's preceding sibling also terminates (no fallthrough
+    /// reaches it), move the body into the goto's slot and drop the label.
+    /// Safe because no other goto observes the label, no fallthrough
+    /// reaches it, and the moved body terminates.
     /// Returns true if any label was inlined.
     bool InlineCrossScopeSingleRef(std::vector< SNode * > &root,
                                    SNodeFactory &factory);
 
-    /// Remove unreachable SSeq children that follow a terminating
-    /// sibling.  Preserves SLabel children (may be goto targets from
-    /// other scopes).  Bottom-up recursive.
+    /// Remove unreachable siblings that follow a terminating sibling.
+    /// Preserves SLabel children (may be goto targets from other scopes).
+    /// Bottom-up recursive.
     bool RemoveDeadSSeqChildren(std::vector< SNode * > &root);
 
 } // namespace patchestry::ast

--- a/include/patchestry/AST/CGraph.hpp
+++ b/include/patchestry/AST/CGraph.hpp
@@ -51,9 +51,8 @@ namespace patchestry::ast {
         // Edge properties (indexed same as succs)
         std::vector<uint32_t> edge_flags;
 
-        // The structured SNode sequence produced when this node is
-        // collapsed (empty = leaf).  A "sequence" is a std::vector<SNode*>
-        // since the SSeq node kind was removed.
+        // Structured SNode sequence produced when this node is
+        // collapsed (empty = leaf).
         std::vector< SNode * > structured;
 
         // Leaf payload: statements from the original basic block

--- a/include/patchestry/AST/CGraph.hpp
+++ b/include/patchestry/AST/CGraph.hpp
@@ -51,8 +51,10 @@ namespace patchestry::ast {
         // Edge properties (indexed same as succs)
         std::vector<uint32_t> edge_flags;
 
-        // The SNode produced when this node is collapsed (null = leaf)
-        SNode *structured = nullptr;
+        // The structured SNode sequence produced when this node is
+        // collapsed (empty = leaf).  A "sequence" is a std::vector<SNode*>
+        // since the SSeq node kind was removed.
+        std::vector< SNode * > structured;
 
         // Leaf payload: statements from the original basic block
         std::string label;                      // mutable label (cleared after SLabel wrapping)
@@ -183,7 +185,8 @@ namespace patchestry::ast {
         /// collapsed but their stmts/labels remain accessible.
         /// Returns the representative node id.
         size_t IdentifyInternal(const std::vector<size_t> &ids,
-                                CNode::BlockType type, SNode *snode);
+                                CNode::BlockType type,
+                                std::vector< SNode * > snodes);
     };
 
     class FunctionBuilder;

--- a/include/patchestry/AST/ClangEmitter.hpp
+++ b/include/patchestry/AST/ClangEmitter.hpp
@@ -27,6 +27,13 @@ namespace patchestry::ast {
     void EmitClangAST(SNode *root, clang::FunctionDecl *fn,
                       clang::ASTContext &ctx);
 
+    // Layer C Stage 4 overload: take the function-body slot directly as a
+    // std::vector<SNode*> instead of routing through an intermediate SSeq.
+    // Materializes a single CompoundStmt from the vector and sets it as
+    // the function body.
+    void EmitClangAST(const std::vector< SNode * > &root_children,
+                      clang::FunctionDecl *fn, clang::ASTContext &ctx);
+
     // Post-emission cleanup for prettier C output.
     // Flattens nested CompoundStmts and pushes LabelStmts inside
     // CompoundStmt bodies. Only call for patchir-decomp path.

--- a/include/patchestry/AST/ClangEmitter.hpp
+++ b/include/patchestry/AST/ClangEmitter.hpp
@@ -22,15 +22,8 @@ namespace patchestry::ast {
         bool EndsWithTerminator(clang::Stmt *s);
     } // namespace detail
 
-    // Convert an SNode tree back to a Clang CompoundStmt and set it as the
-    // function body.
-    void EmitClangAST(SNode *root, clang::FunctionDecl *fn,
-                      clang::ASTContext &ctx);
-
-    // Layer C Stage 4 overload: take the function-body slot directly as a
-    // std::vector<SNode*> instead of routing through an intermediate SSeq.
-    // Materializes a single CompoundStmt from the vector and sets it as
-    // the function body.
+    // Convert a function-body SNode sequence to a Clang CompoundStmt and
+    // set it as the function body.
     void EmitClangAST(const std::vector< SNode * > &root_children,
                       clang::FunctionDecl *fn, clang::ASTContext &ctx);
 

--- a/include/patchestry/AST/SNode.hpp
+++ b/include/patchestry/AST/SNode.hpp
@@ -9,6 +9,8 @@
 
 #include <cassert>
 #include <cstring>
+#include <functional>
+#include <initializer_list>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -51,6 +53,21 @@ namespace patchestry::ast {
 
         SNode *Parent() const { return parent_; }
         void SetParent(SNode *p) { parent_ = p; }
+
+        // ChildVisitor API (added in Layer C migration Stage 0).
+        // Each subtype iterates over its immediate SNode children
+        // (slots that hold an SNode* — not raw clang::Stmt members
+        // like SBlock::Stmts or SFor::Init/Cond/Inc).
+        //
+        // Used by uniform recursion in cleanup walks during/after the
+        // SSeq → vector-slot migration.  Read-only form takes SNode*;
+        // mutable form takes SNode*& so callers can reassign the slot.
+        //
+        // Default: no children.  Each subtype with children overrides.
+        using ChildFn = std::function< void(SNode *) >;
+        using ChildMutFn = std::function< void(SNode *&) >;
+        virtual void for_each_child(const ChildFn &) const {}
+        virtual void for_each_child_mut(const ChildMutFn &) {}
 
         void Dump(llvm::raw_ostream &os, unsigned indent = 0) const;
 
@@ -126,6 +143,13 @@ namespace patchestry::ast {
         SNode *operator[](size_t i) { return children_[i]; }
         const SNode *operator[](size_t i) const { return children_[i]; }
 
+        void for_each_child(const ChildFn &fn) const override {
+            for (auto *c : children_) fn(c);
+        }
+        void for_each_child_mut(const ChildMutFn &fn) override {
+            for (auto &slot : children_) fn(slot);
+        }
+
         static bool classof(const SNode *n) { return n->Kind() == SNodeKind::kSeq; }
 
       protected:
@@ -182,6 +206,15 @@ namespace patchestry::ast {
         SNode *ElseBranch() const { return else_; }
         void SetElseBranch(SNode *n) { else_ = n; if (n) n->SetParent(this); }
 
+        void for_each_child(const ChildFn &fn) const override {
+            if (then_) fn(then_);
+            if (else_) fn(else_);
+        }
+        void for_each_child_mut(const ChildMutFn &fn) override {
+            if (then_) fn(then_);
+            if (else_) fn(else_);
+        }
+
         static bool classof(const SNode *n) { return n->Kind() == SNodeKind::kIfThenElse; }
 
       protected:
@@ -215,6 +248,13 @@ namespace patchestry::ast {
         std::string_view HeaderLabel() const { return header_label_; }
         void SetHeaderLabel(std::string_view l) { header_label_ = l; }
 
+        void for_each_child(const ChildFn &fn) const override {
+            if (body_) fn(body_);
+        }
+        void for_each_child_mut(const ChildMutFn &fn) override {
+            if (body_) fn(body_);
+        }
+
         static bool classof(const SNode *n) { return n->Kind() == SNodeKind::kWhile; }
 
       protected:
@@ -247,6 +287,13 @@ namespace patchestry::ast {
         void SetExitLabel(std::string_view l) { exit_label_ = l; }
         std::string_view HeaderLabel() const { return header_label_; }
         void SetHeaderLabel(std::string_view l) { header_label_ = l; }
+
+        void for_each_child(const ChildFn &fn) const override {
+            if (body_) fn(body_);
+        }
+        void for_each_child_mut(const ChildMutFn &fn) override {
+            if (body_) fn(body_);
+        }
 
         static bool classof(const SNode *n) { return n->Kind() == SNodeKind::kDoWhile; }
 
@@ -287,6 +334,13 @@ namespace patchestry::ast {
         void SetExitLabel(std::string_view l) { exit_label_ = l; }
         std::string_view HeaderLabel() const { return header_label_; }
         void SetHeaderLabel(std::string_view l) { header_label_ = l; }
+
+        void for_each_child(const ChildFn &fn) const override {
+            if (body_) fn(body_);
+        }
+        void for_each_child_mut(const ChildMutFn &fn) override {
+            if (body_) fn(body_);
+        }
 
         static bool classof(const SNode *n) { return n->Kind() == SNodeKind::kFor; }
 
@@ -330,6 +384,15 @@ namespace patchestry::ast {
         SNode *DefaultBody() const { return default_; }
         void SetDefaultBody(SNode *n) { default_ = n; if (n) n->SetParent(this); }
 
+        void for_each_child(const ChildFn &fn) const override {
+            for (auto &c : cases_) if (c.body) fn(c.body);
+            if (default_) fn(default_);
+        }
+        void for_each_child_mut(const ChildMutFn &fn) override {
+            for (auto &c : cases_) if (c.body) fn(c.body);
+            if (default_) fn(default_);
+        }
+
         static bool classof(const SNode *n) { return n->Kind() == SNodeKind::kSwitch; }
 
       protected:
@@ -371,6 +434,13 @@ namespace patchestry::ast {
 
         SNode *Body() const { return body_; }
         void SetBody(SNode *n) { body_ = n; if (n) n->SetParent(this); }
+
+        void for_each_child(const ChildFn &fn) const override {
+            if (body_) fn(body_);
+        }
+        void for_each_child_mut(const ChildMutFn &fn) override {
+            if (body_) fn(body_);
+        }
 
         static bool classof(const SNode *n) { return n->Kind() == SNodeKind::kLabel; }
 
@@ -447,6 +517,36 @@ namespace patchestry::ast {
             nodes_.push_back(std::move(node));
             return ptr;
         }
+
+        // Build a sequence with normalization (Layer C migration Stage 0).
+        //
+        // Rules applied at construction time:
+        //   - Drop nullptr children.
+        //   - If size 0 → return nullptr (caller decides substitute).
+        //   - If size 1 → return the single child directly (no wrap).
+        //   - Otherwise → allocate an SSeq and AddChild each.
+        //
+        // Two more aggressive normalizations are intentionally deferred:
+        //   * Empty unlabeled SBlock children are NOT dropped (they
+        //     correspond to CFG nodes with no stmts; sibling distance
+        //     is load-bearing for downstream fallthrough reasoning).
+        //   * Nested SSeq children are NOT flattened inline (flattening
+        //     exposes label adjacency that the EliminateGotoToNextLabel
+        //     elision logic mishandles when the label has live non-goto
+        //     predecessors).
+        // Both have been tried and revert with the same 4-fixture
+        // regression set; see SNode.cpp for details.  Re-enabling them
+        // requires a separate fix to downstream cleanup passes and
+        // belongs in a follow-up policy change, not this refactor.
+        //
+        // After Stage 5 (SSeq removal) callers will use std::vector<SNode*>
+        // directly; until then, MakeSeq is the single chokepoint that
+        // ensures every constructed SSeq is non-trivial and non-redundant.
+        SNode *MakeSeq(std::initializer_list< SNode * > children) {
+            return MakeSeq(std::vector< SNode * >(children));
+        }
+
+        SNode *MakeSeq(std::vector< SNode * > children);
 
         // Intern a copy of a string; the returned view is valid until Reset().
         // Uses a bump allocator because raw char data carries no destructor.

--- a/include/patchestry/AST/SNode.hpp
+++ b/include/patchestry/AST/SNode.hpp
@@ -10,7 +10,6 @@
 #include <cassert>
 #include <cstring>
 #include <functional>
-#include <initializer_list>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -53,20 +52,10 @@ namespace patchestry::ast {
         SNode *Parent() const { return parent_; }
         void SetParent(SNode *p) { parent_ = p; }
 
-        // ChildVisitor API (added in Layer C migration Stage 0).
-        // Each subtype iterates over its immediate SNode children
-        // (slots that hold an SNode* — not raw clang::Stmt members
-        // like SStmt::Stmt or SFor::Init/Cond/Inc).
-        //
-        // Used by uniform recursion in cleanup walks during/after the
-        // SSeq → vector-slot migration.  Read-only form takes SNode*;
-        // mutable form takes SNode*& so callers can reassign the slot.
-        //
-        // Default: no children.  Each subtype with children overrides.
+        // Visit immediate SNode children (slots holding SNode*, not raw
+        // clang::Stmt members). Default: no children; subtypes override.
         using ChildFn = std::function< void(SNode *) >;
-        using ChildMutFn = std::function< void(SNode *&) >;
         virtual void for_each_child(const ChildFn &) const {}
-        virtual void for_each_child_mut(const ChildMutFn &) {}
 
         void Dump(llvm::raw_ostream &os, unsigned indent = 0) const;
 
@@ -89,10 +78,8 @@ namespace patchestry::ast {
         SNode *parent_ = nullptr;
     };
 
-    // Single-statement leaf — holds one raw clang::Stmt*.  The
-    // statement-level counterpart to the control-flow SNode kinds:
-    // a "block" of N statements is represented as N SStmt siblings
-    // in a body vector (Phase 3 piece 2 — the SBlock replacement).
+    // Single-statement leaf — holds one raw clang::Stmt*. A "block" of N
+    // statements is N SStmt siblings in a body vector.
     class SStmt : public SNode
     {
       public:
@@ -111,9 +98,8 @@ namespace patchestry::ast {
         clang::Stmt *stmt_;
     };
 
-    // If-then-else — Layer C Stage 3c: then_/else_ are
-    // std::vector<SNode*>.  See SLabel docstring for the back-compat
-    // API rationale.
+    // If-then-else. then_/else_ are SNode* vectors; single-body
+    // Then/ElseBranch accessors preserve the prior field-style API.
     class SIfThenElse : public SNode
     {
       public:
@@ -145,14 +131,6 @@ namespace patchestry::ast {
         void SetCond(clang::Expr *c) { cond_ = c; }
 
         SNode *ThenBranch() const { return then_.empty() ? nullptr : then_[0]; }
-        void SetThenBranch(SNode *n) {
-            then_.clear();
-            if (n) { then_.push_back(n); n->SetParent(this); }
-        }
-        void SetThenBranch(std::vector< SNode * > body) {
-            then_ = std::move(body);
-            for (auto *c : then_) if (c) c->SetParent(this);
-        }
 
         SNode *ElseBranch() const { return else_.empty() ? nullptr : else_[0]; }
         void SetElseBranch(SNode *n) {
@@ -173,10 +151,6 @@ namespace patchestry::ast {
             for (auto *c : then_) if (c) fn(c);
             for (auto *c : else_) if (c) fn(c);
         }
-        void for_each_child_mut(const ChildMutFn &fn) override {
-            for (auto &slot : then_) if (slot) fn(slot);
-            for (auto &slot : else_) if (slot) fn(slot);
-        }
 
         static bool classof(const SNode *n) { return n->Kind() == SNodeKind::kIfThenElse; }
 
@@ -189,20 +163,10 @@ namespace patchestry::ast {
         std::vector< SNode * > else_;
     };
 
-    // While loop — Layer C Stage 3b: body_ is std::vector<SNode*>.
-    // See SLabel docstring for the back-compat API rationale.
+    // While loop. body_ is an SNode* vector.
     class SWhile : public SNode
     {
       public:
-        SWhile(clang::Expr *cond, SNode *body)
-            : SNode(SNodeKind::kWhile), cond_(cond)
-        {
-            if (body) {
-                body_.push_back(body);
-                body->SetParent(this);
-            }
-        }
-
         SWhile(clang::Expr *cond, std::vector< SNode * > body)
             : SNode(SNodeKind::kWhile), cond_(cond), body_(std::move(body))
         {
@@ -213,10 +177,6 @@ namespace patchestry::ast {
         void SetCond(clang::Expr *c) { cond_ = c; }
 
         SNode *Body() const { return body_.empty() ? nullptr : body_[0]; }
-        void SetBody(SNode *n) {
-            body_.clear();
-            if (n) { body_.push_back(n); n->SetParent(this); }
-        }
 
         const std::vector< SNode * > &BodyList() const { return body_; }
         std::vector< SNode * > &BodyList() { return body_; }
@@ -229,9 +189,6 @@ namespace patchestry::ast {
 
         void for_each_child(const ChildFn &fn) const override {
             for (auto *c : body_) if (c) fn(c);
-        }
-        void for_each_child_mut(const ChildMutFn &fn) override {
-            for (auto &slot : body_) if (slot) fn(slot);
         }
 
         static bool classof(const SNode *n) { return n->Kind() == SNodeKind::kWhile; }
@@ -246,19 +203,10 @@ namespace patchestry::ast {
         std::string_view header_label_;
     };
 
-    // Do-while loop — Layer C Stage 3b: body_ is std::vector<SNode*>.
+    // Do-while loop. body_ is an SNode* vector.
     class SDoWhile : public SNode
     {
       public:
-        SDoWhile(SNode *body, clang::Expr *cond)
-            : SNode(SNodeKind::kDoWhile), cond_(cond)
-        {
-            if (body) {
-                body_.push_back(body);
-                body->SetParent(this);
-            }
-        }
-
         SDoWhile(std::vector< SNode * > body, clang::Expr *cond)
             : SNode(SNodeKind::kDoWhile), cond_(cond), body_(std::move(body))
         {
@@ -266,10 +214,6 @@ namespace patchestry::ast {
         }
 
         SNode *Body() const { return body_.empty() ? nullptr : body_[0]; }
-        void SetBody(SNode *n) {
-            body_.clear();
-            if (n) { body_.push_back(n); n->SetParent(this); }
-        }
 
         const std::vector< SNode * > &BodyList() const { return body_; }
         std::vector< SNode * > &BodyList() { return body_; }
@@ -285,9 +229,6 @@ namespace patchestry::ast {
         void for_each_child(const ChildFn &fn) const override {
             for (auto *c : body_) if (c) fn(c);
         }
-        void for_each_child_mut(const ChildMutFn &fn) override {
-            for (auto &slot : body_) if (slot) fn(slot);
-        }
 
         static bool classof(const SNode *n) { return n->Kind() == SNodeKind::kDoWhile; }
 
@@ -301,20 +242,10 @@ namespace patchestry::ast {
         std::string_view header_label_;
     };
 
-    // For loop — Layer C Stage 3b: body_ is std::vector<SNode*>.
+    // For loop. body_ is an SNode* vector.
     class SFor : public SNode
     {
       public:
-        SFor(clang::Stmt *init, clang::Expr *cond, clang::Expr *inc, SNode *body)
-            : SNode(SNodeKind::kFor)
-            , init_(init), cond_(cond), inc_(inc)
-        {
-            if (body) {
-                body_.push_back(body);
-                body->SetParent(this);
-            }
-        }
-
         SFor(clang::Stmt *init, clang::Expr *cond, clang::Expr *inc,
              std::vector< SNode * > body)
             : SNode(SNodeKind::kFor)
@@ -333,10 +264,6 @@ namespace patchestry::ast {
         void SetInc(clang::Expr *e) { inc_ = e; }
 
         SNode *Body() const { return body_.empty() ? nullptr : body_[0]; }
-        void SetBody(SNode *n) {
-            body_.clear();
-            if (n) { body_.push_back(n); n->SetParent(this); }
-        }
 
         const std::vector< SNode * > &BodyList() const { return body_; }
         std::vector< SNode * > &BodyList() { return body_; }
@@ -348,9 +275,6 @@ namespace patchestry::ast {
 
         void for_each_child(const ChildFn &fn) const override {
             for (auto *c : body_) if (c) fn(c);
-        }
-        void for_each_child_mut(const ChildMutFn &fn) override {
-            for (auto &slot : body_) if (slot) fn(slot);
         }
 
         static bool classof(const SNode *n) { return n->Kind() == SNodeKind::kFor; }
@@ -367,26 +291,16 @@ namespace patchestry::ast {
         std::string_view header_label_;
     };
 
-    // Switch case — Layer C Stage 3d: body becomes std::vector<SNode*>.
-    //
-    // Back-compat helpers preserve the prior field-style read pattern:
-    //   c.body() returns the first element of body_list (or nullptr)
-    //   c.set_body(n) clears body_list and pushes n (caller manages SetParent
-    //                                                on the enclosing SSwitch)
-    // body_list is the storage; callers that need direct access use it.
+    // Switch case. body_list holds the case body; body() returns its
+    // first element (or nullptr) for the prior field-style read pattern.
     struct SCase {
         clang::Expr *value;  // nullptr for default
         std::vector< SNode * > body_list;
 
         SNode *body() const { return body_list.empty() ? nullptr : body_list[0]; }
-        void set_body(SNode *n) {
-            body_list.clear();
-            if (n) body_list.push_back(n);
-        }
     };
 
-    // Switch statement — Layer C Stage 3d: default_ becomes
-    // std::vector<SNode*> (matches the cases_ list-of-list shape).
+    // Switch statement. cases_ and default_ hold SNode* vectors.
     class SSwitch : public SNode
     {
       public:
@@ -432,11 +346,6 @@ namespace patchestry::ast {
                 for (auto *b : c.body_list) if (b) fn(b);
             for (auto *b : default_) if (b) fn(b);
         }
-        void for_each_child_mut(const ChildMutFn &fn) override {
-            for (auto &c : cases_)
-                for (auto &slot : c.body_list) if (slot) fn(slot);
-            for (auto &slot : default_) if (slot) fn(slot);
-        }
 
         static bool classof(const SNode *n) { return n->Kind() == SNodeKind::kSwitch; }
 
@@ -464,16 +373,9 @@ namespace patchestry::ast {
         std::string target_;
     };
 
-    // Label
-    //
-    // Layer C Stage 3a: body changed from SNode* to std::vector<SNode*>
-    // so that label bodies can directly hold multi-statement sequences
-    // without an SSeq wrapper.  Public Body()/SetBody() preserve the
-    // single-body API for back-compat (Body() returns the first child
-    // or nullptr; SetBody replaces the whole list).  Construction with
-    // a single SNode* still works via the existing constructor.  New
-    // BodyList accessors expose the vector directly for callers that
-    // want to append/iterate without round-tripping through SSeq.
+    // Label. body_ is an SNode* vector so a label can directly hold a
+    // multi-statement body; Body() returns the first child for the
+    // prior single-body API.
     class SLabel : public SNode
     {
       public:
@@ -495,26 +397,13 @@ namespace patchestry::ast {
         std::string_view Name() const { return name_; }
         void SetName(std::string_view n) { name_ = n; }
 
-        // Back-compat single-body view: returns the sole child or
-        // nullptr.  Callers handling multi-child bodies should use
-        // BodyList() instead.
         SNode *Body() const { return body_.empty() ? nullptr : body_[0]; }
-        void SetBody(SNode *n) {
-            body_.clear();
-            if (n) {
-                body_.push_back(n);
-                n->SetParent(this);
-            }
-        }
 
         const std::vector< SNode * > &BodyList() const { return body_; }
         std::vector< SNode * > &BodyList() { return body_; }
 
         void for_each_child(const ChildFn &fn) const override {
             for (auto *c : body_) if (c) fn(c);
-        }
-        void for_each_child_mut(const ChildMutFn &fn) override {
-            for (auto &slot : body_) if (slot) fn(slot);
         }
 
         static bool classof(const SNode *n) { return n->Kind() == SNodeKind::kLabel; }
@@ -593,13 +482,8 @@ namespace patchestry::ast {
             return ptr;
         }
 
-        // Build a sequence (std::vector<SNode*>) with normalization:
-        // nullptr children are dropped.  A "sequence" is a plain
-        // std::vector<SNode*> — the SSeq node kind no longer exists.
-        std::vector< SNode * > MakeSeq(std::initializer_list< SNode * > children) {
-            return MakeSeq(std::vector< SNode * >(children));
-        }
-
+        // Build a normalized sequence (a std::vector<SNode*>): nullptr
+        // children are dropped.
         std::vector< SNode * > MakeSeq(std::vector< SNode * > children);
 
         // Intern a copy of a string; the returned view is valid until Reset().

--- a/include/patchestry/AST/SNode.hpp
+++ b/include/patchestry/AST/SNode.hpp
@@ -185,34 +185,63 @@ namespace patchestry::ast {
         std::vector< clang::Stmt * > stmts_;
     };
 
-    // If-then-else
+    // If-then-else — Layer C Stage 3c: then_/else_ are
+    // std::vector<SNode*>.  See SLabel docstring for the back-compat
+    // API rationale.
     class SIfThenElse : public SNode
     {
       public:
-        SIfThenElse(clang::Expr *cond, SNode *then_branch, SNode *else_branch = nullptr)
-            : SNode(SNodeKind::kIfThenElse)
-            , cond_(cond), then_(then_branch), else_(else_branch)
+        SIfThenElse(clang::Expr *cond, SNode *then_branch,
+                    SNode *else_branch = nullptr)
+            : SNode(SNodeKind::kIfThenElse), cond_(cond)
         {
-            if (then_) then_->SetParent(this);
-            if (else_) else_->SetParent(this);
+            if (then_branch) {
+                then_.push_back(then_branch);
+                then_branch->SetParent(this);
+            }
+            if (else_branch) {
+                else_.push_back(else_branch);
+                else_branch->SetParent(this);
+            }
+        }
+
+        SIfThenElse(clang::Expr *cond,
+                    std::vector< SNode * > then_list,
+                    std::vector< SNode * > else_list)
+            : SNode(SNodeKind::kIfThenElse), cond_(cond)
+            , then_(std::move(then_list)), else_(std::move(else_list))
+        {
+            for (auto *c : then_) if (c) c->SetParent(this);
+            for (auto *c : else_) if (c) c->SetParent(this);
         }
 
         clang::Expr *Cond() const { return cond_; }
         void SetCond(clang::Expr *c) { cond_ = c; }
 
-        SNode *ThenBranch() const { return then_; }
-        void SetThenBranch(SNode *n) { then_ = n; if (n) n->SetParent(this); }
+        SNode *ThenBranch() const { return then_.empty() ? nullptr : then_[0]; }
+        void SetThenBranch(SNode *n) {
+            then_.clear();
+            if (n) { then_.push_back(n); n->SetParent(this); }
+        }
 
-        SNode *ElseBranch() const { return else_; }
-        void SetElseBranch(SNode *n) { else_ = n; if (n) n->SetParent(this); }
+        SNode *ElseBranch() const { return else_.empty() ? nullptr : else_[0]; }
+        void SetElseBranch(SNode *n) {
+            else_.clear();
+            if (n) { else_.push_back(n); n->SetParent(this); }
+        }
+
+        const std::vector< SNode * > &ThenList() const { return then_; }
+        std::vector< SNode * > &ThenList() { return then_; }
+        const std::vector< SNode * > &ElseList() const { return else_; }
+        std::vector< SNode * > &ElseList() { return else_; }
 
         void for_each_child(const ChildFn &fn) const override {
-            if (then_) fn(then_);
-            if (else_) fn(else_);
+            for (auto *c : then_) if (c) fn(c);
+            for (auto *c : else_) if (c) fn(c);
         }
         void for_each_child_mut(const ChildMutFn &fn) override {
-            if (then_) fn(then_);
-            if (else_) fn(else_);
+            for (auto &slot : then_) if (slot) fn(slot);
+            for (auto &slot : else_) if (slot) fn(slot);
         }
 
         static bool classof(const SNode *n) { return n->Kind() == SNodeKind::kIfThenElse; }
@@ -222,25 +251,41 @@ namespace patchestry::ast {
 
       private:
         clang::Expr *cond_;
-        SNode *then_;
-        SNode *else_;
+        std::vector< SNode * > then_;
+        std::vector< SNode * > else_;
     };
 
-    // While loop
+    // While loop — Layer C Stage 3b: body_ is std::vector<SNode*>.
+    // See SLabel docstring for the back-compat API rationale.
     class SWhile : public SNode
     {
       public:
         SWhile(clang::Expr *cond, SNode *body)
-            : SNode(SNodeKind::kWhile), cond_(cond), body_(body)
+            : SNode(SNodeKind::kWhile), cond_(cond)
         {
-            if (body_) body_->SetParent(this);
+            if (body) {
+                body_.push_back(body);
+                body->SetParent(this);
+            }
+        }
+
+        SWhile(clang::Expr *cond, std::vector< SNode * > body)
+            : SNode(SNodeKind::kWhile), cond_(cond), body_(std::move(body))
+        {
+            for (auto *c : body_) if (c) c->SetParent(this);
         }
 
         clang::Expr *Cond() const { return cond_; }
         void SetCond(clang::Expr *c) { cond_ = c; }
 
-        SNode *Body() const { return body_; }
-        void SetBody(SNode *n) { body_ = n; if (n) n->SetParent(this); }
+        SNode *Body() const { return body_.empty() ? nullptr : body_[0]; }
+        void SetBody(SNode *n) {
+            body_.clear();
+            if (n) { body_.push_back(n); n->SetParent(this); }
+        }
+
+        const std::vector< SNode * > &BodyList() const { return body_; }
+        std::vector< SNode * > &BodyList() { return body_; }
 
         // Scope labels for break/continue resolution (set by fold rules)
         std::string_view ExitLabel() const { return exit_label_; }
@@ -249,10 +294,10 @@ namespace patchestry::ast {
         void SetHeaderLabel(std::string_view l) { header_label_ = l; }
 
         void for_each_child(const ChildFn &fn) const override {
-            if (body_) fn(body_);
+            for (auto *c : body_) if (c) fn(c);
         }
         void for_each_child_mut(const ChildMutFn &fn) override {
-            if (body_) fn(body_);
+            for (auto &slot : body_) if (slot) fn(slot);
         }
 
         static bool classof(const SNode *n) { return n->Kind() == SNodeKind::kWhile; }
@@ -262,23 +307,38 @@ namespace patchestry::ast {
 
       private:
         clang::Expr *cond_;
-        SNode *body_;
+        std::vector< SNode * > body_;
         std::string_view exit_label_;
         std::string_view header_label_;
     };
 
-    // Do-while loop
+    // Do-while loop — Layer C Stage 3b: body_ is std::vector<SNode*>.
     class SDoWhile : public SNode
     {
       public:
         SDoWhile(SNode *body, clang::Expr *cond)
-            : SNode(SNodeKind::kDoWhile), body_(body), cond_(cond)
+            : SNode(SNodeKind::kDoWhile), cond_(cond)
         {
-            if (body_) body_->SetParent(this);
+            if (body) {
+                body_.push_back(body);
+                body->SetParent(this);
+            }
         }
 
-        SNode *Body() const { return body_; }
-        void SetBody(SNode *n) { body_ = n; if (n) n->SetParent(this); }
+        SDoWhile(std::vector< SNode * > body, clang::Expr *cond)
+            : SNode(SNodeKind::kDoWhile), cond_(cond), body_(std::move(body))
+        {
+            for (auto *c : body_) if (c) c->SetParent(this);
+        }
+
+        SNode *Body() const { return body_.empty() ? nullptr : body_[0]; }
+        void SetBody(SNode *n) {
+            body_.clear();
+            if (n) { body_.push_back(n); n->SetParent(this); }
+        }
+
+        const std::vector< SNode * > &BodyList() const { return body_; }
+        std::vector< SNode * > &BodyList() { return body_; }
 
         clang::Expr *Cond() const { return cond_; }
         void SetCond(clang::Expr *c) { cond_ = c; }
@@ -289,10 +349,10 @@ namespace patchestry::ast {
         void SetHeaderLabel(std::string_view l) { header_label_ = l; }
 
         void for_each_child(const ChildFn &fn) const override {
-            if (body_) fn(body_);
+            for (auto *c : body_) if (c) fn(c);
         }
         void for_each_child_mut(const ChildMutFn &fn) override {
-            if (body_) fn(body_);
+            for (auto &slot : body_) if (slot) fn(slot);
         }
 
         static bool classof(const SNode *n) { return n->Kind() == SNodeKind::kDoWhile; }
@@ -301,21 +361,32 @@ namespace patchestry::ast {
         void DumpChildren(llvm::raw_ostream &os, unsigned indent) const override;
 
       private:
-        SNode *body_;
         clang::Expr *cond_;
+        std::vector< SNode * > body_;
         std::string_view exit_label_;
         std::string_view header_label_;
     };
 
-    // For loop
+    // For loop — Layer C Stage 3b: body_ is std::vector<SNode*>.
     class SFor : public SNode
     {
       public:
         SFor(clang::Stmt *init, clang::Expr *cond, clang::Expr *inc, SNode *body)
             : SNode(SNodeKind::kFor)
-            , init_(init), cond_(cond), inc_(inc), body_(body)
+            , init_(init), cond_(cond), inc_(inc)
         {
-            if (body_) body_->SetParent(this);
+            if (body) {
+                body_.push_back(body);
+                body->SetParent(this);
+            }
+        }
+
+        SFor(clang::Stmt *init, clang::Expr *cond, clang::Expr *inc,
+             std::vector< SNode * > body)
+            : SNode(SNodeKind::kFor)
+            , init_(init), cond_(cond), inc_(inc), body_(std::move(body))
+        {
+            for (auto *c : body_) if (c) c->SetParent(this);
         }
 
         clang::Stmt *Init() const { return init_; }
@@ -327,8 +398,14 @@ namespace patchestry::ast {
         clang::Expr *Inc() const { return inc_; }
         void SetInc(clang::Expr *e) { inc_ = e; }
 
-        SNode *Body() const { return body_; }
-        void SetBody(SNode *n) { body_ = n; if (n) n->SetParent(this); }
+        SNode *Body() const { return body_.empty() ? nullptr : body_[0]; }
+        void SetBody(SNode *n) {
+            body_.clear();
+            if (n) { body_.push_back(n); n->SetParent(this); }
+        }
+
+        const std::vector< SNode * > &BodyList() const { return body_; }
+        std::vector< SNode * > &BodyList() { return body_; }
 
         std::string_view ExitLabel() const { return exit_label_; }
         void SetExitLabel(std::string_view l) { exit_label_ = l; }
@@ -336,10 +413,10 @@ namespace patchestry::ast {
         void SetHeaderLabel(std::string_view l) { header_label_ = l; }
 
         void for_each_child(const ChildFn &fn) const override {
-            if (body_) fn(body_);
+            for (auto *c : body_) if (c) fn(c);
         }
         void for_each_child_mut(const ChildMutFn &fn) override {
-            if (body_) fn(body_);
+            for (auto &slot : body_) if (slot) fn(slot);
         }
 
         static bool classof(const SNode *n) { return n->Kind() == SNodeKind::kFor; }
@@ -351,18 +428,31 @@ namespace patchestry::ast {
         clang::Stmt *init_;
         clang::Expr *cond_;
         clang::Expr *inc_;
-        SNode *body_;
+        std::vector< SNode * > body_;
         std::string_view exit_label_;
         std::string_view header_label_;
     };
 
-    // Switch case
+    // Switch case — Layer C Stage 3d: body becomes std::vector<SNode*>.
+    //
+    // Back-compat helpers preserve the prior field-style read pattern:
+    //   c.body() returns the first element of body_list (or nullptr)
+    //   c.set_body(n) clears body_list and pushes n (caller manages SetParent
+    //                                                on the enclosing SSwitch)
+    // body_list is the storage; callers that need direct access use it.
     struct SCase {
         clang::Expr *value;  // nullptr for default
-        SNode *body;
+        std::vector< SNode * > body_list;
+
+        SNode *body() const { return body_list.empty() ? nullptr : body_list[0]; }
+        void set_body(SNode *n) {
+            body_list.clear();
+            if (n) body_list.push_back(n);
+        }
     };
 
-    // Switch statement
+    // Switch statement — Layer C Stage 3d: default_ becomes
+    // std::vector<SNode*> (matches the cases_ list-of-list shape).
     class SSwitch : public SNode
     {
       public:
@@ -378,19 +468,36 @@ namespace patchestry::ast {
 
         void AddCase(clang::Expr *value, SNode *body) {
             if (body) body->SetParent(this);
-            cases_.push_back({value, body});
+            SCase c{value, {}};
+            if (body) c.body_list.push_back(body);
+            cases_.push_back(std::move(c));
         }
 
-        SNode *DefaultBody() const { return default_; }
-        void SetDefaultBody(SNode *n) { default_ = n; if (n) n->SetParent(this); }
+        void AddCase(clang::Expr *value, std::vector< SNode * > body_list) {
+            for (auto *b : body_list) if (b) b->SetParent(this);
+            cases_.push_back({value, std::move(body_list)});
+        }
+
+        SNode *DefaultBody() const {
+            return default_.empty() ? nullptr : default_[0];
+        }
+        void SetDefaultBody(SNode *n) {
+            default_.clear();
+            if (n) { default_.push_back(n); n->SetParent(this); }
+        }
+
+        const std::vector< SNode * > &DefaultBodyList() const { return default_; }
+        std::vector< SNode * > &DefaultBodyList() { return default_; }
 
         void for_each_child(const ChildFn &fn) const override {
-            for (auto &c : cases_) if (c.body) fn(c.body);
-            if (default_) fn(default_);
+            for (auto &c : cases_)
+                for (auto *b : c.body_list) if (b) fn(b);
+            for (auto *b : default_) if (b) fn(b);
         }
         void for_each_child_mut(const ChildMutFn &fn) override {
-            for (auto &c : cases_) if (c.body) fn(c.body);
-            if (default_) fn(default_);
+            for (auto &c : cases_)
+                for (auto &slot : c.body_list) if (slot) fn(slot);
+            for (auto &slot : default_) if (slot) fn(slot);
         }
 
         static bool classof(const SNode *n) { return n->Kind() == SNodeKind::kSwitch; }
@@ -401,7 +508,7 @@ namespace patchestry::ast {
       private:
         clang::Expr *discriminant_;
         std::vector< SCase > cases_;
-        SNode *default_ = nullptr;
+        std::vector< SNode * > default_;
     };
 
     // Goto
@@ -420,26 +527,56 @@ namespace patchestry::ast {
     };
 
     // Label
+    //
+    // Layer C Stage 3a: body changed from SNode* to std::vector<SNode*>
+    // so that label bodies can directly hold multi-statement sequences
+    // without an SSeq wrapper.  Public Body()/SetBody() preserve the
+    // single-body API for back-compat (Body() returns the first child
+    // or nullptr; SetBody replaces the whole list).  Construction with
+    // a single SNode* still works via the existing constructor.  New
+    // BodyList accessors expose the vector directly for callers that
+    // want to append/iterate without round-tripping through SSeq.
     class SLabel : public SNode
     {
       public:
         SLabel(std::string_view name, SNode *body = nullptr)
-            : SNode(SNodeKind::kLabel), name_(name), body_(body)
+            : SNode(SNodeKind::kLabel), name_(name)
         {
-            if (body_) body_->SetParent(this);
+            if (body) {
+                body_.push_back(body);
+                body->SetParent(this);
+            }
+        }
+
+        SLabel(std::string_view name, std::vector< SNode * > body)
+            : SNode(SNodeKind::kLabel), name_(name), body_(std::move(body))
+        {
+            for (auto *c : body_) if (c) c->SetParent(this);
         }
 
         std::string_view Name() const { return name_; }
         void SetName(std::string_view n) { name_ = n; }
 
-        SNode *Body() const { return body_; }
-        void SetBody(SNode *n) { body_ = n; if (n) n->SetParent(this); }
+        // Back-compat single-body view: returns the sole child or
+        // nullptr.  Callers handling multi-child bodies should use
+        // BodyList() instead.
+        SNode *Body() const { return body_.empty() ? nullptr : body_[0]; }
+        void SetBody(SNode *n) {
+            body_.clear();
+            if (n) {
+                body_.push_back(n);
+                n->SetParent(this);
+            }
+        }
+
+        const std::vector< SNode * > &BodyList() const { return body_; }
+        std::vector< SNode * > &BodyList() { return body_; }
 
         void for_each_child(const ChildFn &fn) const override {
-            if (body_) fn(body_);
+            for (auto *c : body_) if (c) fn(c);
         }
         void for_each_child_mut(const ChildMutFn &fn) override {
-            if (body_) fn(body_);
+            for (auto &slot : body_) if (slot) fn(slot);
         }
 
         static bool classof(const SNode *n) { return n->Kind() == SNodeKind::kLabel; }
@@ -449,7 +586,7 @@ namespace patchestry::ast {
 
       private:
         std::string name_;
-        SNode *body_;
+        std::vector< SNode * > body_;
     };
 
     // Break (with optional depth for multi-level breaks)

--- a/include/patchestry/AST/SNode.hpp
+++ b/include/patchestry/AST/SNode.hpp
@@ -27,7 +27,6 @@
 namespace patchestry::ast {
 
     enum class SNodeKind {
-        kSeq,
         kBlock,
         kIfThenElse,
         kWhile,
@@ -88,75 +87,6 @@ namespace patchestry::ast {
       private:
         SNodeKind kind_;
         SNode *parent_ = nullptr;
-    };
-
-    // Sequence of SNodes (analogous to CompoundStmt)
-    class SSeq : public SNode
-    {
-      public:
-        SSeq() : SNode(SNodeKind::kSeq) {}
-
-        const std::vector< SNode * > &Children() const { return children_; }
-        std::vector< SNode * > &Children() { return children_; }
-
-        void AddChild(SNode *child) {
-            child->SetParent(this);
-            children_.push_back(child);
-        }
-
-        void InsertChild(size_t pos, SNode *child) {
-            child->SetParent(this);
-            children_.insert(children_.begin() + static_cast< ptrdiff_t >(pos), child);
-        }
-
-        void RemoveChild(size_t pos) {
-            children_.erase(children_.begin() + static_cast< ptrdiff_t >(pos));
-        }
-
-        void ReplaceChild(size_t pos, SNode *child) {
-            child->SetParent(this);
-            children_[pos] = child;
-        }
-
-        // Replace a range [from, to) with a single node
-        void ReplaceRange(size_t from, size_t to, SNode *replacement) {
-            replacement->SetParent(this);
-            auto begin = children_.begin();
-            children_.erase(begin + static_cast< ptrdiff_t >(from) + 1,
-                            begin + static_cast< ptrdiff_t >(to));
-            children_[from] = replacement;
-        }
-
-        // Replace a range [from, to) with multiple nodes
-        void ReplaceRange(size_t from, size_t to,
-                           const std::vector< SNode * > &replacements) {
-            for (auto *r : replacements) r->SetParent(this);
-            auto begin = children_.begin();
-            children_.erase(begin + static_cast< ptrdiff_t >(from),
-                            begin + static_cast< ptrdiff_t >(to));
-            children_.insert(children_.begin() + static_cast< ptrdiff_t >(from),
-                             replacements.begin(), replacements.end());
-        }
-
-        size_t Size() const { return children_.size(); }
-        bool Empty() const { return children_.empty(); }
-        SNode *operator[](size_t i) { return children_[i]; }
-        const SNode *operator[](size_t i) const { return children_[i]; }
-
-        void for_each_child(const ChildFn &fn) const override {
-            for (auto *c : children_) fn(c);
-        }
-        void for_each_child_mut(const ChildMutFn &fn) override {
-            for (auto &slot : children_) fn(slot);
-        }
-
-        static bool classof(const SNode *n) { return n->Kind() == SNodeKind::kSeq; }
-
-      protected:
-        void DumpChildren(llvm::raw_ostream &os, unsigned indent) const override;
-
-      private:
-        std::vector< SNode * > children_;
     };
 
     // Basic block: holds raw Clang Stmt* and an optional label
@@ -223,11 +153,19 @@ namespace patchestry::ast {
             then_.clear();
             if (n) { then_.push_back(n); n->SetParent(this); }
         }
+        void SetThenBranch(std::vector< SNode * > body) {
+            then_ = std::move(body);
+            for (auto *c : then_) if (c) c->SetParent(this);
+        }
 
         SNode *ElseBranch() const { return else_.empty() ? nullptr : else_[0]; }
         void SetElseBranch(SNode *n) {
             else_.clear();
             if (n) { else_.push_back(n); n->SetParent(this); }
+        }
+        void SetElseBranch(std::vector< SNode * > body) {
+            else_ = std::move(body);
+            for (auto *c : else_) if (c) c->SetParent(this);
         }
 
         const std::vector< SNode * > &ThenList() const { return then_; }
@@ -485,6 +423,10 @@ namespace patchestry::ast {
             default_.clear();
             if (n) { default_.push_back(n); n->SetParent(this); }
         }
+        void SetDefaultBody(std::vector< SNode * > body) {
+            default_ = std::move(body);
+            for (auto *c : default_) if (c) c->SetParent(this);
+        }
 
         const std::vector< SNode * > &DefaultBodyList() const { return default_; }
         std::vector< SNode * > &DefaultBodyList() { return default_; }
@@ -655,35 +597,18 @@ namespace patchestry::ast {
             return ptr;
         }
 
-        // Build a sequence with normalization (Layer C migration Stage 0).
+        // Build a sequence (std::vector<SNode*>) with normalization:
+        // nullptr children are dropped.  A "sequence" is a plain
+        // std::vector<SNode*> — the SSeq node kind no longer exists.
         //
-        // Rules applied at construction time:
-        //   - Drop nullptr children.
-        //   - If size 0 → return nullptr (caller decides substitute).
-        //   - If size 1 → return the single child directly (no wrap).
-        //   - Otherwise → allocate an SSeq and AddChild each.
-        //
-        // Two more aggressive normalizations are intentionally deferred:
-        //   * Empty unlabeled SBlock children are NOT dropped (they
-        //     correspond to CFG nodes with no stmts; sibling distance
-        //     is load-bearing for downstream fallthrough reasoning).
-        //   * Nested SSeq children are NOT flattened inline (flattening
-        //     exposes label adjacency that the EliminateGotoToNextLabel
-        //     elision logic mishandles when the label has live non-goto
-        //     predecessors).
-        // Both have been tried and revert with the same 4-fixture
-        // regression set; see SNode.cpp for details.  Re-enabling them
-        // requires a separate fix to downstream cleanup passes and
-        // belongs in a follow-up policy change, not this refactor.
-        //
-        // After Stage 5 (SSeq removal) callers will use std::vector<SNode*>
-        // directly; until then, MakeSeq is the single chokepoint that
-        // ensures every constructed SSeq is non-trivial and non-redundant.
-        SNode *MakeSeq(std::initializer_list< SNode * > children) {
+        // Empty unlabeled SBlock children are intentionally NOT dropped
+        // (they correspond to CFG nodes with no stmts; sibling distance
+        // is load-bearing for downstream fallthrough reasoning).
+        std::vector< SNode * > MakeSeq(std::initializer_list< SNode * > children) {
             return MakeSeq(std::vector< SNode * >(children));
         }
 
-        SNode *MakeSeq(std::vector< SNode * > children);
+        std::vector< SNode * > MakeSeq(std::vector< SNode * > children);
 
         // Intern a copy of a string; the returned view is valid until Reset().
         // Uses a bump allocator because raw char data carries no destructor.

--- a/include/patchestry/AST/SNode.hpp
+++ b/include/patchestry/AST/SNode.hpp
@@ -27,7 +27,7 @@
 namespace patchestry::ast {
 
     enum class SNodeKind {
-        kBlock,
+        kStmt,
         kIfThenElse,
         kWhile,
         kDoWhile,
@@ -56,7 +56,7 @@ namespace patchestry::ast {
         // ChildVisitor API (added in Layer C migration Stage 0).
         // Each subtype iterates over its immediate SNode children
         // (slots that hold an SNode* — not raw clang::Stmt members
-        // like SBlock::Stmts or SFor::Init/Cond/Inc).
+        // like SStmt::Stmt or SFor::Init/Cond/Inc).
         //
         // Used by uniform recursion in cleanup walks during/after the
         // SSeq → vector-slot migration.  Read-only form takes SNode*;
@@ -89,30 +89,26 @@ namespace patchestry::ast {
         SNode *parent_ = nullptr;
     };
 
-    // Basic block: holds raw Clang Stmt* and an optional label
-    class SBlock : public SNode
+    // Single-statement leaf — holds one raw clang::Stmt*.  The
+    // statement-level counterpart to the control-flow SNode kinds:
+    // a "block" of N statements is represented as N SStmt siblings
+    // in a body vector (Phase 3 piece 2 — the SBlock replacement).
+    class SStmt : public SNode
     {
       public:
-        SBlock() : SNode(SNodeKind::kBlock) {}
+        explicit SStmt(clang::Stmt *stmt)
+            : SNode(SNodeKind::kStmt), stmt_(stmt) {}
 
-        std::string_view Label() const { return label_; }
-        void SetLabel(std::string_view l) { label_ = l; }
+        clang::Stmt *Stmt() const { return stmt_; }
+        void SetStmt(clang::Stmt *s) { stmt_ = s; }
 
-        const std::vector< clang::Stmt * > &Stmts() const { return stmts_; }
-        std::vector< clang::Stmt * > &Stmts() { return stmts_; }
-
-        void AddStmt(clang::Stmt *s) { stmts_.push_back(s); }
-        bool Empty() const { return stmts_.empty(); }
-        size_t Size() const { return stmts_.size(); }
-
-        static bool classof(const SNode *n) { return n->Kind() == SNodeKind::kBlock; }
+        static bool classof(const SNode *n) { return n->Kind() == SNodeKind::kStmt; }
 
       protected:
         void DumpChildren(llvm::raw_ostream &os, unsigned indent) const override;
 
       private:
-        std::string label_;
-        std::vector< clang::Stmt * > stmts_;
+        clang::Stmt *stmt_;
     };
 
     // If-then-else — Layer C Stage 3c: then_/else_ are
@@ -600,10 +596,6 @@ namespace patchestry::ast {
         // Build a sequence (std::vector<SNode*>) with normalization:
         // nullptr children are dropped.  A "sequence" is a plain
         // std::vector<SNode*> — the SSeq node kind no longer exists.
-        //
-        // Empty unlabeled SBlock children are intentionally NOT dropped
-        // (they correspond to CFG nodes with no stmts; sibling distance
-        // is load-bearing for downstream fallthrough reasoning).
         std::vector< SNode * > MakeSeq(std::initializer_list< SNode * > children) {
             return MakeSeq(std::vector< SNode * >(children));
         }

--- a/include/patchestry/AST/SNode.hpp
+++ b/include/patchestry/AST/SNode.hpp
@@ -49,9 +49,6 @@ namespace patchestry::ast {
         static const char *KindName(SNodeKind k);
         const char *KindName() const { return KindName(kind_); }
 
-        SNode *Parent() const { return parent_; }
-        void SetParent(SNode *p) { parent_ = p; }
-
         // Visit immediate SNode children (slots holding SNode*, not raw
         // clang::Stmt members). Default: no children; subtypes override.
         using ChildFn = std::function< void(SNode *) >;
@@ -75,7 +72,6 @@ namespace patchestry::ast {
 
       private:
         SNodeKind kind_;
-        SNode *parent_ = nullptr;
     };
 
     // Single-statement leaf — holds one raw clang::Stmt*. A "block" of N
@@ -109,11 +105,9 @@ namespace patchestry::ast {
         {
             if (then_branch) {
                 then_.push_back(then_branch);
-                then_branch->SetParent(this);
             }
             if (else_branch) {
                 else_.push_back(else_branch);
-                else_branch->SetParent(this);
             }
         }
 
@@ -122,10 +116,7 @@ namespace patchestry::ast {
                     std::vector< SNode * > else_list)
             : SNode(SNodeKind::kIfThenElse), cond_(cond)
             , then_(std::move(then_list)), else_(std::move(else_list))
-        {
-            for (auto *c : then_) if (c) c->SetParent(this);
-            for (auto *c : else_) if (c) c->SetParent(this);
-        }
+        {}
 
         clang::Expr *Cond() const { return cond_; }
         void SetCond(clang::Expr *c) { cond_ = c; }
@@ -135,11 +126,10 @@ namespace patchestry::ast {
         SNode *ElseBranch() const { return else_.empty() ? nullptr : else_[0]; }
         void SetElseBranch(SNode *n) {
             else_.clear();
-            if (n) { else_.push_back(n); n->SetParent(this); }
+            if (n) { else_.push_back(n); }
         }
         void SetElseBranch(std::vector< SNode * > body) {
             else_ = std::move(body);
-            for (auto *c : else_) if (c) c->SetParent(this);
         }
 
         const std::vector< SNode * > &ThenList() const { return then_; }
@@ -169,9 +159,7 @@ namespace patchestry::ast {
       public:
         SWhile(clang::Expr *cond, std::vector< SNode * > body)
             : SNode(SNodeKind::kWhile), cond_(cond), body_(std::move(body))
-        {
-            for (auto *c : body_) if (c) c->SetParent(this);
-        }
+        {}
 
         clang::Expr *Cond() const { return cond_; }
         void SetCond(clang::Expr *c) { cond_ = c; }
@@ -209,9 +197,7 @@ namespace patchestry::ast {
       public:
         SDoWhile(std::vector< SNode * > body, clang::Expr *cond)
             : SNode(SNodeKind::kDoWhile), cond_(cond), body_(std::move(body))
-        {
-            for (auto *c : body_) if (c) c->SetParent(this);
-        }
+        {}
 
         SNode *Body() const { return body_.empty() ? nullptr : body_[0]; }
 
@@ -250,9 +236,7 @@ namespace patchestry::ast {
              std::vector< SNode * > body)
             : SNode(SNodeKind::kFor)
             , init_(init), cond_(cond), inc_(inc), body_(std::move(body))
-        {
-            for (auto *c : body_) if (c) c->SetParent(this);
-        }
+        {}
 
         clang::Stmt *Init() const { return init_; }
         void SetInit(clang::Stmt *s) { init_ = s; }
@@ -315,14 +299,12 @@ namespace patchestry::ast {
         std::vector< SCase > &Cases() { return cases_; }
 
         void AddCase(clang::Expr *value, SNode *body) {
-            if (body) body->SetParent(this);
             SCase c{value, {}};
             if (body) c.body_list.push_back(body);
             cases_.push_back(std::move(c));
         }
 
         void AddCase(clang::Expr *value, std::vector< SNode * > body_list) {
-            for (auto *b : body_list) if (b) b->SetParent(this);
             cases_.push_back({value, std::move(body_list)});
         }
 
@@ -331,11 +313,10 @@ namespace patchestry::ast {
         }
         void SetDefaultBody(SNode *n) {
             default_.clear();
-            if (n) { default_.push_back(n); n->SetParent(this); }
+            if (n) { default_.push_back(n); }
         }
         void SetDefaultBody(std::vector< SNode * > body) {
             default_ = std::move(body);
-            for (auto *c : default_) if (c) c->SetParent(this);
         }
 
         const std::vector< SNode * > &DefaultBodyList() const { return default_; }
@@ -384,15 +365,12 @@ namespace patchestry::ast {
         {
             if (body) {
                 body_.push_back(body);
-                body->SetParent(this);
             }
         }
 
         SLabel(std::string_view name, std::vector< SNode * > body)
             : SNode(SNodeKind::kLabel), name_(name), body_(std::move(body))
-        {
-            for (auto *c : body_) if (c) c->SetParent(this);
-        }
+        {}
 
         std::string_view Name() const { return name_; }
         void SetName(std::string_view n) { name_ = n; }

--- a/lib/patchestry/AST/ASTConsumer.cpp
+++ b/lib/patchestry/AST/ASTConsumer.cpp
@@ -200,8 +200,10 @@ namespace patchestry::ast {
                     // Switch blocks get an SSwitch with goto-to-label cases.
                     for (auto &node : flow_graph.nodes) {
                         if (node.IsCollapsed()) continue;
-                        auto *blk = factory.Make<SBlock>();
-                        for (auto *s : node.stmts) blk->AddStmt(s);
+                        // Spill the node's stmts as SStmt siblings.
+                        std::vector<SNode *> blk_nodes;
+                        for (auto *s : node.stmts)
+                            if (s) blk_nodes.push_back(factory.Make<SStmt>(s));
 
                         // Switch block: build SSwitch with goto cases
                         if (!node.switch_cases.empty() && node.branch_cond) {
@@ -267,10 +269,9 @@ namespace patchestry::ast {
                                     sw->AddCase(val, body);
                                 }
                             }
-                            // MakeSeq drops the prefix block when empty.
-                            std::vector<SNode *> sw_seq = factory.MakeSeq({
-                                blk->Stmts().empty() ? nullptr : blk,
-                                sw});
+                            // Pre-switch stmts (if any) precede the switch.
+                            std::vector<SNode *> sw_seq = std::move(blk_nodes);
+                            sw_seq.push_back(sw);
                             if (!node.label.empty()) {
                                 root_body.push_back(factory.Make<SLabel>(
                                     factory.Intern(node.label),
@@ -283,12 +284,16 @@ namespace patchestry::ast {
                         }
 
                         // Non-switch: append terminal (goto/if-goto)
-                        if (node.terminal) blk->AddStmt(node.terminal);
+                        if (node.terminal)
+                            blk_nodes.push_back(
+                                factory.Make<SStmt>(node.terminal));
                         if (!node.label.empty()) {
                             root_body.push_back(factory.Make<SLabel>(
-                                factory.Intern(node.label), blk));
+                                factory.Intern(node.label),
+                                std::move(blk_nodes)));
                         } else {
-                            root_body.push_back(blk);
+                            for (SNode *s : blk_nodes)
+                                root_body.push_back(s);
                         }
                     }
                 }

--- a/lib/patchestry/AST/ASTConsumer.cpp
+++ b/lib/patchestry/AST/ASTConsumer.cpp
@@ -107,7 +107,10 @@ namespace patchestry::ast {
                 }
 
                 SNodeFactory factory;
-                SNode *root_snode = nullptr;
+                // The function body is a sequence of SNodes
+                // (std::vector) — the SSeq node kind was removed.
+                std::vector<SNode *> root_body;
+                bool have_structured = false;
 
                 if (options.use_structuring_pass) {
                     // Structured path: run CFGStructure to fold the
@@ -115,84 +118,86 @@ namespace patchestry::ast {
                     CFGStructure cfg_structure(flow_graph, factory, ctx);
                     cfg_structure.StructureAll();
 
-                    // Build root SSeq from the remaining active (uncollapsed)
-                    // nodes.  After StructureAll, each active node has a
-                    // ->structured SNode set.  MakeSeq normalizes (drops
-                    // null/empty children, unwraps single-child cases);
-                    // a fully-empty function yields nullptr, which the
-                    // emitter treats as an empty body.
-                    std::vector<SNode *> root_children;
+                    // Build the root sequence from the remaining active
+                    // (uncollapsed) nodes.  After StructureAll, each
+                    // active node carries a ->structured sequence.
                     for (auto &node : flow_graph.nodes) {
                         if (node.IsCollapsed()) continue;
-                        if (node.structured)
-                            root_children.push_back(node.structured);
-                    }
-                    root_snode = factory.MakeSeq(std::move(root_children));
-
-                    // Post-pass: replace goto→break/continue for loop labels.
-                    ConvertGotoToBreakContinue(root_snode, factory);
-
-                    // Post-pass: replace goto→return patterns.
-                    ConvertGotoToReturn(root_snode, factory, ctx);
-
-                    // Post-pass: duplicate small label targets into
-                    // switch case arms that end in `goto L`, making
-                    // switches goto-free (including goto-into-switch).
-                    DuplicateSwitchCaseTargets(root_snode, factory);
-
-                    // Post-pass: inline residual goto-to-label pairs
-                    // where the label is only referenced once.
-                    InlineResidualGotos(root_snode, factory);
-
-                    // Post-pass: cross-scope single-ref goto inliner.
-                    // Moves terminating label bodies into their sole
-                    // goto site when no fallthrough reaches the label.
-                    InlineCrossScopeSingleRef(root_snode, factory);
-
-                    // Post-pass: eliminate gotos to immediately following
-                    // labels.  Iterates with InlineResidualGotos and the
-                    // cross-scope inliner for cascading cleanup, bounded
-                    // by kMaxGotoEliminationPasses.
-                    for (int pass = 0; pass < kMaxGotoEliminationPasses; ++pass) {
-                        bool did_absorb = AbsorbFallthroughIntoElse(
-                            root_snode, factory);
-                        bool did_scope = ScopeifyIfGotos(
-                            root_snode, factory, ctx);
-                        bool did_elim = EliminateGotoToNextLabel(
-                            root_snode, factory, ctx);
-                        bool did_inline = InlineResidualGotos(
-                            root_snode, factory);
-                        bool did_cross = InlineCrossScopeSingleRef(
-                            root_snode, factory);
-                        if (!did_absorb && !did_scope && !did_elim
-                            && !did_inline && !did_cross)
-                            break;
+                        for (SNode *s : node.structured)
+                            root_body.push_back(s);
                     }
 
-                    // Post-pass: remove unreachable SSeq children after
-                    // terminating siblings (dead code from block sequencing).
-                    RemoveDeadSSeqChildren(root_snode);
+                    // A fully-empty structured result falls through to
+                    // the goto-based path below (matches prior behaviour
+                    // when MakeSeq returned nullptr).
+                    if (!root_body.empty()) {
+                        have_structured = true;
 
-                    // NOTE: RemoveUnreferencedLabels is intentionally
-                    // NOT called here.  CountAllGotoRefs does not yet
-                    // walk every clang::Stmt embedded inside all SNode
-                    // kinds (e.g. if-guarded gotos synthesised by the
-                    // goto-path), so enabling it drops live labels on
-                    // some fixtures.  The duplication pass above still
-                    // inlines shared targets correctly; dead label
-                    // bodies simply remain in the output as unreferenced
-                    // labelled blocks, which is preferable to losing
-                    // reachable code.
+                        // Post-pass: replace goto→break/continue for loop labels.
+                        ConvertGotoToBreakContinue(root_body, factory);
 
+                        // Post-pass: replace goto→return patterns.
+                        ConvertGotoToReturn(root_body, factory, ctx);
+
+                        // Post-pass: duplicate small label targets into
+                        // switch case arms that end in `goto L`, making
+                        // switches goto-free (including goto-into-switch).
+                        DuplicateSwitchCaseTargets(root_body, factory);
+
+                        // Post-pass: inline residual goto-to-label pairs
+                        // where the label is only referenced once.
+                        InlineResidualGotos(root_body, factory);
+
+                        // Post-pass: cross-scope single-ref goto inliner.
+                        // Moves terminating label bodies into their sole
+                        // goto site when no fallthrough reaches the label.
+                        InlineCrossScopeSingleRef(root_body, factory);
+
+                        // Post-pass: eliminate gotos to immediately
+                        // following labels.  Iterates with the inliners
+                        // for cascading cleanup, bounded by
+                        // kMaxGotoEliminationPasses.
+                        for (int pass = 0;
+                             pass < kMaxGotoEliminationPasses; ++pass) {
+                            bool did_absorb = AbsorbFallthroughIntoElse(
+                                root_body, factory);
+                            bool did_scope = ScopeifyIfGotos(
+                                root_body, factory, ctx);
+                            bool did_elim = EliminateGotoToNextLabel(
+                                root_body, factory, ctx);
+                            bool did_inline = InlineResidualGotos(
+                                root_body, factory);
+                            bool did_cross = InlineCrossScopeSingleRef(
+                                root_body, factory);
+                            if (!did_absorb && !did_scope && !did_elim
+                                && !did_inline && !did_cross)
+                                break;
+                        }
+
+                        // Post-pass: remove unreachable children after
+                        // terminating siblings (dead code from block
+                        // sequencing).
+                        RemoveDeadSSeqChildren(root_body);
+
+                        // NOTE: RemoveUnreferencedLabels is intentionally
+                        // NOT called here.  CountAllGotoRefs does not yet
+                        // walk every clang::Stmt embedded inside all SNode
+                        // kinds (e.g. if-guarded gotos synthesised by the
+                        // goto-path), so enabling it drops live labels on
+                        // some fixtures.  The duplication pass above still
+                        // inlines shared targets correctly; dead label
+                        // bodies simply remain in the output as
+                        // unreferenced labelled blocks, which is
+                        // preferable to losing reachable code.
+                    }
                 }
 
-                if (!root_snode) {
-                    // Goto-based path (original, unchanged).
+                if (!have_structured) {
+                    root_body.clear();
+                    // Goto-based path.
                     // Emit the CGraph blocks sequentially with goto-based
                     // control flow from terminals.
                     // Switch blocks get an SSwitch with goto-to-label cases.
-                    std::vector<SNode *> root_children;
-
                     for (auto &node : flow_graph.nodes) {
                         if (node.IsCollapsed()) continue;
                         auto *blk = factory.Make<SBlock>();
@@ -262,16 +267,17 @@ namespace patchestry::ast {
                                     sw->AddCase(val, body);
                                 }
                             }
-                            // MakeSeq drops the prefix block when empty
-                            // and unwraps single-child to plain SSwitch.
-                            SNode *sw_seq = factory.MakeSeq({
+                            // MakeSeq drops the prefix block when empty.
+                            std::vector<SNode *> sw_seq = factory.MakeSeq({
                                 blk->Stmts().empty() ? nullptr : blk,
                                 sw});
                             if (!node.label.empty()) {
-                                root_children.push_back(factory.Make<SLabel>(
-                                    factory.Intern(node.label), sw_seq));
+                                root_body.push_back(factory.Make<SLabel>(
+                                    factory.Intern(node.label),
+                                    std::move(sw_seq)));
                             } else {
-                                root_children.push_back(sw_seq);
+                                for (SNode *s : sw_seq)
+                                    root_body.push_back(s);
                             }
                             continue;
                         }
@@ -279,16 +285,15 @@ namespace patchestry::ast {
                         // Non-switch: append terminal (goto/if-goto)
                         if (node.terminal) blk->AddStmt(node.terminal);
                         if (!node.label.empty()) {
-                            root_children.push_back(factory.Make<SLabel>(
+                            root_body.push_back(factory.Make<SLabel>(
                                 factory.Intern(node.label), blk));
                         } else {
-                            root_children.push_back(blk);
+                            root_body.push_back(blk);
                         }
                     }
-                    root_snode = factory.MakeSeq(std::move(root_children));
                 }
 
-                EmitClangAST(root_snode, fn, ctx);
+                EmitClangAST(root_body, fn, ctx);
 
                 CleanupPrettyPrint(fn, ctx);
             }

--- a/lib/patchestry/AST/ASTConsumer.cpp
+++ b/lib/patchestry/AST/ASTConsumer.cpp
@@ -107,8 +107,7 @@ namespace patchestry::ast {
                 }
 
                 SNodeFactory factory;
-                // The function body is a sequence of SNodes
-                // (std::vector) — the SSeq node kind was removed.
+                // The function body is a sequence of SNodes.
                 std::vector<SNode *> root_body;
                 bool have_structured = false;
 
@@ -127,9 +126,8 @@ namespace patchestry::ast {
                             root_body.push_back(s);
                     }
 
-                    // A fully-empty structured result falls through to
-                    // the goto-based path below (matches prior behaviour
-                    // when MakeSeq returned nullptr).
+                    // An empty structured result falls through to the
+                    // goto-based path below.
                     if (!root_body.empty()) {
                         have_structured = true;
 
@@ -179,16 +177,10 @@ namespace patchestry::ast {
                         // sequencing).
                         RemoveDeadSSeqChildren(root_body);
 
-                        // NOTE: RemoveUnreferencedLabels is intentionally
-                        // NOT called here.  CountAllGotoRefs does not yet
-                        // walk every clang::Stmt embedded inside all SNode
-                        // kinds (e.g. if-guarded gotos synthesised by the
-                        // goto-path), so enabling it drops live labels on
-                        // some fixtures.  The duplication pass above still
-                        // inlines shared targets correctly; dead label
-                        // bodies simply remain in the output as
-                        // unreferenced labelled blocks, which is
-                        // preferable to losing reachable code.
+                        // RemoveUnreferencedLabels is intentionally NOT
+                        // called: CountAllGotoRefs misses gotos embedded
+                        // in some SNode kinds, so it would drop live
+                        // labels on some fixtures.
                     }
                 }
 

--- a/lib/patchestry/AST/ASTConsumer.cpp
+++ b/lib/patchestry/AST/ASTConsumer.cpp
@@ -117,15 +117,17 @@ namespace patchestry::ast {
 
                     // Build root SSeq from the remaining active (uncollapsed)
                     // nodes.  After StructureAll, each active node has a
-                    // ->structured SNode set.
-                    auto *seq = factory.Make<SSeq>();
+                    // ->structured SNode set.  MakeSeq normalizes (drops
+                    // null/empty children, unwraps single-child cases);
+                    // a fully-empty function yields nullptr, which the
+                    // emitter treats as an empty body.
+                    std::vector<SNode *> root_children;
                     for (auto &node : flow_graph.nodes) {
                         if (node.IsCollapsed()) continue;
-                        if (node.structured) {
-                            seq->AddChild(node.structured);
-                        }
+                        if (node.structured)
+                            root_children.push_back(node.structured);
                     }
-                    root_snode = seq;
+                    root_snode = factory.MakeSeq(std::move(root_children));
 
                     // Post-pass: replace goto→break/continue for loop labels.
                     ConvertGotoToBreakContinue(root_snode, factory);
@@ -189,7 +191,7 @@ namespace patchestry::ast {
                     // Emit the CGraph blocks sequentially with goto-based
                     // control flow from terminals.
                     // Switch blocks get an SSwitch with goto-to-label cases.
-                    auto *seq = factory.Make<SSeq>();
+                    std::vector<SNode *> root_children;
 
                     for (auto &node : flow_graph.nodes) {
                         if (node.IsCollapsed()) continue;
@@ -260,14 +262,16 @@ namespace patchestry::ast {
                                     sw->AddCase(val, body);
                                 }
                             }
-                            auto *sw_seq = factory.Make<SSeq>();
-                            if (!blk->Stmts().empty()) sw_seq->AddChild(blk);
-                            sw_seq->AddChild(sw);
+                            // MakeSeq drops the prefix block when empty
+                            // and unwraps single-child to plain SSwitch.
+                            SNode *sw_seq = factory.MakeSeq({
+                                blk->Stmts().empty() ? nullptr : blk,
+                                sw});
                             if (!node.label.empty()) {
-                                seq->AddChild(factory.Make<SLabel>(
+                                root_children.push_back(factory.Make<SLabel>(
                                     factory.Intern(node.label), sw_seq));
                             } else {
-                                seq->AddChild(sw_seq);
+                                root_children.push_back(sw_seq);
                             }
                             continue;
                         }
@@ -275,14 +279,13 @@ namespace patchestry::ast {
                         // Non-switch: append terminal (goto/if-goto)
                         if (node.terminal) blk->AddStmt(node.terminal);
                         if (!node.label.empty()) {
-                            auto *lbl = factory.Make<SLabel>(
-                                factory.Intern(node.label), blk);
-                            seq->AddChild(lbl);
+                            root_children.push_back(factory.Make<SLabel>(
+                                factory.Intern(node.label), blk));
                         } else {
-                            seq->AddChild(blk);
+                            root_children.push_back(blk);
                         }
                     }
-                    root_snode = seq;
+                    root_snode = factory.MakeSeq(std::move(root_children));
                 }
 
                 EmitClangAST(root_snode, fn, ctx);

--- a/lib/patchestry/AST/CFGStructure.cpp
+++ b/lib/patchestry/AST/CFGStructure.cpp
@@ -26,6 +26,9 @@ namespace patchestry::ast {
                               std::unordered_map<std::string_view, int> &refs) {
         if (!node) return;
 
+        // Two leaf cases that the generic for_each_child can't express:
+        //   - SGoto contributes a ref to its target label (no SNode children).
+        //   - SBlock holds raw clang::Stmt*; embedded GotoStmt also counts.
         if (auto *g = node->dyn_cast<SGoto>()) {
             refs[g->Target()]++;
             return;
@@ -43,36 +46,9 @@ namespace patchestry::ast {
             for (auto *s : blk->Stmts()) walk(s);
             return;
         }
-        if (auto *seq = node->dyn_cast<SSeq>()) {
-            for (auto *c : seq->Children()) CountGotoRefs(c, refs);
-            return;
-        }
-        if (auto *ite = node->dyn_cast<SIfThenElse>()) {
-            CountGotoRefs(ite->ThenBranch(), refs);
-            CountGotoRefs(ite->ElseBranch(), refs);
-            return;
-        }
-        if (auto *w = node->dyn_cast<SWhile>()) {
-            CountGotoRefs(w->Body(), refs);
-            return;
-        }
-        if (auto *dw = node->dyn_cast<SDoWhile>()) {
-            CountGotoRefs(dw->Body(), refs);
-            return;
-        }
-        if (auto *f = node->dyn_cast<SFor>()) {
-            CountGotoRefs(f->Body(), refs);
-            return;
-        }
-        if (auto *sw = node->dyn_cast<SSwitch>()) {
-            for (auto &c : sw->Cases()) CountGotoRefs(c.body, refs);
-            CountGotoRefs(sw->DefaultBody(), refs);
-            return;
-        }
-        if (auto *lbl = node->dyn_cast<SLabel>()) {
-            CountGotoRefs(lbl->Body(), refs);
-            return;
-        }
+
+        // All other SNode kinds: recurse uniformly via the visitor API.
+        node->for_each_child([&](SNode *c) { CountGotoRefs(c, refs); });
     }
 
     CFGStructure::CFGStructure(CGraph &g, SNodeFactory &factory,
@@ -566,11 +542,11 @@ namespace patchestry::ast {
                 auto &sn = graph_.Node(succ);
                 if (sn.original_label.empty()) continue;
                 // Wrap: SSeq { existing structured, SGoto(succ_label) }
-                auto *seq = factory_.Make<SSeq>();
-                seq->AddChild(node.structured);
-                seq->AddChild(factory_.Make<SGoto>(
-                    factory_.Intern(sn.original_label)));
-                node.structured = seq;
+                node.structured = factory_.MakeSeq({
+                    node.structured,
+                    factory_.Make<SGoto>(
+                        factory_.Intern(sn.original_label))
+                });
             }
         }
 
@@ -718,16 +694,13 @@ namespace patchestry::ast {
             }
         }
 
-        // Build the merged SNode.
-        auto *seq = factory_.Make<SSeq>();
-
-        // Add A's content (strip terminal — the A→B edge is absorbed).
+        // Build the merged SNode.  MakeSeq drops null/empty-block
+        // children and unwraps single-child results; the rare case
+        // where both are absent yields nullptr, which IdentifyInternal
+        // accepts as the representative's `structured` field.
         SNode *a_node = BuildLeafSNode(id, /*include_terminal=*/false);
-        if (a_node) seq->AddChild(a_node);
-
-        // Add B's content.
         SNode *b_node = BuildLeafSNode(b_id);
-        if (b_node) seq->AddChild(b_node);
+        SNode *seq = factory_.MakeSeq({a_node, b_node});
 
         // Collapse {A, B} into the representative node.
         graph_.IdentifyInternal({id, b_id}, CNode::BlockType::kSequence, seq);
@@ -778,20 +751,19 @@ namespace patchestry::ast {
 
     SNode *CFGStructure::WrapWithPriorContent(size_t id, SNode *child) {
         auto &a = graph_.Node(id);
-        SNode *result = child;
+        // Determine the prefix (a's prior content, if any).  Either a
+        // pre-structured SNode from an earlier rule, or a fresh SBlock
+        // wrapping a.stmts.  MakeSeq handles the no-prefix case by
+        // returning child unchanged.
+        SNode *prefix = nullptr;
         if (a.structured) {
-            auto *seq = factory_.Make<SSeq>();
-            seq->AddChild(a.structured);
-            seq->AddChild(child);
-            result = seq;
+            prefix = a.structured;
         } else if (!a.stmts.empty()) {
-            auto *seq = factory_.Make<SSeq>();
             auto *a_blk = factory_.Make<SBlock>();
             for (auto *s : a.stmts) a_blk->AddStmt(s);
-            seq->AddChild(a_blk);
-            seq->AddChild(child);
-            result = seq;
+            prefix = a_blk;
         }
+        SNode *result = factory_.MakeSeq({prefix, child});
         if (!a.original_label.empty()) {
             // Skip the wrap if `result` already exposes the label at
             // its head; loop rules emit SLabel(name, SWhile(...)) and
@@ -1504,10 +1476,7 @@ namespace patchestry::ast {
                         if (!tn.original_label.empty()) {
                             auto *go = factory_.Make<SGoto>(
                                 factory_.Intern(tn.original_label));
-                            auto *w = factory_.Make<SSeq>();
-                            if (leaf) w->AddChild(leaf);
-                            w->AddChild(go);
-                            return static_cast<SNode *>(w);
+                            return factory_.MakeSeq({leaf, go});
                         }
                     }
                 }
@@ -1545,16 +1514,10 @@ namespace patchestry::ast {
                     auto *if_goto = factory_.Make<SIfThenElse>(
                         nd.branch_cond, taken_goto, else_branch);
 
-                    auto *leaf_blk = leaf ? leaf->dyn_cast<SBlock>() : nullptr;
-                    bool leaf_empty = !nd.structured
-                        && nd.original_label.empty()
-                        && ((!leaf) || (leaf_blk && leaf_blk->Stmts().empty()));
-                    if (leaf_empty) return if_goto;
-
-                    auto *w = factory_.Make<SSeq>();
-                    if (leaf) w->AddChild(leaf);
-                    w->AddChild(if_goto);
-                    return static_cast<SNode *>(w);
+                    // MakeSeq drops empty unlabeled SBlock leaves and
+                    // unwraps the single-child case, so the explicit
+                    // leaf_empty short-circuit is no longer needed.
+                    return factory_.MakeSeq({leaf, if_goto});
                 }
                 return leaf;
             }
@@ -1583,20 +1546,10 @@ namespace patchestry::ast {
             auto *if_goto = factory_.Make<SIfThenElse>(
                 exit_cond, exit_stmt, nullptr);
 
-            // If the leaf is effectively empty (no stmts, no label),
-            // emit just the if-goto without a wrapper.  Labeled nodes
-            // are NEVER empty — the label must be preserved because
-            // external gotos may target it.
-            auto *leaf_blk = leaf ? leaf->dyn_cast<SBlock>() : nullptr;
-            bool leaf_empty = !nd.structured
-                && nd.original_label.empty()
-                && ((!leaf) || (leaf_blk && leaf_blk->Stmts().empty()));
-            if (leaf_empty) return if_goto;
-
-            auto *wrapper = factory_.Make<SSeq>();
-            if (leaf) wrapper->AddChild(leaf);
-            wrapper->AddChild(if_goto);
-            return static_cast<SNode *>(wrapper);
+            // MakeSeq drops empty unlabeled SBlock leaves; labeled
+            // SLabel-wrapped leaves and structured-content leaves
+            // survive as needed for label preservation.
+            return factory_.MakeSeq({leaf, if_goto});
         };
 
         if (interior.size() == 1) {
@@ -1660,16 +1613,14 @@ namespace patchestry::ast {
             --i;  // retry from same position (might merge 3+)
         }
 
-        // Remove any remaining empty blocks.
+        // Remove any remaining empty blocks.  MakeSeq drops empty
+        // unlabeled SBlocks too, but the explicit pre-filter keeps
+        // the merged-if-goto loop above from chasing emptied slots.
         children.erase(
             std::remove_if(children.begin(), children.end(), is_empty_block),
             children.end());
 
-        auto *seq = factory_.Make<SSeq>();
-        for (auto *child : children) {
-            seq->AddChild(child);
-        }
-        return seq;
+        return factory_.MakeSeq(std::move(children));
     }
 
     // ---------------------------------------------------------------
@@ -1721,13 +1672,13 @@ namespace patchestry::ast {
         if (s0_in_body && s1_in_body) {
             SNode *loop_body_snode = BuildLoopBodySNode(body, id, bodyset);
 
-            auto *inner = factory_.Make<SSeq>();
+            std::vector<SNode *> inner_children;
             if (h.structured) {
-                inner->AddChild(h.structured);
+                inner_children.push_back(h.structured);
             } else if (!h.stmts.empty()) {
                 auto *h_blk = factory_.Make<SBlock>();
                 for (auto *s : h.stmts) h_blk->AddStmt(s);
-                inner->AddChild(h_blk);
+                inner_children.push_back(h_blk);
             }
 
             // Header conditional: if(branch_cond) goto taken_label;
@@ -1735,12 +1686,13 @@ namespace patchestry::ast {
             if (!s1_node.original_label.empty()) {
                 auto *taken_goto = factory_.Make<SGoto>(
                     factory_.Intern(s1_node.original_label));
-                inner->AddChild(factory_.Make<SIfThenElse>(
+                inner_children.push_back(factory_.Make<SIfThenElse>(
                     h.branch_cond, taken_goto, nullptr));
             }
 
-            if (loop_body_snode) inner->AddChild(loop_body_snode);
+            inner_children.push_back(loop_body_snode);
 
+            SNode *inner = factory_.MakeSeq(std::move(inner_children));
             auto *while_node = factory_.Make<SWhile>(nullptr, inner);
             if (!h.original_label.empty())
                 while_node->SetHeaderLabel(factory_.Intern(h.original_label));
@@ -1780,24 +1732,25 @@ namespace patchestry::ast {
             // Header has computation stmts (or prior structured content)
             // that must re-execute each iteration.  Emit as:
             //   while(1) { header_content; if (exit_cond) break; body; }
-            auto *inner = factory_.Make<SSeq>();
 
             // 1. Header content (re-execute each iteration).
+            SNode *header_content = nullptr;
             if (h.structured) {
-                inner->AddChild(h.structured);
+                header_content = h.structured;
             } else {
                 auto *h_blk = factory_.Make<SBlock>();
                 for (auto *s : h.stmts) h_blk->AddStmt(s);
-                inner->AddChild(h_blk);
+                header_content = h_blk;
             }
 
             // 2. Exit test: if (exit_cond) break;
             auto *break_node = factory_.Make<SIfThenElse>(
                 exit_cond, factory_.Make<SBreak>(), nullptr);
-            inner->AddChild(break_node);
 
-            // 3. Loop body.
-            if (loop_body_snode) inner->AddChild(loop_body_snode);
+            // 3. Loop body — wrapped via MakeSeq, dropping the loop-body
+            // slot when BuildLoopBodySNode returned nullptr.
+            SNode *inner = factory_.MakeSeq({
+                header_content, break_node, loop_body_snode});
 
             // while(1) — nullptr condition → emitter synthesizes true.
             result = factory_.Make<SWhile>(nullptr, inner);
@@ -1879,16 +1832,13 @@ namespace patchestry::ast {
         // Include header's content in the body (executes each iteration).
         SNode *full_body = loop_body;
         if (h.structured || !h.stmts.empty()) {
-            auto *seq = factory_.Make<SSeq>();
-            if (h.structured) {
-                seq->AddChild(h.structured);
-            } else {
+            SNode *header_content = h.structured;
+            if (!header_content) {
                 auto *h_blk = factory_.Make<SBlock>();
                 for (auto *s : h.stmts) h_blk->AddStmt(s);
-                seq->AddChild(h_blk);
+                header_content = h_blk;
             }
-            if (loop_body) seq->AddChild(loop_body);
-            full_body = seq;
+            full_body = factory_.MakeSeq({header_content, loop_body});
         }
 
         // CGraph: succs[0] = not-taken (cond false), succs[1] = taken (cond true).
@@ -1983,16 +1933,13 @@ namespace patchestry::ast {
         // Include header content in body.
         SNode *full_body = loop_body;
         if (h.structured || !h.stmts.empty()) {
-            auto *seq = factory_.Make<SSeq>();
-            if (h.structured) {
-                seq->AddChild(h.structured);
-            } else {
+            SNode *header_content = h.structured;
+            if (!header_content) {
                 auto *h_blk = factory_.Make<SBlock>();
                 for (auto *s : h.stmts) h_blk->AddStmt(s);
-                seq->AddChild(h_blk);
+                header_content = h_blk;
             }
-            if (loop_body) seq->AddChild(loop_body);
-            full_body = seq;
+            full_body = factory_.MakeSeq({header_content, loop_body});
         }
 
         auto *inf_while = factory_.Make<SWhile>(nullptr, full_body);
@@ -2254,12 +2201,9 @@ namespace patchestry::ast {
         // A's pre-switch stmts go before the switch.
         SNode *result = sw;
         if (!a.stmts.empty()) {
-            auto *seq = factory_.Make<SSeq>();
             auto *a_blk = factory_.Make<SBlock>();
             for (auto *s : a.stmts) a_blk->AddStmt(s);
-            seq->AddChild(a_blk);
-            seq->AddChild(sw);
-            result = seq;
+            result = factory_.MakeSeq({a_blk, sw});
         }
 
         // Preserve A's label.
@@ -2424,15 +2368,10 @@ namespace patchestry::ast {
     // ---------------------------------------------------------------
 
     SNode *CFGStructure::BuildBodySNode(const std::vector<size_t> &ids) {
-        if (ids.empty()) return nullptr;
-        if (ids.size() == 1) return BuildLeafSNode(ids[0]);
-
-        auto *seq = factory_.Make<SSeq>();
-        for (size_t nid : ids) {
-            SNode *child = BuildLeafSNode(nid);
-            if (child) seq->AddChild(child);
-        }
-        return seq;
+        std::vector<SNode *> children;
+        children.reserve(ids.size());
+        for (size_t nid : ids) children.push_back(BuildLeafSNode(nid));
+        return factory_.MakeSeq(std::move(children));
     }
 
     // ---------------------------------------------------------------
@@ -2526,55 +2465,23 @@ namespace patchestry::ast {
             return changed;
         }
 
-        // Recursively process all SSeq nodes in the tree.
+        // Recursively process all SSeq nodes in the tree, bottom-up.
+        // The SSeq case is special — children are walked first, then
+        // InlineGotosInSeq runs to splice goto/label adjacencies.
+        // For every other kind, the visitor recurses uniformly.
         bool InlineGotosRecursive(
             SNode *node, SNodeFactory &factory,
             const std::unordered_map<std::string_view, int> &refs
         ) {
             if (!node) return false;
             bool changed = false;
-
+            node->for_each_child([&](SNode *c) {
+                if (InlineGotosRecursive(c, factory, refs)) changed = true;
+            });
             if (auto *seq = node->dyn_cast<SSeq>()) {
-                // Process children first (bottom-up).
-                for (size_t i = 0; i < seq->Size(); ++i) {
-                    if (InlineGotosRecursive((*seq)[i], factory, refs))
-                        changed = true;
-                }
-                if (InlineGotosInSeq(seq, factory, refs))
-                    changed = true;
-                return changed;
+                if (InlineGotosInSeq(seq, factory, refs)) changed = true;
             }
-
-            if (auto *ite = node->dyn_cast<SIfThenElse>()) {
-                if (InlineGotosRecursive(ite->ThenBranch(), factory, refs))
-                    changed = true;
-                if (InlineGotosRecursive(ite->ElseBranch(), factory, refs))
-                    changed = true;
-                return changed;
-            }
-            if (auto *w = node->dyn_cast<SWhile>()) {
-                return InlineGotosRecursive(w->Body(), factory, refs);
-            }
-            if (auto *dw = node->dyn_cast<SDoWhile>()) {
-                return InlineGotosRecursive(dw->Body(), factory, refs);
-            }
-            if (auto *f = node->dyn_cast<SFor>()) {
-                return InlineGotosRecursive(f->Body(), factory, refs);
-            }
-            if (auto *sw = node->dyn_cast<SSwitch>()) {
-                for (auto &c : sw->Cases()) {
-                    if (InlineGotosRecursive(c.body, factory, refs))
-                        changed = true;
-                }
-                if (InlineGotosRecursive(sw->DefaultBody(), factory, refs))
-                    changed = true;
-                return changed;
-            }
-            if (auto *lbl = node->dyn_cast<SLabel>()) {
-                return InlineGotosRecursive(lbl->Body(), factory, refs);
-            }
-
-            return false;
+            return changed;
         }
 
     } // anonymous namespace
@@ -2637,23 +2544,11 @@ namespace patchestry::ast {
                                 clang::ASTContext &ctx) {
             if (!node) return false;
             bool changed = false;
+            node->for_each_child([&](SNode *c) {
+                if (EliminateRecursive(c, factory, ctx)) changed = true;
+            });
             if (auto *seq = node->dyn_cast<SSeq>()) {
-                for (auto *child : seq->Children())
-                    if (EliminateRecursive(child, factory, ctx)) changed = true;
                 if (EliminateInSSeq(seq, factory, ctx)) changed = true;
-            } else if (auto *ite = node->dyn_cast<SIfThenElse>()) {
-                if (EliminateRecursive(ite->ThenBranch(), factory, ctx)) changed = true;
-                if (EliminateRecursive(ite->ElseBranch(), factory, ctx)) changed = true;
-            } else if (auto *w = node->dyn_cast<SWhile>()) {
-                if (EliminateRecursive(w->Body(), factory, ctx)) changed = true;
-            } else if (auto *dw = node->dyn_cast<SDoWhile>()) {
-                if (EliminateRecursive(dw->Body(), factory, ctx)) changed = true;
-            } else if (auto *lbl = node->dyn_cast<SLabel>()) {
-                if (EliminateRecursive(lbl->Body(), factory, ctx)) changed = true;
-            } else if (auto *sw = node->dyn_cast<SSwitch>()) {
-                for (auto &c : sw->Cases())
-                    if (EliminateRecursive(c.body, factory, ctx)) changed = true;
-                if (EliminateRecursive(sw->DefaultBody(), factory, ctx)) changed = true;
             }
             return changed;
         }
@@ -2976,50 +2871,53 @@ namespace patchestry::ast {
             if (!node) return false;
             if (node->dyn_cast<SLabel>()) return true;
 
-            if (auto *seq = node->dyn_cast<SSeq>()) {
-                for (auto *c : seq->Children())
-                    if (SubtreeHasLabel(c)) return true;
-                return false;
-            }
-            if (auto *ite = node->dyn_cast<SIfThenElse>()) {
-                return SubtreeHasLabel(ite->ThenBranch())
-                    || SubtreeHasLabel(ite->ElseBranch());
-            }
-            if (auto *w = node->dyn_cast<SWhile>())
-                return SubtreeHasLabel(w->Body());
-            if (auto *dw = node->dyn_cast<SDoWhile>())
-                return SubtreeHasLabel(dw->Body());
-            if (auto *f = node->dyn_cast<SFor>())
-                return SubtreeHasLabel(f->Body());
-            if (auto *sw = node->dyn_cast<SSwitch>()) {
-                for (auto &c : sw->Cases())
-                    if (SubtreeHasLabel(c.body)) return true;
-                return SubtreeHasLabel(sw->DefaultBody());
-            }
             // SBlock may hold a clang::LabelStmt — check too.
+            // (SBlock has no SNode children, so we return early.)
             if (auto *blk = node->dyn_cast<SBlock>()) {
                 for (auto *s : blk->Stmts())
                     if (llvm::isa<clang::LabelStmt>(s)) return true;
                 return false;
             }
-            return false;
+
+            // Uniform recursion via the visitor API: any descendant
+            // SLabel triggers the early return above on the next call.
+            bool found = false;
+            node->for_each_child([&](SNode *c) {
+                if (!found && SubtreeHasLabel(c)) found = true;
+            });
+            return found;
         }
 
         /// Locate an SLabel by name anywhere in the tree, returning
         /// the enclosing SSeq and the label's index within it.  Only
         /// labels that are *direct children of an SSeq* are returned —
         /// labels embedded as bodies of if/while/switch or as the sole
-        /// child of an SLabel do not qualify (removing them requires
-        /// parent-slot mutation which the caller cannot perform with a
-        /// generic SSeq interface).
+        /// child of an SLabel do not qualify.
+        ///
+        /// The SSeq-position restriction is intentional and load-bearing:
+        ///   - Inlining checks (preceding-sibling-terminates) need a
+        ///     genuine sibling list, not a single-slot body.
+        ///   - The body's break/continue stmts have lexical scope
+        ///     determined by enclosing loops; moving a body that
+        ///     contains break/continue across loop boundaries would
+        ///     change which loop the terminator refers to.
+        ///
+        /// Layer C Stage 2d migrates only the descent dispatch to
+        /// for_each_child for consistency with Stages 2a–c.  Widening
+        /// the search to non-SSeq positions (Benefit 3 from the
+        /// migration analysis) needs the vector slot storage from
+        /// Stage 3+ before it can be done with the right safety
+        /// analysis — deferred to a follow-up policy change.
         struct LabelLoc {
             SSeq *parent = nullptr;
             size_t idx = 0;
         };
 
-        bool FindLabelInSSeq(SNode *node, std::string_view name,
-                             LabelLoc &out) {
+        bool FindLabel(SNode *node, std::string_view name, LabelLoc &out) {
             if (!node) return false;
+            // SSeq is the only kind that can hold the label as a
+            // direct child — check children first, then descend
+            // into nested kinds via for_each_child.
             if (auto *seq = node->dyn_cast<SSeq>()) {
                 for (size_t i = 0; i < seq->Size(); ++i) {
                     if (auto *lbl = (*seq)[i]->dyn_cast<SLabel>()) {
@@ -3030,30 +2928,12 @@ namespace patchestry::ast {
                         }
                     }
                 }
-                for (size_t i = 0; i < seq->Size(); ++i) {
-                    if (FindLabelInSSeq((*seq)[i], name, out))
-                        return true;
-                }
-                return false;
             }
-            if (auto *ite = node->dyn_cast<SIfThenElse>()) {
-                return FindLabelInSSeq(ite->ThenBranch(), name, out)
-                    || FindLabelInSSeq(ite->ElseBranch(), name, out);
-            }
-            if (auto *w = node->dyn_cast<SWhile>())
-                return FindLabelInSSeq(w->Body(), name, out);
-            if (auto *dw = node->dyn_cast<SDoWhile>())
-                return FindLabelInSSeq(dw->Body(), name, out);
-            if (auto *f = node->dyn_cast<SFor>())
-                return FindLabelInSSeq(f->Body(), name, out);
-            if (auto *sw = node->dyn_cast<SSwitch>()) {
-                for (auto &c : sw->Cases())
-                    if (FindLabelInSSeq(c.body, name, out)) return true;
-                return FindLabelInSSeq(sw->DefaultBody(), name, out);
-            }
-            if (auto *lbl = node->dyn_cast<SLabel>())
-                return FindLabelInSSeq(lbl->Body(), name, out);
-            return false;
+            bool found = false;
+            node->for_each_child([&](SNode *c) {
+                if (!found && FindLabel(c, name, out)) found = true;
+            });
+            return found;
         }
 
         /// Attempt to inline a single goto slot.  `get` returns the
@@ -3074,7 +2954,7 @@ namespace patchestry::ast {
             if (it == refs.end() || it->second != 1) return false;
 
             LabelLoc loc;
-            if (!FindLabelInSSeq(root, target, loc)) return false;
+            if (!FindLabel(root, target, loc)) return false;
 
             auto *lbl = (*loc.parent)[loc.idx]->as<SLabel>();
             SNode *body = lbl->Body();
@@ -3313,25 +3193,11 @@ namespace patchestry::ast {
                              const std::unordered_map<std::string_view, int> &refs) {
             if (!node) return false;
             bool changed = false;
+            node->for_each_child([&](SNode *c) {
+                if (AbsorbRecursive(c, refs)) changed = true;
+            });
             if (auto *seq = node->dyn_cast<SSeq>()) {
-                for (auto *child : seq->Children())
-                    if (AbsorbRecursive(child, refs)) changed = true;
                 if (AbsorbInSSeq(seq, refs)) changed = true;
-            } else if (auto *ite = node->dyn_cast<SIfThenElse>()) {
-                if (AbsorbRecursive(ite->ThenBranch(), refs)) changed = true;
-                if (AbsorbRecursive(ite->ElseBranch(), refs)) changed = true;
-            } else if (auto *w = node->dyn_cast<SWhile>()) {
-                if (AbsorbRecursive(w->Body(), refs)) changed = true;
-            } else if (auto *dw = node->dyn_cast<SDoWhile>()) {
-                if (AbsorbRecursive(dw->Body(), refs)) changed = true;
-            } else if (auto *f = node->dyn_cast<SFor>()) {
-                if (AbsorbRecursive(f->Body(), refs)) changed = true;
-            } else if (auto *lbl = node->dyn_cast<SLabel>()) {
-                if (AbsorbRecursive(lbl->Body(), refs)) changed = true;
-            } else if (auto *sw = node->dyn_cast<SSwitch>()) {
-                for (auto &c : sw->Cases())
-                    if (AbsorbRecursive(c.body, refs)) changed = true;
-                if (AbsorbRecursive(sw->DefaultBody(), refs)) changed = true;
             }
             return changed;
         }
@@ -3360,27 +3226,15 @@ namespace patchestry::ast {
         bool ScopeifyHasLabel(SNode *node) {
             if (!node) return false;
             if (node->dyn_cast<SLabel>()) return true;
-            if (auto *seq = node->dyn_cast<SSeq>()) {
-                for (auto *c : seq->Children())
-                    if (ScopeifyHasLabel(c)) return true;
-                return false;
-            }
-            if (auto *ite = node->dyn_cast<SIfThenElse>()) {
-                return ScopeifyHasLabel(ite->ThenBranch())
-                    || ScopeifyHasLabel(ite->ElseBranch());
-            }
-            if (auto *w = node->dyn_cast<SWhile>())
-                return ScopeifyHasLabel(w->Body());
-            if (auto *dw = node->dyn_cast<SDoWhile>())
-                return ScopeifyHasLabel(dw->Body());
-            if (auto *f = node->dyn_cast<SFor>())
-                return ScopeifyHasLabel(f->Body());
-            if (auto *sw = node->dyn_cast<SSwitch>()) {
-                for (auto &c : sw->Cases())
-                    if (ScopeifyHasLabel(c.body)) return true;
-                return ScopeifyHasLabel(sw->DefaultBody());
-            }
-            return false;
+            // Note: this scan deliberately does NOT inspect clang::LabelStmt
+            // inside SBlock (unlike SubtreeHasLabel).  Preserving that
+            // narrower scope; the SBlock leaf has no SNode children so
+            // the visitor simply returns false for it.
+            bool found = false;
+            node->for_each_child([&](SNode *c) {
+                if (!found && ScopeifyHasLabel(c)) found = true;
+            });
+            return found;
         }
 
 
@@ -3432,16 +3286,14 @@ namespace patchestry::ast {
                     }
                     if (has_label) continue;
 
-                    // Build scoped body from intermediates
-                    SNode *scoped_body;
-                    if (label_idx - i - 1 == 1) {
-                        scoped_body = children[i + 1];
-                    } else {
-                        auto *inner = factory.Make<SSeq>();
-                        for (size_t j = i + 1; j < label_idx; ++j)
-                            inner->AddChild(children[j]);
-                        scoped_body = inner;
-                    }
+                    // Build scoped body from intermediates.  MakeSeq
+                    // unwraps the size-1 case automatically.
+                    std::vector<SNode *> scoped_children;
+                    scoped_children.reserve(label_idx - i - 1);
+                    for (size_t j = i + 1; j < label_idx; ++j)
+                        scoped_children.push_back(children[j]);
+                    SNode *scoped_body =
+                        factory.MakeSeq(std::move(scoped_children));
 
                     // Negate condition
                     auto *neg = NegateExpr(ctx, ite->Cond());
@@ -3470,35 +3322,11 @@ namespace patchestry::ast {
                                const std::unordered_map<std::string_view, int> &refs) {
             if (!node) return false;
             bool changed = false;
+            node->for_each_child([&](SNode *c) {
+                if (ScopeifyRecursive(c, factory, ctx, refs)) changed = true;
+            });
             if (auto *seq = node->dyn_cast<SSeq>()) {
-                for (auto *child : seq->Children())
-                    if (ScopeifyRecursive(child, factory, ctx, refs))
-                        changed = true;
-                if (ScopeifyInSSeq(seq, factory, ctx, refs))
-                    changed = true;
-            } else if (auto *ite = node->dyn_cast<SIfThenElse>()) {
-                if (ScopeifyRecursive(ite->ThenBranch(), factory, ctx, refs))
-                    changed = true;
-                if (ScopeifyRecursive(ite->ElseBranch(), factory, ctx, refs))
-                    changed = true;
-            } else if (auto *w = node->dyn_cast<SWhile>()) {
-                if (ScopeifyRecursive(w->Body(), factory, ctx, refs))
-                    changed = true;
-            } else if (auto *dw = node->dyn_cast<SDoWhile>()) {
-                if (ScopeifyRecursive(dw->Body(), factory, ctx, refs))
-                    changed = true;
-            } else if (auto *f = node->dyn_cast<SFor>()) {
-                if (ScopeifyRecursive(f->Body(), factory, ctx, refs))
-                    changed = true;
-            } else if (auto *lbl = node->dyn_cast<SLabel>()) {
-                if (ScopeifyRecursive(lbl->Body(), factory, ctx, refs))
-                    changed = true;
-            } else if (auto *sw = node->dyn_cast<SSwitch>()) {
-                for (auto &c : sw->Cases())
-                    if (ScopeifyRecursive(c.body, factory, ctx, refs))
-                        changed = true;
-                if (ScopeifyRecursive(sw->DefaultBody(), factory, ctx, refs))
-                    changed = true;
+                if (ScopeifyInSSeq(seq, factory, ctx, refs)) changed = true;
             }
             return changed;
         }
@@ -3534,18 +3362,21 @@ namespace patchestry::ast {
     namespace {
 
         /// Check if an SNode contains any SLabel (directly or nested).
+        /// Note: this scan uses the visitor API and therefore now also
+        /// descends through SWhile/SDoWhile/SFor/SSwitch/SLabel bodies
+        /// — the previous implementation only descended through SSeq
+        /// and SIfThenElse, which was a latent under-scan that could
+        /// false-negative on labels nested inside loop/switch arms.
+        /// Conservative direction (more "yes, has label" answers) so
+        /// safe with respect to the dead-code removal caller.
         bool ContainsLabel(SNode *node) {
             if (!node) return false;
             if (node->dyn_cast<SLabel>()) return true;
-            if (auto *seq = node->dyn_cast<SSeq>()) {
-                for (auto *c : seq->Children())
-                    if (ContainsLabel(c)) return true;
-            }
-            if (auto *ite = node->dyn_cast<SIfThenElse>()) {
-                return ContainsLabel(ite->ThenBranch())
-                    || ContainsLabel(ite->ElseBranch());
-            }
-            return false;
+            bool found = false;
+            node->for_each_child([&](SNode *c) {
+                if (!found && ContainsLabel(c)) found = true;
+            });
+            return found;
         }
 
         /// Trim dead stmts inside an SBlock after the first terminator.
@@ -3637,27 +3468,15 @@ namespace patchestry::ast {
         bool RemoveDeadRecursive(SNode *node) {
             if (!node) return false;
             bool changed = false;
-            if (auto *seq = node->dyn_cast<SSeq>()) {
-                for (size_t i = 0; i < seq->Size(); ++i)
-                    if (RemoveDeadRecursive((*seq)[i])) changed = true;
-                if (RemoveDeadInSSeq(seq)) changed = true;
-            } else if (auto *ite = node->dyn_cast<SIfThenElse>()) {
-                if (RemoveDeadRecursive(ite->ThenBranch())) changed = true;
-                if (RemoveDeadRecursive(ite->ElseBranch())) changed = true;
-            } else if (auto *w = node->dyn_cast<SWhile>()) {
-                if (RemoveDeadRecursive(w->Body())) changed = true;
-            } else if (auto *dw = node->dyn_cast<SDoWhile>()) {
-                if (RemoveDeadRecursive(dw->Body())) changed = true;
-            } else if (auto *f = node->dyn_cast<SFor>()) {
-                if (RemoveDeadRecursive(f->Body())) changed = true;
-            } else if (auto *lbl = node->dyn_cast<SLabel>()) {
-                if (RemoveDeadRecursive(lbl->Body())) changed = true;
-            } else if (auto *sw = node->dyn_cast<SSwitch>()) {
-                for (auto &c : sw->Cases())
-                    if (RemoveDeadRecursive(c.body)) changed = true;
-                if (RemoveDeadRecursive(sw->DefaultBody())) changed = true;
-            } else if (auto *blk = node->dyn_cast<SBlock>()) {
+            if (auto *blk = node->dyn_cast<SBlock>()) {
                 if (TrimDeadStmtsInSBlock(blk)) changed = true;
+                return changed;  // SBlock has no SNode children
+            }
+            node->for_each_child([&](SNode *c) {
+                if (RemoveDeadRecursive(c)) changed = true;
+            });
+            if (auto *seq = node->dyn_cast<SSeq>()) {
+                if (RemoveDeadInSSeq(seq)) changed = true;
             }
             return changed;
         }
@@ -3793,17 +3612,12 @@ namespace patchestry::ast {
                             // SBlock: remove trailing goto, wrap block + break/continue.
                             auto *block = branch->as<SBlock>();
                             block->Stmts().pop_back();
-                            if (block->Empty()) {
-                                // Block only had the goto — replace entirely.
-                                if (arm == 0) ite->SetThenBranch(replacement);
-                                else ite->SetElseBranch(replacement);
-                            } else {
-                                auto *seq = factory.Make<SSeq>();
-                                seq->AddChild(block);
-                                seq->AddChild(replacement);
-                                if (arm == 0) ite->SetThenBranch(seq);
-                                else ite->SetElseBranch(seq);
-                            }
+                            // MakeSeq drops the now-empty SBlock (no
+                            // label) and unwraps to just `replacement`,
+                            // so the explicit Empty() branch collapses.
+                            SNode *new_arm = factory.MakeSeq({block, replacement});
+                            if (arm == 0) ite->SetThenBranch(new_arm);
+                            else ite->SetElseBranch(new_arm);
                         }
                         if (arm == 0) then_replaced = true;
                         else else_replaced = true;
@@ -4755,12 +4569,11 @@ namespace patchestry::ast {
                 return out;
             }
             if (auto *seq = src->dyn_cast<SSeq>()) {
-                auto *out = factory.Make<SSeq>();
-                for (auto *c : seq->Children()) {
-                    auto *cc = CloneSNode(c, factory);
-                    if (cc) out->AddChild(cc);
-                }
-                return out;
+                std::vector<SNode *> cloned;
+                cloned.reserve(seq->Size());
+                for (auto *c : seq->Children())
+                    cloned.push_back(CloneSNode(c, factory));
+                return factory.MakeSeq(std::move(cloned));
             }
             if (auto *ite = src->dyn_cast<SIfThenElse>()) {
                 return factory.Make<SIfThenElse>(
@@ -4871,10 +4684,7 @@ namespace patchestry::ast {
             bool need_break = NeedsTerminatorBreak(clone);
             auto wrap_with_break = [&](SNode *n) -> SNode * {
                 if (!need_break) return n;
-                auto *seq = factory.Make<SSeq>();
-                seq->AddChild(n);
-                seq->AddChild(factory.Make<SBreak>());
-                return seq;
+                return factory.MakeSeq({n, factory.Make<SBreak>()});
             };
 
             // Pure SGoto — replace with clone (+ break).
@@ -4897,11 +4707,9 @@ namespace patchestry::ast {
                 trimmed->SetLabel(blk->Label());
                 for (size_t i = 0; i + 1 < blk->Size(); ++i)
                     trimmed->AddStmt(blk->Stmts()[i]);
-                auto *seq = factory.Make<SSeq>();
-                seq->AddChild(trimmed);
-                seq->AddChild(clone);
-                if (need_break) seq->AddChild(factory.Make<SBreak>());
-                return seq;
+                std::vector<SNode *> spliced{trimmed, clone};
+                if (need_break) spliced.push_back(factory.Make<SBreak>());
+                return factory.MakeSeq(std::move(spliced));
             }
 
             // SLabel wrapping any of the above: splice inside, keep the
@@ -4919,32 +4727,33 @@ namespace patchestry::ast {
                 if (seq->Empty()) return nullptr;
                 SNode *last = seq->Children().back();
 
-                // Case A: last child is bare SGoto → drop it.
-                if (last->dyn_cast<SGoto>()) {
-                    auto *out = factory.Make<SSeq>();
+                auto build_out = [&](SNode *trimmed_last) -> SNode * {
+                    std::vector<SNode *> out;
+                    out.reserve(seq->Size() + 2);
                     for (size_t i = 0; i + 1 < seq->Size(); ++i)
-                        out->AddChild(seq->Children()[i]);
-                    out->AddChild(clone);
-                    if (need_break) out->AddChild(factory.Make<SBreak>());
-                    return out;
-                }
+                        out.push_back(seq->Children()[i]);
+                    if (trimmed_last) out.push_back(trimmed_last);
+                    out.push_back(clone);
+                    if (need_break) out.push_back(factory.Make<SBreak>());
+                    return factory.MakeSeq(std::move(out));
+                };
+
+                // Case A: last child is bare SGoto → drop it.
+                if (last->dyn_cast<SGoto>()) return build_out(nullptr);
+
                 // Case B: last child is SBlock with trailing GotoStmt.
                 if (auto *blk = last->dyn_cast<SBlock>()) {
                     if (!blk->Empty()
                         && llvm::isa<clang::GotoStmt>(blk->Stmts().back())) {
-                        auto *out = factory.Make<SSeq>();
-                        for (size_t i = 0; i + 1 < seq->Size(); ++i)
-                            out->AddChild(seq->Children()[i]);
+                        SNode *trimmed = nullptr;
                         if (blk->Size() > 1) {
-                            auto *trimmed = factory.Make<SBlock>();
-                            trimmed->SetLabel(blk->Label());
+                            auto *t = factory.Make<SBlock>();
+                            t->SetLabel(blk->Label());
                             for (size_t i = 0; i + 1 < blk->Size(); ++i)
-                                trimmed->AddStmt(blk->Stmts()[i]);
-                            out->AddChild(trimmed);
+                                t->AddStmt(blk->Stmts()[i]);
+                            trimmed = t;
                         }
-                        out->AddChild(clone);
-                        if (need_break) out->AddChild(factory.Make<SBreak>());
-                        return out;
+                        return build_out(trimmed);
                     }
                 }
                 return nullptr;
@@ -4991,37 +4800,17 @@ namespace patchestry::ast {
         ) {
             if (!node) return false;
             bool changed = false;
+            // Run the switch-specific duplication on SSwitch nodes
+            // before descending — DuplicateInSwitch can replace case
+            // bodies, and we want recursion to see the new shapes.
             if (auto *sw = node->dyn_cast<SSwitch>()) {
                 if (DuplicateInSwitch(sw, factory, labels)) changed = true;
-                for (auto &c : sw->Cases())
-                    if (WalkAndDuplicate(c.body, factory, labels))
-                        changed = true;
-                if (WalkAndDuplicate(sw->DefaultBody(), factory, labels))
-                    changed = true;
-                return changed;
             }
-            if (auto *seq = node->dyn_cast<SSeq>()) {
-                for (auto *c : seq->Children())
-                    if (WalkAndDuplicate(c, factory, labels))
-                        changed = true;
-                return changed;
-            }
-            if (auto *ite = node->dyn_cast<SIfThenElse>()) {
-                if (WalkAndDuplicate(ite->ThenBranch(), factory, labels))
-                    changed = true;
-                if (WalkAndDuplicate(ite->ElseBranch(), factory, labels))
-                    changed = true;
-                return changed;
-            }
-            if (auto *w = node->dyn_cast<SWhile>())
-                return WalkAndDuplicate(w->Body(), factory, labels);
-            if (auto *dw = node->dyn_cast<SDoWhile>())
-                return WalkAndDuplicate(dw->Body(), factory, labels);
-            if (auto *f = node->dyn_cast<SFor>())
-                return WalkAndDuplicate(f->Body(), factory, labels);
-            if (auto *lbl = node->dyn_cast<SLabel>())
-                return WalkAndDuplicate(lbl->Body(), factory, labels);
-            return false;
+            // Uniform descent into every SNode child slot.
+            node->for_each_child([&](SNode *c) {
+                if (WalkAndDuplicate(c, factory, labels)) changed = true;
+            });
+            return changed;
         }
 
         /// Debug assertion: every remaining goto target resolves to a

--- a/lib/patchestry/AST/CFGStructure.cpp
+++ b/lib/patchestry/AST/CFGStructure.cpp
@@ -2853,7 +2853,7 @@ namespace patchestry::ast {
                 if (!SNodeAlwaysTerminates(sw->DefaultBody()))
                     return false;
                 for (auto &c : sw->Cases()) {
-                    if (!SNodeAlwaysTerminates(c.body))
+                    if (!SNodeAlwaysTerminates(c.body()))
                         return false;
                 }
                 return true;
@@ -3050,7 +3050,7 @@ namespace patchestry::ast {
             if (auto *sw = node->dyn_cast<SSwitch>()) {
                 for (size_t ci = 0; ci < sw->Cases().size(); ++ci) {
                     auto &c = sw->Cases()[ci];
-                    if (CrossScopeInlineRecursive(c.body, root, refs))
+                    if (CrossScopeInlineRecursive(c.body(), root, refs))
                         return true;
                 }
                 if (CrossScopeInlineRecursive(
@@ -3058,9 +3058,9 @@ namespace patchestry::ast {
                     return true;
                 for (size_t ci = 0; ci < sw->Cases().size(); ++ci) {
                     if (TryInlineGotoSlot(
-                            [sw, ci]() { return sw->Cases()[ci].body; },
+                            [sw, ci]() { return sw->Cases()[ci].body(); },
                             [sw, ci](SNode *n) {
-                                sw->Cases()[ci].body = n;
+                                sw->Cases()[ci].set_body(n);
                                 if (n) n->SetParent(sw);
                             },
                             root, refs))
@@ -3661,7 +3661,7 @@ namespace patchestry::ast {
 
             if (auto *sw = node->dyn_cast<SSwitch>()) {
                 for (auto &c : sw->Cases()) {
-                    if (ConvertGotosInNode(c.body, factory, scopes))
+                    if (ConvertGotosInNode(c.body(), factory, scopes))
                         changed = true;
                 }
                 if (ConvertGotosInNode(sw->DefaultBody(), factory, scopes))
@@ -3772,7 +3772,7 @@ namespace patchestry::ast {
                 return;
             }
             if (auto *sw = node->dyn_cast<SSwitch>()) {
-                for (auto &c : sw->Cases()) CollectLabels(c.body, labels);
+                for (auto &c : sw->Cases()) CollectLabels(c.body(), labels);
                 CollectLabels(sw->DefaultBody(), labels);
                 return;
             }
@@ -4306,7 +4306,7 @@ namespace patchestry::ast {
             }
             if (auto *sw = node->dyn_cast<SSwitch>()) {
                 for (auto &c : sw->Cases()) {
-                    if (ReplaceGotoWithReturn(c.body, factory, ctx, labels))
+                    if (ReplaceGotoWithReturn(c.body(), factory, ctx, labels))
                         changed = true;
                 }
                 if (ReplaceGotoWithReturn(sw->DefaultBody(), factory, ctx, labels))
@@ -4392,7 +4392,7 @@ namespace patchestry::ast {
                 CountAllGotoRefs(f->Body(), refs); return;
             }
             if (auto *sw = node->dyn_cast<SSwitch>()) {
-                for (auto &c : sw->Cases()) CountAllGotoRefs(c.body, refs);
+                for (auto &c : sw->Cases()) CountAllGotoRefs(c.body(), refs);
                 CountAllGotoRefs(sw->DefaultBody(), refs);
                 return;
             }
@@ -4445,7 +4445,7 @@ namespace patchestry::ast {
                 return RemoveDeadLabelsRecursive(dw->Body(), refs);
             if (auto *sw = node->dyn_cast<SSwitch>()) {
                 for (auto &c : sw->Cases())
-                    if (RemoveDeadLabelsRecursive(c.body, refs)) changed = true;
+                    if (RemoveDeadLabelsRecursive(c.body(), refs)) changed = true;
                 if (RemoveDeadLabelsRecursive(sw->DefaultBody(), refs)) changed = true;
                 return changed;
             }
@@ -4502,7 +4502,7 @@ namespace patchestry::ast {
             if (auto *sw = node->dyn_cast<SSwitch>()) {
                 size_t n = 1;
                 for (auto &c : sw->Cases()) {
-                    n += CountCloneStmts(c.body);
+                    n += CountCloneStmts(c.body());
                     if (n > kMaxCloneStmts) return n;
                 }
                 n += CountCloneStmts(sw->DefaultBody());
@@ -4542,7 +4542,7 @@ namespace patchestry::ast {
             }
             if (auto *sw = node->dyn_cast<SSwitch>()) {
                 for (auto &c : sw->Cases())
-                    if (!SubtreeIsSafeToClone(c.body)) return false;
+                    if (!SubtreeIsSafeToClone(c.body())) return false;
                 return SubtreeIsSafeToClone(sw->DefaultBody());
             }
             // Reject SLabel (would duplicate definition) and all loops.
@@ -4584,7 +4584,7 @@ namespace patchestry::ast {
             if (auto *sw = src->dyn_cast<SSwitch>()) {
                 auto *out = factory.Make<SSwitch>(sw->Discriminant());
                 for (auto &c : sw->Cases())
-                    out->AddCase(c.value, CloneSNode(c.body, factory));
+                    out->AddCase(c.value, CloneSNode(c.body(), factory));
                 if (sw->DefaultBody())
                     out->SetDefaultBody(CloneSNode(sw->DefaultBody(), factory));
                 return out;
@@ -4768,13 +4768,13 @@ namespace patchestry::ast {
         ) {
             bool changed = false;
             for (auto &c : sw->Cases()) {
-                auto target = TrailingGotoTarget(c.body);
+                auto target = TrailingGotoTarget(c.body());
                 if (target.empty()) continue;
                 SNode *clone = TryCloneLabelBody(target, labels, factory);
                 if (!clone) continue;
-                SNode *spliced = BuildSplicedBody(c.body, clone, factory);
+                SNode *spliced = BuildSplicedBody(c.body(), clone, factory);
                 if (!spliced) continue;
-                c.body = spliced;
+                c.set_body(spliced);
                 spliced->SetParent(sw);
                 changed = true;
             }

--- a/lib/patchestry/AST/CFGStructure.cpp
+++ b/lib/patchestry/AST/CFGStructure.cpp
@@ -110,14 +110,26 @@ namespace patchestry::ast {
     // Run `worker` on every body-vector in the tree rooted at the
     // sequence `seq`, post-order: deepest body-vectors first, then
     // `seq` itself.  `worker` returns true if it mutated the list.
+    //
+    // With `stop_after_change`, the traversal unwinds immediately once
+    // `worker` reports a mutation — no suspended ancestor loop resumes
+    // over a vector the worker may have mutated.  Required for workers
+    // that mutate a non-local sequence (e.g. cross-scope inlining).
     static bool ForEachSeqPostOrder(
         std::vector< SNode * > &seq,
-        const std::function< bool(std::vector< SNode * > &) > &worker) {
+        const std::function< bool(std::vector< SNode * > &) > &worker,
+        bool stop_after_change = false) {
         bool changed = false;
         for (SNode *child : seq) {
+            bool stop = false;
             ForEachBodyList(child, [&](std::vector< SNode * > &body) {
-                if (ForEachSeqPostOrder(body, worker)) changed = true;
+                if (stop) return;
+                if (ForEachSeqPostOrder(body, worker, stop_after_change)) {
+                    changed = true;
+                    if (stop_after_change) stop = true;
+                }
             });
+            if (stop) return true;
         }
         if (worker(seq)) changed = true;
         return changed;
@@ -3028,17 +3040,18 @@ namespace patchestry::ast {
         // goto, so the initial ref count bounds the loop.
         size_t max_passes = std::min(refs.size() + 1, size_t{20});
         for (size_t p = 0; p < max_passes; ++p) {
-            bool done = false;
-            ForEachSeqPostOrder(
-                root, [&](std::vector< SNode * > &seq) {
-                    if (done) return false;
-                    if (CrossScopeInlineInSeq(seq, root, refs)) {
-                        done = true;
-                        return true;
-                    }
-                    return false;
-                });
-            if (!done) break;
+            // stop_after_change: CrossScopeInlineInSeq erases the target
+            // label from whatever sequence holds it — possibly a strict
+            // ancestor of the goto's sequence.  Unwinding immediately
+            // keeps a suspended ancestor traversal from resuming over
+            // the mutated vector (iterator invalidation / UB).
+            bool changed = ForEachSeqPostOrder(
+                root,
+                [&](std::vector< SNode * > &seq) {
+                    return CrossScopeInlineInSeq(seq, root, refs);
+                },
+                /*stop_after_change=*/true);
+            if (!changed) break;
             any_changed = true;
             refs.clear();
             CountGotoRefs(root, refs);

--- a/lib/patchestry/AST/CFGStructure.cpp
+++ b/lib/patchestry/AST/CFGStructure.cpp
@@ -3099,7 +3099,12 @@ namespace patchestry::ast {
 
                 auto rc = refs.find(lbl->Name());
                 if (rc != refs.end() && rc->second > 0) continue;
-                if (!SNodeAlwaysTerminates(ite->ThenBranch())) continue;
+                // The whole then-sequence must terminate — ThenBranch()
+                // only exposes then_[0], so a multi-statement then that
+                // ends in a return would otherwise be missed.
+                if (ite->ThenList().empty()
+                    || !SNodeAlwaysTerminates(ite->ThenList().back()))
+                    continue;
 
                 ite->SetElseBranch(lbl->BodyList());
 

--- a/lib/patchestry/AST/CFGStructure.cpp
+++ b/lib/patchestry/AST/CFGStructure.cpp
@@ -3635,9 +3635,13 @@ namespace patchestry::ast {
                 out.push_back(s);
                 return out.size() <= max_stmts;
             }
-            // SIfThenElse where both arms terminate.
+            // SIfThenElse where both arms terminate.  An empty else
+            // falls through, so it cannot be flattened as a terminating
+            // body — hard-fail rather than drop the fallthrough path
+            // (the else is filled later by AbsorbFallthroughIntoElse).
             if (auto *ite = body->dyn_cast<SIfThenElse>()) {
-                if (!ite->Cond() || ite->ThenList().empty())
+                if (!ite->Cond() || ite->ThenList().empty()
+                    || ite->ElseList().empty())
                     return false;
                 std::vector<clang::Stmt *> then_stmts, else_stmts;
                 if (!FlattenTerminatingSeq(
@@ -3653,7 +3657,7 @@ namespace patchestry::ast {
                         loc, loc);
                 }
                 clang::Stmt *else_body = nullptr;
-                if (!ite->ElseList().empty()) {
+                {
                     if (!FlattenTerminatingSeq(
                             ite->ElseList(), ctx, else_stmts, max_stmts))
                         return false;

--- a/lib/patchestry/AST/CFGStructure.cpp
+++ b/lib/patchestry/AST/CFGStructure.cpp
@@ -51,6 +51,73 @@ namespace patchestry::ast {
         node->for_each_child([&](SNode *c) { CountGotoRefs(c, refs); });
     }
 
+    // Count goto refs across a sequence (vector) of SNodes.
+    static void CountGotoRefs(const std::vector< SNode * > &seq,
+                              std::unordered_map<std::string_view, int> &refs) {
+        for (auto *c : seq) CountGotoRefs(c, refs);
+    }
+
+    // Append every element of `src` onto `dst`.  Helper for the
+    // SSeq-free model where a "sequence" is a std::vector<SNode*>.
+    static void SeqAppend(std::vector< SNode * > &dst,
+                          const std::vector< SNode * > &src) {
+        dst.insert(dst.end(), src.begin(), src.end());
+    }
+
+    // Invoke fn(std::vector<SNode*>&) on each body-vector slot held by
+    // `node` (SLabel/loop bodies, if-then/else arms, switch case lists).
+    // SGoto/SBlock/SBreak/SContinue/SReturn carry no body-vectors.
+    // This replaces the old SSeq-based child sequencing now that the
+    // SSeq node kind no longer exists.
+    template< typename Fn >
+    static void ForEachBodyList(SNode *node, Fn &&fn) {
+        if (!node) return;
+        switch (node->Kind()) {
+            case SNodeKind::kLabel:
+                fn(node->as< SLabel >()->BodyList());
+                break;
+            case SNodeKind::kWhile:
+                fn(node->as< SWhile >()->BodyList());
+                break;
+            case SNodeKind::kDoWhile:
+                fn(node->as< SDoWhile >()->BodyList());
+                break;
+            case SNodeKind::kFor:
+                fn(node->as< SFor >()->BodyList());
+                break;
+            case SNodeKind::kIfThenElse: {
+                auto *ite = node->as< SIfThenElse >();
+                fn(ite->ThenList());
+                fn(ite->ElseList());
+                break;
+            }
+            case SNodeKind::kSwitch: {
+                auto *sw = node->as< SSwitch >();
+                for (auto &c : sw->Cases()) fn(c.body_list);
+                fn(sw->DefaultBodyList());
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
+    // Run `worker` on every body-vector in the tree rooted at the
+    // sequence `seq`, post-order: deepest body-vectors first, then
+    // `seq` itself.  `worker` returns true if it mutated the list.
+    static bool ForEachSeqPostOrder(
+        std::vector< SNode * > &seq,
+        const std::function< bool(std::vector< SNode * > &) > &worker) {
+        bool changed = false;
+        for (SNode *child : seq) {
+            ForEachBodyList(child, [&](std::vector< SNode * > &body) {
+                if (ForEachSeqPostOrder(body, worker)) changed = true;
+            });
+        }
+        if (worker(seq)) changed = true;
+        return changed;
+    }
+
     CFGStructure::CFGStructure(CGraph &g, SNodeFactory &factory,
                                          clang::ASTContext &ctx)
         : graph_(g), factory_(factory), ctx_(ctx) {}
@@ -129,6 +196,23 @@ namespace patchestry::ast {
                 break;  // restart scan — topology changed
             }
         }
+    }
+
+    // After a rule emits an explicit `if(cond) goto X` SNode for one
+    // arm of a conditional, the graph edge rep→X is redundant — the
+    // jump is now encoded in the SNode, not the topology.  Drop it so
+    // downstream rules treat the rep as a plain fallthrough node
+    // instead of re-structuring it as a two-way conditional (which
+    // duplicates the guard and can strand the fallthrough block).
+    static void ConsumeGotoEdge(CGraph &g, size_t rep, size_t target) {
+        auto &n = g.Node(rep);
+        bool present = false;
+        for (size_t s : n.succs) {
+            if (s == target) { present = true; break; }
+        }
+        if (!present) return;
+        g.RemoveEdge(rep, target);
+        n.is_conditional = n.succs.size() >= 2;
     }
 
     // ---------------------------------------------------------------
@@ -509,9 +593,9 @@ namespace patchestry::ast {
         }
 
         // Wrap any remaining uncollapsed leaf nodes so they have an
-        // SNode for the emitter to consume.
+        // SNode sequence for the emitter to consume.
         for (auto &node : graph_.nodes) {
-            if (!node.IsCollapsed() && node.structured == nullptr) {
+            if (!node.IsCollapsed() && node.structured.empty()) {
                 node.structured = BuildLeafSNode(node.id);
             }
         }
@@ -530,7 +614,7 @@ namespace patchestry::ast {
 
             for (size_t idx = 0; idx < active_order.size(); ++idx) {
                 auto &node = graph_.Node(active_order[idx]);
-                if (!node.structured) continue;
+                if (node.structured.empty()) continue;
                 if (node.succs.size() != 1) continue;
                 // Skip if the sole successor IS the next active node
                 // (fallthrough is correct).
@@ -541,12 +625,9 @@ namespace patchestry::ast {
                 // Successor is NOT next — need explicit goto.
                 auto &sn = graph_.Node(succ);
                 if (sn.original_label.empty()) continue;
-                // Wrap: SSeq { existing structured, SGoto(succ_label) }
-                node.structured = factory_.MakeSeq({
-                    node.structured,
-                    factory_.Make<SGoto>(
-                        factory_.Intern(sn.original_label))
-                });
+                // Append an explicit SGoto to the node's structured seq.
+                node.structured.push_back(factory_.Make<SGoto>(
+                    factory_.Intern(sn.original_label)));
             }
         }
 
@@ -557,27 +638,30 @@ namespace patchestry::ast {
         //
         // Check recursively: the label might be inside an SSeq child
         // (e.g., after the explicit-goto pass wrapped the node).
-        auto has_label = [](const SNode *sn, std::string_view name) -> bool {
+        auto has_label = [](const std::vector<SNode *> &snodes,
+                            std::string_view name) -> bool {
             std::function<bool(const SNode *)> check = [&](const SNode *n) -> bool {
                 if (!n) return false;
                 if (auto *lbl = n->dyn_cast<SLabel>())
-                    return lbl->Name() == name || check(lbl->Body());
-                if (auto *seq = n->dyn_cast<SSeq>()) {
-                    for (auto *c : seq->Children())
-                        if (check(c)) return true;
-                }
-                return false;
+                    if (lbl->Name() == name) return true;
+                bool found = false;
+                n->for_each_child([&](const SNode *c) {
+                    if (!found && check(c)) found = true;
+                });
+                return found;
             };
-            return check(sn);
+            for (const auto *n : snodes)
+                if (check(n)) return true;
+            return false;
         };
 
         for (auto &node : graph_.nodes) {
             if (node.IsCollapsed()) continue;
             if (node.original_label.empty()) continue;
-            if (!node.structured) continue;
+            if (node.structured.empty()) continue;
             if (has_label(node.structured, node.original_label)) continue;
-            node.structured = factory_.Make<SLabel>(
-                factory_.Intern(node.original_label), node.structured);
+            node.structured = { factory_.Make<SLabel>(
+                factory_.Intern(node.original_label), node.structured) };
         }
     }
 
@@ -694,16 +778,13 @@ namespace patchestry::ast {
             }
         }
 
-        // Build the merged SNode.  MakeSeq drops null/empty-block
-        // children and unwraps single-child results; the rare case
-        // where both are absent yields nullptr, which IdentifyInternal
-        // accepts as the representative's `structured` field.
-        SNode *a_node = BuildLeafSNode(id, /*include_terminal=*/false);
-        SNode *b_node = BuildLeafSNode(b_id);
-        SNode *seq = factory_.MakeSeq({a_node, b_node});
+        // Build the merged sequence: A's content followed by B's.
+        std::vector< SNode * > seq = BuildLeafSNode(id, /*include_terminal=*/false);
+        SeqAppend(seq, BuildLeafSNode(b_id));
 
         // Collapse {A, B} into the representative node.
-        graph_.IdentifyInternal({id, b_id}, CNode::BlockType::kSequence, seq);
+        graph_.IdentifyInternal({id, b_id}, CNode::BlockType::kSequence,
+                                std::move(seq));
 
         return true;
     }
@@ -749,39 +830,32 @@ namespace patchestry::ast {
     // WrapWithPriorContent — shared helper for all if/if-else rules
     // ---------------------------------------------------------------
 
-    SNode *CFGStructure::WrapWithPriorContent(size_t id, SNode *child) {
+    std::vector< SNode * > CFGStructure::WrapWithPriorContent(
+        size_t id, SNode *child) {
         auto &a = graph_.Node(id);
-        // Determine the prefix (a's prior content, if any).  Either a
-        // pre-structured SNode from an earlier rule, or a fresh SBlock
-        // wrapping a.stmts.  MakeSeq handles the no-prefix case by
-        // returning child unchanged.
-        SNode *prefix = nullptr;
-        if (a.structured) {
-            prefix = a.structured;
+        // Prefix: a's prior content — either a pre-structured sequence
+        // from an earlier rule, or a fresh SBlock wrapping a.stmts.
+        std::vector< SNode * > result;
+        if (!a.structured.empty()) {
+            result = a.structured;
         } else if (!a.stmts.empty()) {
             auto *a_blk = factory_.Make<SBlock>();
             for (auto *s : a.stmts) a_blk->AddStmt(s);
-            prefix = a_blk;
+            result.push_back(a_blk);
         }
-        SNode *result = factory_.MakeSeq({prefix, child});
+        if (child) result.push_back(child);
         if (!a.original_label.empty()) {
             // Skip the wrap if `result` already exposes the label at
             // its head; loop rules emit SLabel(name, SWhile(...)) and
             // a second wrap would produce duplicate LabelStmts.
-            std::function<bool(const SNode *)> head_has_label =
-                [&](const SNode *n) -> bool {
-                    if (!n) return false;
-                    if (auto *lbl = n->dyn_cast<SLabel>())
-                        return lbl->Name() == a.original_label;
-                    if (auto *seq = n->dyn_cast<SSeq>()) {
-                        if (seq->Size() == 0) return false;
-                        return head_has_label((*seq)[0]);
-                    }
-                    return false;
-                };
-            if (!head_has_label(result)) {
-                result = factory_.Make<SLabel>(
-                    factory_.Intern(a.original_label), result);
+            bool head_has_label = false;
+            if (!result.empty()) {
+                if (auto *lbl = result[0]->dyn_cast<SLabel>())
+                    head_has_label = (lbl->Name() == a.original_label);
+            }
+            if (!head_has_label) {
+                return { factory_.Make<SLabel>(
+                    factory_.Intern(a.original_label), result) };
             }
         }
         return result;
@@ -830,11 +904,11 @@ namespace patchestry::ast {
             && HasSoleRealPredecessor(t_id, id) && t.succs.size() == 1
             && t.succs[0] == f_id && !t.is_conditional)
         {
-            auto *then_body = BuildLeafSNode(t_id, /*include_terminal=*/false);
+            auto then_body = BuildLeafSNode(t_id, /*include_terminal=*/false);
             auto *if_node = factory_.Make<SIfThenElse>(
-                a.branch_cond, then_body, nullptr);
+                a.branch_cond, then_body, std::vector< SNode * >{});
 
-            SNode *result = WrapWithPriorContent(id, if_node);
+            std::vector< SNode * > result = WrapWithPriorContent(id, if_node);
 
             graph_.IdentifyInternal({id, t_id}, CNode::BlockType::kIf, result);
             return true;
@@ -859,7 +933,7 @@ namespace patchestry::ast {
         // stmts cleared by IdentifyInternal but carry content in structured.
         if (!skip_case1
             && HasSoleRealPredecessor(t_id, id) && t.is_conditional
-            && t.stmts.empty() && !t.structured
+            && t.stmts.empty() && t.structured.empty()
             && t.succs.size() == 2 && t.branch_cond)
         {
             bool t_s0_is_merge = (t.succs[0] == f_id);
@@ -910,8 +984,11 @@ namespace patchestry::ast {
                         factory_.Make<SGoto>(factory_.Intern(f.original_label)),
                         nullptr);
 
-                    SNode *result = WrapWithPriorContent(id, if_goto);
+                    std::vector< SNode * > result = WrapWithPriorContent(id, if_goto);
                     graph_.IdentifyInternal({id, t_id}, CNode::BlockType::kIf, result);
+                    // The guard jumps to f via an explicit goto; the
+                    // fallthrough is the non-merge arm.
+                    ConsumeGotoEdge(graph_, id, f_id);
                     return true;
                 }
 
@@ -940,8 +1017,11 @@ namespace patchestry::ast {
                         factory_.Make<SGoto>(factory_.Intern(target_node.original_label)),
                         nullptr);
 
-                    SNode *result = WrapWithPriorContent(id, if_goto);
+                    std::vector< SNode * > result = WrapWithPriorContent(id, if_goto);
                     graph_.IdentifyInternal({id, t_id}, CNode::BlockType::kIf, result);
+                    // The guard jumps to goto_target via an explicit
+                    // goto; the fallthrough is the merge arm.
+                    ConsumeGotoEdge(graph_, id, goto_target);
                     return true;
                 }
             }
@@ -954,13 +1034,14 @@ namespace patchestry::ast {
             && HasSoleRealPredecessor(f_id, id) && f.succs.size() == 1
             && f.succs[0] == t_id && !f.is_conditional)
         {
-            auto *then_body = BuildLeafSNode(f_id, /*include_terminal=*/false);
+            auto then_body = BuildLeafSNode(f_id, /*include_terminal=*/false);
             // The condition is for the taken branch (T = merge).
             // The body executes when the condition is false — negate.
             auto *if_node = factory_.Make<SIfThenElse>(
-                NegateExpr(ctx_, a.branch_cond), then_body, nullptr);
+                NegateExpr(ctx_, a.branch_cond), then_body,
+                std::vector< SNode * >{});
 
-            SNode *result = WrapWithPriorContent(id, if_node);
+            std::vector< SNode * > result = WrapWithPriorContent(id, if_node);
 
             graph_.IdentifyInternal({id, f_id}, CNode::BlockType::kIf, result);
             return true;
@@ -977,7 +1058,7 @@ namespace patchestry::ast {
         // See Case 1b for rationale.  Guard: must not have structured SNode.
         if (!skip_case2
             && HasSoleRealPredecessor(f_id, id) && f.is_conditional
-            && f.stmts.empty() && !f.structured
+            && f.stmts.empty() && f.structured.empty()
             && f.succs.size() == 2 && f.branch_cond)
         {
             bool f_s0_is_merge = (f.succs[0] == t_id);
@@ -1016,8 +1097,11 @@ namespace patchestry::ast {
                         factory_.Make<SGoto>(factory_.Intern(t.original_label)),
                         nullptr);
 
-                    SNode *result = WrapWithPriorContent(id, if_goto);
+                    std::vector< SNode * > result = WrapWithPriorContent(id, if_goto);
                     graph_.IdentifyInternal({id, f_id}, CNode::BlockType::kIf, result);
+                    // The guard jumps to t via an explicit goto; the
+                    // fallthrough is the non-merge arm.
+                    ConsumeGotoEdge(graph_, id, t_id);
                     return true;
                 }
 
@@ -1045,8 +1129,11 @@ namespace patchestry::ast {
                         factory_.Make<SGoto>(factory_.Intern(target_node.original_label)),
                         nullptr);
 
-                    SNode *result = WrapWithPriorContent(id, if_goto);
+                    std::vector< SNode * > result = WrapWithPriorContent(id, if_goto);
                     graph_.IdentifyInternal({id, f_id}, CNode::BlockType::kIf, result);
+                    // The guard jumps to goto_target via an explicit
+                    // goto; the fallthrough is the merge arm.
+                    ConsumeGotoEdge(graph_, id, goto_target);
                     return true;
                 }
             }
@@ -1178,16 +1265,17 @@ namespace patchestry::ast {
             if (merge.IsCollapsed()) continue;
 
             // Build if-then: body is the then-branch.
-            auto *then_body = BuildLeafSNode(body_id, /*include_terminal=*/false);
+            auto then_body = BuildLeafSNode(body_id, /*include_terminal=*/false);
 
             // Negate condition if body is the not-taken arm (orient==1).
             clang::Expr *cond = orient == 0
                 ? a.branch_cond
                 : NegateExpr(ctx_, a.branch_cond);
 
-            auto *if_node = factory_.Make<SIfThenElse>(cond, then_body, nullptr);
+            auto *if_node = factory_.Make<SIfThenElse>(
+                cond, then_body, std::vector< SNode * >{});
 
-            SNode *result = WrapWithPriorContent(id, if_node);
+            std::vector< SNode * > result = WrapWithPriorContent(id, if_node);
 
             // Collapse {A, body} with exit to merge.
             graph_.IdentifyInternal(
@@ -1267,12 +1355,12 @@ namespace patchestry::ast {
             bool f_sole = HasSoleRealPredecessor(f_id, id);
 
             if (t_sole && f_sole) {
-                auto *then_body = BuildLeafSNode(t_id, /*include_terminal=*/false);
-                auto *else_body = BuildLeafSNode(f_id, /*include_terminal=*/false);
+                auto then_body = BuildLeafSNode(t_id, /*include_terminal=*/false);
+                auto else_body = BuildLeafSNode(f_id, /*include_terminal=*/false);
                 auto *if_node = factory_.Make<SIfThenElse>(
                     a.branch_cond, then_body, else_body);
 
-                SNode *result = WrapWithPriorContent(id, if_node);
+                std::vector< SNode * > result = WrapWithPriorContent(id, if_node);
 
                 graph_.IdentifyInternal(
                     {id, t_id, f_id}, CNode::BlockType::kIf, result);
@@ -1285,23 +1373,23 @@ namespace patchestry::ast {
             // branches instead of only the original one.
             size_t sole_id;
             bool sole_is_taken;
-            if (t_sole && !f_sole && f.stmts.empty() && !f.structured) {
+            if (t_sole && !f_sole && f.stmts.empty() && f.structured.empty()) {
                 sole_id = t_id; sole_is_taken = true;
-            } else if (f_sole && !t_sole && t.stmts.empty() && !t.structured) {
+            } else if (f_sole && !t_sole && t.stmts.empty() && t.structured.empty()) {
                 sole_id = f_id; sole_is_taken = false;
             } else {
                 return false;
             }
 
             {
-                auto *sole_body = BuildLeafSNode(sole_id, /*include_terminal=*/false);
+                auto sole_body = BuildLeafSNode(sole_id, /*include_terminal=*/false);
                 clang::Expr *cond = sole_is_taken
                     ? a.branch_cond
                     : NegateExpr(ctx_, a.branch_cond);
                 auto *if_node = factory_.Make<SIfThenElse>(
-                    cond, sole_body, nullptr);
+                    cond, sole_body, std::vector< SNode * >{});
 
-                SNode *result = WrapWithPriorContent(id, if_node);
+                std::vector< SNode * > result = WrapWithPriorContent(id, if_node);
 
                 graph_.IdentifyInternal(
                     {id, sole_id}, CNode::BlockType::kIf, result);
@@ -1351,13 +1439,13 @@ namespace patchestry::ast {
 
         // Build the if-then-else SNode.
         // Both arms include their terminal (return stmt).
-        auto *then_body = BuildLeafSNode(t_id, /*include_terminal=*/true);
-        auto *else_body = BuildLeafSNode(f_id, /*include_terminal=*/true);
+        auto then_body = BuildLeafSNode(t_id, /*include_terminal=*/true);
+        auto else_body = BuildLeafSNode(f_id, /*include_terminal=*/true);
         auto *if_node = factory_.Make<SIfThenElse>(
             a.branch_cond, then_body, else_body);
 
         // A's prior content goes before the if: use a.structured
-        SNode *result = WrapWithPriorContent(id, if_node);
+        std::vector< SNode * > result = WrapWithPriorContent(id, if_node);
 
         graph_.IdentifyInternal(
             {id, t_id, f_id}, CNode::BlockType::kIf, result);
@@ -1382,7 +1470,7 @@ namespace patchestry::ast {
             if (!nd.IsCollapsed()) {
                 // Active node — keep as-is.
                 if (seen.insert(nid).second) resolved.push_back(nid);
-            } else if (nd.structured) {
+            } else if (!nd.structured.empty()) {
                 // Collapsed but has structured content from a prior rule.
                 // Keep the original id so BuildLoopBodySNode can use
                 // its structured SNode.  Don't resolve to representative
@@ -1418,7 +1506,7 @@ namespace patchestry::ast {
     // strips terminals from interior nodes, and wraps in SSeq.
     // ---------------------------------------------------------------
 
-    SNode *CFGStructure::BuildLoopBodySNode(
+    std::vector< SNode * > CFGStructure::BuildLoopBodySNode(
         const std::vector<size_t> &body, size_t header_id,
         const std::unordered_set<size_t> &bodyset
     ) {
@@ -1436,7 +1524,7 @@ namespace patchestry::ast {
             auto &nd = graph_.Node(nid);
             if (!nd.IsCollapsed()) {
                 if (seen.insert(nid).second) interior.push_back(nid);
-            } else if (nd.structured) {
+            } else if (!nd.structured.empty()) {
                 // Collapsed but has structured content — include it.
                 if (seen.insert(nid).second) interior.push_back(nid);
             }
@@ -1444,7 +1532,7 @@ namespace patchestry::ast {
         std::sort(interior.begin(), interior.end());
 
         if (interior.empty()) {
-            return factory_.Make<SBlock>(); // empty body
+            return { factory_.Make<SBlock>() }; // empty body
         }
 
         // Helper: for a conditional interior node, if one successor
@@ -1454,14 +1542,17 @@ namespace patchestry::ast {
         // next_rpo_id: node ID of the next interior block in RPO order,
         // or SIZE_MAX if this is the last block.  Used to decide whether
         // stripping a terminal goto produces correct fallthrough.
-        auto build_node = [&](size_t nid, size_t next_rpo_id) -> SNode * {
+        auto build_node = [&](size_t nid,
+                              size_t next_rpo_id) -> std::vector< SNode * > {
             auto &nd = graph_.Node(nid);
 
-            // Collapsed nodes with a pre-built structured SNode: return
+            // Collapsed nodes with pre-built structured content: return
             // it directly — don't try to access succs/preds (stale).
-            if (nd.IsCollapsed() && nd.structured) return nd.structured;
+            if (nd.IsCollapsed() && !nd.structured.empty())
+                return nd.structured;
 
-            SNode *leaf = BuildLeafSNode(nid, /*include_terminal=*/false);
+            std::vector< SNode * > leaf =
+                BuildLeafSNode(nid, /*include_terminal=*/false);
 
             // Non-conditional nodes: check if the sole successor is
             // the next RPO block.  If not, emit an explicit goto to
@@ -1474,9 +1565,8 @@ namespace patchestry::ast {
                         && !nd.IsGotoOut(0)) {
                         auto &tn = graph_.Node(target);
                         if (!tn.original_label.empty()) {
-                            auto *go = factory_.Make<SGoto>(
-                                factory_.Intern(tn.original_label));
-                            return factory_.MakeSeq({leaf, go});
+                            leaf.push_back(factory_.Make<SGoto>(
+                                factory_.Intern(tn.original_label)));
                         }
                     }
                 }
@@ -1514,10 +1604,8 @@ namespace patchestry::ast {
                     auto *if_goto = factory_.Make<SIfThenElse>(
                         nd.branch_cond, taken_goto, else_branch);
 
-                    // MakeSeq drops empty unlabeled SBlock leaves and
-                    // unwraps the single-child case, so the explicit
-                    // leaf_empty short-circuit is no longer needed.
-                    return factory_.MakeSeq({leaf, if_goto});
+                    leaf.push_back(if_goto);
+                    return leaf;
                 }
                 return leaf;
             }
@@ -1546,10 +1634,8 @@ namespace patchestry::ast {
             auto *if_goto = factory_.Make<SIfThenElse>(
                 exit_cond, exit_stmt, nullptr);
 
-            // MakeSeq drops empty unlabeled SBlock leaves; labeled
-            // SLabel-wrapped leaves and structured-content leaves
-            // survive as needed for label preservation.
-            return factory_.MakeSeq({leaf, if_goto});
+            leaf.push_back(if_goto);
+            return leaf;
         };
 
         if (interior.size() == 1) {
@@ -1562,8 +1648,7 @@ namespace patchestry::ast {
         for (size_t idx = 0; idx < interior.size(); ++idx) {
             size_t next = (idx + 1 < interior.size())
                 ? interior[idx + 1] : SIZE_MAX;
-            SNode *child = build_node(interior[idx], next);
-            if (child) children.push_back(child);
+            SeqAppend(children, build_node(interior[idx], next));
         }
 
         // Merge pass: look for SIfThenElse(cond, SGoto(L), null) nodes
@@ -1670,11 +1755,12 @@ namespace patchestry::ast {
         // loop exit — all exits are from interior nodes.  Build as
         // while(1) { header_stmts; if(cond) goto taken; body; }
         if (s0_in_body && s1_in_body) {
-            SNode *loop_body_snode = BuildLoopBodySNode(body, id, bodyset);
+            std::vector< SNode * > loop_body_snode =
+                BuildLoopBodySNode(body, id, bodyset);
 
             std::vector<SNode *> inner_children;
-            if (h.structured) {
-                inner_children.push_back(h.structured);
+            if (!h.structured.empty()) {
+                SeqAppend(inner_children, h.structured);
             } else if (!h.stmts.empty()) {
                 auto *h_blk = factory_.Make<SBlock>();
                 for (auto *s : h.stmts) h_blk->AddStmt(s);
@@ -1690,10 +1776,10 @@ namespace patchestry::ast {
                     h.branch_cond, taken_goto, nullptr));
             }
 
-            inner_children.push_back(loop_body_snode);
+            SeqAppend(inner_children, loop_body_snode);
 
-            SNode *inner = factory_.MakeSeq(std::move(inner_children));
-            auto *while_node = factory_.Make<SWhile>(nullptr, inner);
+            auto *while_node = factory_.Make<SWhile>(
+                nullptr, std::move(inner_children));
             if (!h.original_label.empty())
                 while_node->SetHeaderLabel(factory_.Intern(h.original_label));
             if (lb->exit_block != LoopBody::kNone) {
@@ -1710,7 +1796,7 @@ namespace patchestry::ast {
             }
 
             ClearMarks(graph_, body);
-            graph_.IdentifyInternal(body, CNode::BlockType::kWhile, result);
+            graph_.IdentifyInternal(body, CNode::BlockType::kWhile, {result});
             return true;
         }
 
@@ -1725,39 +1811,39 @@ namespace patchestry::ast {
             ? NegateExpr(ctx_, h.branch_cond)   // exit on not-taken → exit when false
             : h.branch_cond;                     // exit on taken → exit when true
 
-        SNode *loop_body_snode = BuildLoopBodySNode(body, id, bodyset);
+        std::vector< SNode * > loop_body_snode =
+            BuildLoopBodySNode(body, id, bodyset);
         SNode *result = nullptr;
 
-        if (h.structured || !h.stmts.empty()) {
+        if (!h.structured.empty() || !h.stmts.empty()) {
             // Header has computation stmts (or prior structured content)
             // that must re-execute each iteration.  Emit as:
             //   while(1) { header_content; if (exit_cond) break; body; }
 
             // 1. Header content (re-execute each iteration).
-            SNode *header_content = nullptr;
-            if (h.structured) {
-                header_content = h.structured;
+            std::vector< SNode * > inner;
+            if (!h.structured.empty()) {
+                SeqAppend(inner, h.structured);
             } else {
                 auto *h_blk = factory_.Make<SBlock>();
                 for (auto *s : h.stmts) h_blk->AddStmt(s);
-                header_content = h_blk;
+                inner.push_back(h_blk);
             }
 
             // 2. Exit test: if (exit_cond) break;
-            auto *break_node = factory_.Make<SIfThenElse>(
-                exit_cond, factory_.Make<SBreak>(), nullptr);
+            inner.push_back(factory_.Make<SIfThenElse>(
+                exit_cond, factory_.Make<SBreak>(), nullptr));
 
-            // 3. Loop body — wrapped via MakeSeq, dropping the loop-body
-            // slot when BuildLoopBodySNode returned nullptr.
-            SNode *inner = factory_.MakeSeq({
-                header_content, break_node, loop_body_snode});
+            // 3. Loop body.
+            SeqAppend(inner, loop_body_snode);
 
             // while(1) — nullptr condition → emitter synthesizes true.
-            result = factory_.Make<SWhile>(nullptr, inner);
+            result = factory_.Make<SWhile>(nullptr, std::move(inner));
         } else {
             // Pure condition header (no side-effectful stmts).
             // Emit as: while(continue_cond) { body; }
-            result = factory_.Make<SWhile>(continue_cond, loop_body_snode);
+            result = factory_.Make<SWhile>(continue_cond,
+                                           std::move(loop_body_snode));
         }
 
         // Set loop scope labels for break/continue resolution.
@@ -1777,7 +1863,7 @@ namespace patchestry::ast {
         }
 
         ClearMarks(graph_, body);
-        graph_.IdentifyInternal(body, CNode::BlockType::kWhile, result);
+        graph_.IdentifyInternal(body, CNode::BlockType::kWhile, {result});
         return true;
     }
 
@@ -1827,19 +1913,20 @@ namespace patchestry::ast {
         // Build do-while: body excludes the tail's branch condition.
         // The tail's stmts (before the branch) are part of the body.
         std::unordered_set<size_t> bodyset(body.begin(), body.end());
-        SNode *loop_body = BuildLoopBodySNode(body, id, bodyset);
+        std::vector< SNode * > loop_body = BuildLoopBodySNode(body, id, bodyset);
 
         // Include header's content in the body (executes each iteration).
-        SNode *full_body = loop_body;
-        if (h.structured || !h.stmts.empty()) {
-            SNode *header_content = h.structured;
-            if (!header_content) {
+        std::vector< SNode * > full_body;
+        if (!h.structured.empty() || !h.stmts.empty()) {
+            if (!h.structured.empty()) {
+                SeqAppend(full_body, h.structured);
+            } else {
                 auto *h_blk = factory_.Make<SBlock>();
                 for (auto *s : h.stmts) h_blk->AddStmt(s);
-                header_content = h_blk;
+                full_body.push_back(h_blk);
             }
-            full_body = factory_.MakeSeq({header_content, loop_body});
         }
+        SeqAppend(full_body, loop_body);
 
         // CGraph: succs[0] = not-taken (cond false), succs[1] = taken (cond true).
         // If the back-edge to header is on taken (s1), continue cond = branch_cond.
@@ -1847,7 +1934,8 @@ namespace patchestry::ast {
         clang::Expr *dowhile_cond = s1_is_header
             ? tail.branch_cond
             : NegateExpr(ctx_, tail.branch_cond);
-        auto *dowhile_node = factory_.Make<SDoWhile>(full_body, dowhile_cond);
+        auto *dowhile_node = factory_.Make<SDoWhile>(
+            std::move(full_body), dowhile_cond);
 
         // Set loop scope labels for break/continue resolution.
         if (!h.original_label.empty())
@@ -1866,7 +1954,7 @@ namespace patchestry::ast {
         }
 
         ClearMarks(graph_, body);
-        graph_.IdentifyInternal(body, CNode::BlockType::kDoWhile, result);
+        graph_.IdentifyInternal(body, CNode::BlockType::kDoWhile, {result});
         return true;
     }
 
@@ -1897,7 +1985,7 @@ namespace patchestry::ast {
         // rule.  Re-wrapping a while/do-while in while(1) creates
         // nested degenerate wrappers with unreachable post-loop code.
         // Also handles spurious loops caused by goto-edge markings.
-        if (body.size() == 1 && body[0] == id && h.structured) {
+        if (body.size() == 1 && body[0] == id && !h.structured.empty()) {
             ClearMarks(graph_, body);
             return false;
         }
@@ -1928,21 +2016,23 @@ namespace patchestry::ast {
         // Build infinite loop: while(1) { body }
         // Pass nullptr as the condition — the emitter synthesizes a
         // true literal (IntegerLiteral 1) for null SWhile conditions.
-        SNode *loop_body = BuildLoopBodySNode(body, id, bodyset);
+        std::vector< SNode * > loop_body = BuildLoopBodySNode(body, id, bodyset);
 
         // Include header content in body.
-        SNode *full_body = loop_body;
-        if (h.structured || !h.stmts.empty()) {
-            SNode *header_content = h.structured;
-            if (!header_content) {
+        std::vector< SNode * > full_body;
+        if (!h.structured.empty() || !h.stmts.empty()) {
+            if (!h.structured.empty()) {
+                SeqAppend(full_body, h.structured);
+            } else {
                 auto *h_blk = factory_.Make<SBlock>();
                 for (auto *s : h.stmts) h_blk->AddStmt(s);
-                header_content = h_blk;
+                full_body.push_back(h_blk);
             }
-            full_body = factory_.MakeSeq({header_content, loop_body});
         }
+        SeqAppend(full_body, loop_body);
 
-        auto *inf_while = factory_.Make<SWhile>(nullptr, full_body);
+        auto *inf_while = factory_.Make<SWhile>(
+            nullptr, std::move(full_body));
 
         // Set header label for continue resolution (no exit label for inf loops).
         if (!h.original_label.empty())
@@ -1955,7 +2045,7 @@ namespace patchestry::ast {
         }
 
         ClearMarks(graph_, body);
-        graph_.IdentifyInternal(body, CNode::BlockType::kWhile, result);
+        graph_.IdentifyInternal(body, CNode::BlockType::kWhile, {result});
         return true;
     }
 
@@ -2025,7 +2115,7 @@ namespace patchestry::ast {
             }
 
             // Build case body from the target block.
-            SNode *case_body = nullptr;
+            std::vector< SNode * > case_body;
 
             // Absorb the target block if all its predecessors come from
             // the switch node (or nodes already in the collapse set).
@@ -2053,7 +2143,7 @@ namespace patchestry::ast {
                 // SIfThenElse that absorbs reachable successors,
                 // eliminating gotos where possible.
                 bool pure_dispatcher = tn.stmts.empty()
-                    && !tn.structured && tn.terminal
+                    && tn.structured.empty() && tn.terminal
                     && tn.is_conditional && tn.succs.size() == 2
                     && tn.branch_cond;
 
@@ -2117,12 +2207,13 @@ namespace patchestry::ast {
                     };
 
                     // Build then/else bodies: absorb or emit goto.
-                    auto build_branch = [&](size_t sid) -> SNode * {
+                    auto build_branch =
+                        [&](size_t sid) -> std::vector< SNode * > {
                         if (can_absorb_succ(sid)) {
                             auto &sn = graph_.Node(sid);
                             bool nested_disp = sn.stmts.empty()
-                                && !sn.structured && sn.terminal;
-                            SNode *body = BuildLeafSNode(sid,
+                                && sn.structured.empty() && sn.terminal;
+                            std::vector< SNode * > body = BuildLeafSNode(sid,
                                 /*include_terminal=*/nested_disp);
                             if (std::find(collapse_ids.begin(),
                                     collapse_ids.end(), sid)
@@ -2132,22 +2223,21 @@ namespace patchestry::ast {
                         }
                         auto &sn = graph_.Node(sid);
                         if (!sn.original_label.empty())
-                            return static_cast<SNode *>(
-                                factory_.Make<SGoto>(
-                                    factory_.Intern(sn.original_label)));
-                        return static_cast<SNode *>(factory_.Make<SBlock>());
+                            return { factory_.Make<SGoto>(
+                                factory_.Intern(sn.original_label)) };
+                        return { factory_.Make<SBlock>() };
                     };
 
-                    SNode *then_body = build_branch(t_id);
-                    SNode *else_body = build_branch(f_id);
-                    case_body = factory_.Make<SIfThenElse>(
-                        tn.branch_cond, then_body, else_body);
+                    std::vector< SNode * > then_body = build_branch(t_id);
+                    std::vector< SNode * > else_body = build_branch(f_id);
+                    case_body = { factory_.Make<SIfThenElse>(
+                        tn.branch_cond, then_body, else_body) };
 
                     // Wrap with dispatcher's label if present.
                     if (!tn.original_label.empty()) {
-                        case_body = factory_.Make<SLabel>(
+                        case_body = { factory_.Make<SLabel>(
                             factory_.Intern(tn.original_label),
-                            case_body);
+                            case_body) };
                     }
                 } else {
                     // Keep terminal if the target has a successor outside
@@ -2180,10 +2270,10 @@ namespace patchestry::ast {
                     LOG(WARNING) << "RuleBlockSwitch: target node "
                                  << target << " missing label for goto"
                                  << " — emitting empty case body\n";
-                    case_body = factory_.Make<SBlock>();
+                    case_body = { factory_.Make<SBlock>() };
                 } else {
                     const std::string &lbl = tn.original_label;
-                    case_body = factory_.Make<SGoto>(factory_.Intern(lbl));
+                    case_body = { factory_.Make<SGoto>(factory_.Intern(lbl)) };
                 }
             }
 
@@ -2199,21 +2289,22 @@ namespace patchestry::ast {
         }
 
         // A's pre-switch stmts go before the switch.
-        SNode *result = sw;
+        std::vector< SNode * > result;
         if (!a.stmts.empty()) {
             auto *a_blk = factory_.Make<SBlock>();
             for (auto *s : a.stmts) a_blk->AddStmt(s);
-            result = factory_.MakeSeq({a_blk, sw});
+            result.push_back(a_blk);
         }
+        result.push_back(sw);
 
         // Preserve A's label.
         if (!a.original_label.empty()) {
-            result = factory_.Make<SLabel>(
-                factory_.Intern(a.original_label), result);
+            result = { factory_.Make<SLabel>(
+                factory_.Intern(a.original_label), result) };
         }
 
         graph_.IdentifyInternal(
-            collapse_ids, CNode::BlockType::kSwitch, result);
+            collapse_ids, CNode::BlockType::kSwitch, std::move(result));
         return true;
     }
 
@@ -2333,12 +2424,13 @@ namespace patchestry::ast {
     //                   wrapped in an SLabel if the node has a label.
     // ---------------------------------------------------------------
 
-    SNode *CFGStructure::BuildLeafSNode(size_t id, bool include_terminal) {
+    std::vector< SNode * > CFGStructure::BuildLeafSNode(
+        size_t id, bool include_terminal) {
         auto &node = graph_.Node(id);
 
         // If this node was already structured (e.g., by a prior rule),
-        // return its existing SNode.
-        if (node.structured) return node.structured;
+        // return its existing structured sequence.
+        if (!node.structured.empty()) return node.structured;
 
         auto *blk = factory_.Make<SBlock>();
         for (auto *s : node.stmts) {
@@ -2360,17 +2452,17 @@ namespace patchestry::ast {
                 factory_.Intern(node.original_label), blk);
         }
 
-        return result;
+        return { result };
     }
 
     // ---------------------------------------------------------------
     // BuildBodySNode — sequence of leaf SNodes from a list of node ids.
     // ---------------------------------------------------------------
 
-    SNode *CFGStructure::BuildBodySNode(const std::vector<size_t> &ids) {
+    std::vector< SNode * > CFGStructure::BuildBodySNode(
+        const std::vector<size_t> &ids) {
         std::vector<SNode *> children;
-        children.reserve(ids.size());
-        for (size_t nid : ids) children.push_back(BuildLeafSNode(nid));
+        for (size_t nid : ids) SeqAppend(children, BuildLeafSNode(nid));
         return factory_.MakeSeq(std::move(children));
     }
 
@@ -2385,17 +2477,17 @@ namespace patchestry::ast {
 
     namespace {
 
-        // Try to inline gotos in a single SSeq.  Returns true if changed.
+        // Try to inline gotos in a single sequence.  Returns true if changed.
         bool InlineGotosInSeq(
-            SSeq *seq, SNodeFactory &factory,
+            std::vector< SNode * > &seq, SNodeFactory &factory,
             const std::unordered_map<std::string_view, int> &refs
         ) {
             bool changed = false;
 
-            // Build index: label name → position in this SSeq.
+            // Build index: label name → position in this sequence.
             std::unordered_map<std::string_view, size_t> label_pos;
-            for (size_t i = 0; i < seq->Size(); ++i) {
-                if (auto *lbl = (*seq)[i]->dyn_cast<SLabel>()) {
+            for (size_t i = 0; i < seq.size(); ++i) {
+                if (auto *lbl = seq[i]->dyn_cast<SLabel>()) {
                     label_pos[lbl->Name()] = i;
                 }
             }
@@ -2406,8 +2498,8 @@ namespace patchestry::ast {
             //   (b) all siblings between goto and label are empty SBlocks (nothing skipped)
             // This prevents changing control-flow semantics by executing code
             // that the goto would have jumped over.
-            for (size_t i = 0; i < seq->Size(); ++i) {
-                auto *g = (*seq)[i]->dyn_cast<SGoto>();
+            for (size_t i = 0; i < seq.size(); ++i) {
+                auto *g = seq[i]->dyn_cast<SGoto>();
                 if (!g) continue;
 
                 auto target = g->Target();
@@ -2427,8 +2519,7 @@ namespace patchestry::ast {
                 // are empty SBlocks — i.e., the goto doesn't skip any real code.
                 bool can_inline = true;
                 for (size_t k = i + 1; k < label_idx; ++k) {
-                    auto *between = (*seq)[k];
-                    auto *blk = between->dyn_cast<SBlock>();
+                    auto *blk = seq[k]->dyn_cast<SBlock>();
                     if (!blk || !blk->Empty()) {
                         can_inline = false;
                         break;
@@ -2436,51 +2527,29 @@ namespace patchestry::ast {
                 }
                 if (!can_inline) continue;
 
-                auto *lbl = (*seq)[label_idx]->as<SLabel>();
+                auto *lbl = seq[label_idx]->as<SLabel>();
 
-                // Replace the goto with the label's body.
-                SNode *body = lbl->Body();
-                if (body) {
-                    seq->ReplaceChild(i, body);
-                } else {
-                    seq->ReplaceChild(i, factory.Make<SBlock>());
-                }
+                // Splice the label's body (a vector) into the goto's
+                // slot, dropping the goto, the empty blocks between,
+                // and the label node itself.
+                std::vector< SNode * > repl = lbl->BodyList();
+                if (repl.empty()) repl.push_back(factory.Make<SBlock>());
 
-                // Remove the label node (and any empty blocks between).
-                // Remove from the end to avoid index shifting.
-                for (size_t k = label_idx; k > i; --k) {
-                    seq->RemoveChild(k);
-                }
+                seq.erase(seq.begin() + static_cast<ptrdiff_t>(i),
+                          seq.begin() + static_cast<ptrdiff_t>(label_idx) + 1);
+                seq.insert(seq.begin() + static_cast<ptrdiff_t>(i),
+                           repl.begin(), repl.end());
 
                 changed = true;
                 // Rebuild label_pos since indices shifted.
                 label_pos.clear();
-                for (size_t j = 0; j < seq->Size(); ++j) {
-                    if (auto *l = (*seq)[j]->dyn_cast<SLabel>()) {
+                for (size_t j = 0; j < seq.size(); ++j) {
+                    if (auto *l = seq[j]->dyn_cast<SLabel>()) {
                         label_pos[l->Name()] = j;
                     }
                 }
             }
 
-            return changed;
-        }
-
-        // Recursively process all SSeq nodes in the tree, bottom-up.
-        // The SSeq case is special — children are walked first, then
-        // InlineGotosInSeq runs to splice goto/label adjacencies.
-        // For every other kind, the visitor recurses uniformly.
-        bool InlineGotosRecursive(
-            SNode *node, SNodeFactory &factory,
-            const std::unordered_map<std::string_view, int> &refs
-        ) {
-            if (!node) return false;
-            bool changed = false;
-            node->for_each_child([&](SNode *c) {
-                if (InlineGotosRecursive(c, factory, refs)) changed = true;
-            });
-            if (auto *seq = node->dyn_cast<SSeq>()) {
-                if (InlineGotosInSeq(seq, factory, refs)) changed = true;
-            }
             return changed;
         }
 
@@ -2509,12 +2578,9 @@ namespace patchestry::ast {
         TrailingInfo DeepTrailingSNode(SNode *node) {
             if (!node) return {};
             if (auto *lbl = node->dyn_cast<SLabel>()) {
-                return DeepTrailingSNode(lbl->Body());
-            }
-            if (auto *seq = node->dyn_cast<SSeq>()) {
-                auto &ch = seq->Children();
-                if (ch.empty()) return {};
-                return DeepTrailingSNode(ch.back());
+                auto &body = lbl->BodyList();
+                if (body.empty()) return {};
+                return DeepTrailingSNode(body.back());
             }
             if (auto *blk = node->dyn_cast<SBlock>()) {
                 if (blk->Empty()) return {};
@@ -2537,28 +2603,12 @@ namespace patchestry::ast {
             return {};
         }
 
-        bool EliminateInSSeq(SSeq *seq, SNodeFactory &factory,
-                             clang::ASTContext &ctx);
-
-        bool EliminateRecursive(SNode *node, SNodeFactory &factory,
-                                clang::ASTContext &ctx) {
-            if (!node) return false;
-            bool changed = false;
-            node->for_each_child([&](SNode *c) {
-                if (EliminateRecursive(c, factory, ctx)) changed = true;
-            });
-            if (auto *seq = node->dyn_cast<SSeq>()) {
-                if (EliminateInSSeq(seq, factory, ctx)) changed = true;
-            }
-            return changed;
-        }
-
         // Forward declaration — defined in InlineCrossScopeSingleRef namespace.
         bool SNodeAlwaysTerminates(SNode *node);
 
-        bool EliminateInSSeq(SSeq *seq, SNodeFactory &factory,
-                             clang::ASTContext &ctx) {
-            auto &children = seq->Children();
+        bool EliminateInSeq(std::vector< SNode * > &children,
+                            SNodeFactory &factory,
+                            clang::ASTContext &ctx) {
             bool changed = false;
             bool local_changed = true;
             // Cap restarts to avoid O(N²) on large SSeq (e.g., 100+
@@ -2569,17 +2619,10 @@ namespace patchestry::ast {
                 local_changed = false;
                 for (size_t i = 0; i + 1 < children.size(); ++i) {
                     // Find the next SLabel sibling, possibly skipping
-                    // dead code after a terminating child.  Also unwrap
-                    // one level of SSeq nesting to find wrapped labels.
+                    // dead code after a terminating child.
                     SLabel *nxt_label = nullptr;
                     for (size_t k = i + 1; k < children.size() && !nxt_label; ++k) {
                         nxt_label = children[k]->dyn_cast<SLabel>();
-                        if (!nxt_label) {
-                            if (auto *ns = children[k]->dyn_cast<SSeq>()) {
-                                if (!ns->Empty())
-                                    nxt_label = (*ns)[0]->dyn_cast<SLabel>();
-                            }
-                        }
                         if (nxt_label) break;
                         // Only skip over siblings that are unreachable
                         // (preceded by a terminating node).
@@ -2595,27 +2638,24 @@ namespace patchestry::ast {
                     // --- Check SGoto SNode ---
                     auto snode_tgt = SNodeGotoTarget(info.container);
                     if (!snode_tgt.empty() && snode_tgt == next_name) {
-                        // Find the parent SSeq containing this SGoto and remove it
-                        // If it's a direct child, remove from this SSeq
+                        // Remove the trailing SGoto.  Direct child →
+                        // erase from this sequence; otherwise chase the
+                        // SLabel body-vectors down to its slot.
                         if (info.container == children[i]) {
-                            seq->RemoveChild(i);
+                            children.erase(
+                                children.begin() + static_cast<ptrdiff_t>(i));
                         } else {
-                            // It's nested — find the parent SSeq's last child
-                            // and remove the SGoto from there
-                            // Walk to find the innermost SSeq containing it
                             std::function<bool(SNode *)> remove_trailing;
                             remove_trailing = [&](SNode *n) -> bool {
-                                if (auto *s = n->dyn_cast<SSeq>()) {
-                                    auto &ch = s->Children();
-                                    if (!ch.empty() && ch.back() == info.container) {
-                                        s->RemoveChild(ch.size() - 1);
-                                        return true;
-                                    }
-                                    if (!ch.empty()) return remove_trailing(ch.back());
+                                auto *l = n->dyn_cast<SLabel>();
+                                if (!l) return false;
+                                auto &body = l->BodyList();
+                                if (body.empty()) return false;
+                                if (body.back() == info.container) {
+                                    body.pop_back();
+                                    return true;
                                 }
-                                if (auto *l = n->dyn_cast<SLabel>())
-                                    return remove_trailing(l->Body());
-                                return false;
+                                return remove_trailing(body.back());
                             };
                             remove_trailing(children[i]);
                         }
@@ -2704,23 +2744,23 @@ namespace patchestry::ast {
                             && !ite->ElseBranch()) {
                             // if(c) goto L; L: → nop (remove the if-then-goto)
                             if (info.container == children[i]) {
-                                seq->RemoveChild(i);
+                                children.erase(
+                                    children.begin()
+                                    + static_cast<ptrdiff_t>(i));
                             } else {
-                                // Nested — chase to the parent SSeq and
-                                // remove the trailing SIfThenElse.
+                                // Nested — chase the SLabel body-vectors
+                                // and remove the trailing SIfThenElse.
                                 std::function<bool(SNode *)> remove_trailing;
                                 remove_trailing = [&](SNode *n) -> bool {
-                                    if (auto *s = n->dyn_cast<SSeq>()) {
-                                        auto &ch = s->Children();
-                                        if (!ch.empty() && ch.back() == info.container) {
-                                            s->RemoveChild(ch.size() - 1);
-                                            return true;
-                                        }
-                                        if (!ch.empty()) return remove_trailing(ch.back());
+                                    auto *l = n->dyn_cast<SLabel>();
+                                    if (!l) return false;
+                                    auto &body = l->BodyList();
+                                    if (body.empty()) return false;
+                                    if (body.back() == info.container) {
+                                        body.pop_back();
+                                        return true;
                                     }
-                                    if (auto *l = n->dyn_cast<SLabel>())
-                                        return remove_trailing(l->Body());
-                                    return false;
+                                    return remove_trailing(body.back());
                                 };
                                 remove_trailing(children[i]);
                             }
@@ -2748,15 +2788,16 @@ namespace patchestry::ast {
 
     } // anonymous namespace (EliminateGotoToNextLabel helpers)
 
-    bool EliminateGotoToNextLabel(SNode *root, SNodeFactory &factory,
+    bool EliminateGotoToNextLabel(std::vector< SNode * > &root,
+                                  SNodeFactory &factory,
                                   clang::ASTContext &ctx) {
-        if (!root) return false;
-        return EliminateRecursive(root, factory, ctx);
+        return ForEachSeqPostOrder(
+            root, [&](std::vector< SNode * > &seq) {
+                return EliminateInSeq(seq, factory, ctx);
+            });
     }
 
-    bool InlineResidualGotos(SNode *root, SNodeFactory &factory) {
-        if (!root) return false;
-
+    bool InlineResidualGotos(std::vector< SNode * > &root, SNodeFactory &factory) {
         // Count all goto references globally.  Keys are string_views
         // into interned strings owned by SNodeFactory (stable lifetime).
         std::unordered_map<std::string_view, int> refs;
@@ -2769,7 +2810,11 @@ namespace patchestry::ast {
         bool any_changed = false;
         size_t max_passes = std::min(refs.size() + 1, size_t{20});
         for (size_t pass = 0; pass < max_passes; ++pass) {
-            if (!InlineGotosRecursive(root, factory, refs))
+            bool did = ForEachSeqPostOrder(
+                root, [&](std::vector< SNode * > &seq) {
+                    return InlineGotosInSeq(seq, factory, refs);
+                });
+            if (!did)
                 break;
             any_changed = true;
             // Recount after mutations.
@@ -2813,6 +2858,14 @@ namespace patchestry::ast {
             return false;
         }
 
+        bool SNodeAlwaysTerminates(SNode *node);
+
+        /// A sequence always terminates iff its last element does.
+        bool SeqAlwaysTerminates(const std::vector< SNode * > &seq) {
+            if (seq.empty()) return false;
+            return SNodeAlwaysTerminates(seq.back());
+        }
+
         /// Return true if this SNode always terminates control flow —
         /// every execution path through the node exits via return,
         /// break, continue, throw, or an unconditional goto.  Such a
@@ -2829,31 +2882,26 @@ namespace patchestry::ast {
                 if (blk->Empty()) return false;
                 return ClangStmtIsTerminator(blk->Stmts().back());
             }
-            if (auto *seq = node->dyn_cast<SSeq>()) {
-                if (seq->Empty()) return false;
-                return SNodeAlwaysTerminates(
-                    seq->Children().back());
-            }
             if (auto *lbl = node->dyn_cast<SLabel>()) {
-                return SNodeAlwaysTerminates(lbl->Body());
+                return SeqAlwaysTerminates(lbl->BodyList());
             }
             if (auto *ite = node->dyn_cast<SIfThenElse>()) {
                 // Both branches must terminate (else fallthrough
                 // when one arm is missing).
-                if (!ite->ThenBranch() || !ite->ElseBranch())
+                if (ite->ThenList().empty() || ite->ElseList().empty())
                     return false;
-                return SNodeAlwaysTerminates(ite->ThenBranch())
-                    && SNodeAlwaysTerminates(ite->ElseBranch());
+                return SeqAlwaysTerminates(ite->ThenList())
+                    && SeqAlwaysTerminates(ite->ElseList());
             }
             if (auto *sw = node->dyn_cast<SSwitch>()) {
                 // Every case + default must terminate, and default
                 // must be present (otherwise unmatched values fall
                 // out of the switch).
-                if (!sw->DefaultBody()) return false;
-                if (!SNodeAlwaysTerminates(sw->DefaultBody()))
+                if (sw->DefaultBodyList().empty()) return false;
+                if (!SeqAlwaysTerminates(sw->DefaultBodyList()))
                     return false;
                 for (auto &c : sw->Cases()) {
-                    if (!SNodeAlwaysTerminates(c.body()))
+                    if (!SeqAlwaysTerminates(c.body_list))
                         return false;
                 }
                 return true;
@@ -2909,186 +2957,93 @@ namespace patchestry::ast {
         /// Stage 3+ before it can be done with the right safety
         /// analysis — deferred to a follow-up policy change.
         struct LabelLoc {
-            SSeq *parent = nullptr;
+            std::vector< SNode * > *parent = nullptr;
             size_t idx = 0;
         };
 
-        bool FindLabel(SNode *node, std::string_view name, LabelLoc &out) {
-            if (!node) return false;
-            // SSeq is the only kind that can hold the label as a
-            // direct child — check children first, then descend
-            // into nested kinds via for_each_child.
-            if (auto *seq = node->dyn_cast<SSeq>()) {
-                for (size_t i = 0; i < seq->Size(); ++i) {
-                    if (auto *lbl = (*seq)[i]->dyn_cast<SLabel>()) {
-                        if (lbl->Name() == name) {
-                            out.parent = seq;
-                            out.idx = i;
-                            return true;
-                        }
+        bool FindLabel(std::vector< SNode * > &seq, std::string_view name,
+                       LabelLoc &out) {
+            for (size_t i = 0; i < seq.size(); ++i) {
+                if (auto *lbl = seq[i]->dyn_cast<SLabel>()) {
+                    if (lbl->Name() == name) {
+                        out.parent = &seq;
+                        out.idx = i;
+                        return true;
                     }
                 }
             }
             bool found = false;
-            node->for_each_child([&](SNode *c) {
-                if (!found && FindLabel(c, name, out)) found = true;
-            });
+            for (SNode *c : seq) {
+                ForEachBodyList(c, [&](std::vector< SNode * > &body) {
+                    if (!found && FindLabel(body, name, out)) found = true;
+                });
+            }
             return found;
         }
 
-        /// Attempt to inline a single goto slot.  `get` returns the
-        /// current node occupying the slot; `set` installs a
-        /// replacement.  Returns true if the goto was inlined.
-        bool TryInlineGotoSlot(
-            std::function<SNode *()> get,
-            std::function<void(SNode *)> set,
-            SNode *root,
+        /// Scan one sequence for an SGoto whose target label can be
+        /// inlined (single ref, terminating label-free body, no
+        /// fallthrough into the label).  On the first match the
+        /// label's body-vector is spliced into the goto's slot and
+        /// the label node removed.  Returns true on success.
+        bool CrossScopeInlineInSeq(
+            std::vector< SNode * > &seq,
+            std::vector< SNode * > &root,
             std::unordered_map<std::string_view, int> &refs
         ) {
-            auto *n = get();
-            auto *g = n ? n->dyn_cast<SGoto>() : nullptr;
-            if (!g) return false;
+            for (size_t i = 0; i < seq.size(); ++i) {
+                auto *g = seq[i]->dyn_cast<SGoto>();
+                if (!g) continue;
 
-            auto target = g->Target();
-            auto it = refs.find(target);
-            if (it == refs.end() || it->second != 1) return false;
+                auto target = g->Target();
+                auto it = refs.find(target);
+                if (it == refs.end() || it->second != 1) continue;
 
-            LabelLoc loc;
-            if (!FindLabel(root, target, loc)) return false;
+                LabelLoc loc;
+                if (!FindLabel(root, target, loc)) continue;
 
-            auto *lbl = (*loc.parent)[loc.idx]->as<SLabel>();
-            SNode *body = lbl->Body();
-            if (!body) return false;
+                auto *lbl = (*loc.parent)[loc.idx]->as<SLabel>();
+                std::vector< SNode * > &body = lbl->BodyList();
+                if (!SeqAlwaysTerminates(body)) continue;
 
-            if (!SNodeAlwaysTerminates(body)) return false;
-            if (SubtreeHasLabel(body)) return false;
+                bool has_label = false;
+                for (SNode *b : body)
+                    if (SubtreeHasLabel(b)) { has_label = true; break; }
+                if (has_label) continue;
 
-            // No fallthrough may reach the label in its original
-            // position.  Require a preceding terminating sibling.
-            if (loc.idx == 0) return false;
-            if (!SNodeAlwaysTerminates((*loc.parent)[loc.idx - 1]))
-                return false;
+                // No fallthrough may reach the label in its original
+                // position.  Require a preceding terminating sibling.
+                if (loc.idx == 0) continue;
+                if (!SNodeAlwaysTerminates((*loc.parent)[loc.idx - 1]))
+                    continue;
 
-            // Splice: install body in goto's slot, remove original
-            // label from its SSeq.
-            set(body);
-            loc.parent->RemoveChild(loc.idx);
-            refs[target] = 0;
-            return true;
-        }
+                // Detach the label first, then re-locate the goto
+                // (its index may shift if the label sat in the same
+                // sequence at a lower position) and splice the body in.
+                std::vector< SNode * > spliced = body;
+                loc.parent->erase(
+                    loc.parent->begin() + static_cast<ptrdiff_t>(loc.idx));
 
-        /// Walk every SNode slot in the tree and try inlining any
-        /// SGoto found there.  Returns true on first successful
-        /// inline (caller reruns with fresh ref counts).
-        bool CrossScopeInlineRecursive(
-            SNode *node, SNode *root,
-            std::unordered_map<std::string_view, int> &refs
-        ) {
-            if (!node) return false;
-
-            if (auto *seq = node->dyn_cast<SSeq>()) {
-                // Visit each child slot.  Recurse first so innermost
-                // gotos are handled before parent-level scans.
-                for (size_t i = 0; i < seq->Size(); ++i) {
-                    if (CrossScopeInlineRecursive(
-                            (*seq)[i], root, refs))
-                        return true;
+                size_t gi = seq.size();
+                for (size_t k = 0; k < seq.size(); ++k)
+                    if (seq[k] == g) { gi = k; break; }
+                if (gi == seq.size()) {
+                    refs[target] = 0;
+                    return true;
                 }
-                for (size_t i = 0; i < seq->Size(); ++i) {
-                    if (TryInlineGotoSlot(
-                            [seq, i]() { return (*seq)[i]; },
-                            [seq, i](SNode *n) { seq->ReplaceChild(i, n); },
-                            root, refs))
-                        return true;
-                }
-                return false;
-            }
-
-            if (auto *ite = node->dyn_cast<SIfThenElse>()) {
-                if (CrossScopeInlineRecursive(
-                        ite->ThenBranch(), root, refs))
-                    return true;
-                if (CrossScopeInlineRecursive(
-                        ite->ElseBranch(), root, refs))
-                    return true;
-                if (TryInlineGotoSlot(
-                        [ite]() { return ite->ThenBranch(); },
-                        [ite](SNode *n) { ite->SetThenBranch(n); },
-                        root, refs))
-                    return true;
-                if (TryInlineGotoSlot(
-                        [ite]() { return ite->ElseBranch(); },
-                        [ite](SNode *n) { ite->SetElseBranch(n); },
-                        root, refs))
-                    return true;
-                return false;
-            }
-            if (auto *w = node->dyn_cast<SWhile>()) {
-                if (CrossScopeInlineRecursive(w->Body(), root, refs))
-                    return true;
-                return TryInlineGotoSlot(
-                    [w]() { return w->Body(); },
-                    [w](SNode *n) { w->SetBody(n); },
-                    root, refs);
-            }
-            if (auto *dw = node->dyn_cast<SDoWhile>()) {
-                if (CrossScopeInlineRecursive(dw->Body(), root, refs))
-                    return true;
-                return TryInlineGotoSlot(
-                    [dw]() { return dw->Body(); },
-                    [dw](SNode *n) { dw->SetBody(n); },
-                    root, refs);
-            }
-            if (auto *f = node->dyn_cast<SFor>()) {
-                if (CrossScopeInlineRecursive(f->Body(), root, refs))
-                    return true;
-                return TryInlineGotoSlot(
-                    [f]() { return f->Body(); },
-                    [f](SNode *n) { f->SetBody(n); },
-                    root, refs);
-            }
-            if (auto *sw = node->dyn_cast<SSwitch>()) {
-                for (size_t ci = 0; ci < sw->Cases().size(); ++ci) {
-                    auto &c = sw->Cases()[ci];
-                    if (CrossScopeInlineRecursive(c.body(), root, refs))
-                        return true;
-                }
-                if (CrossScopeInlineRecursive(
-                        sw->DefaultBody(), root, refs))
-                    return true;
-                for (size_t ci = 0; ci < sw->Cases().size(); ++ci) {
-                    if (TryInlineGotoSlot(
-                            [sw, ci]() { return sw->Cases()[ci].body(); },
-                            [sw, ci](SNode *n) {
-                                sw->Cases()[ci].set_body(n);
-                                if (n) n->SetParent(sw);
-                            },
-                            root, refs))
-                        return true;
-                }
-                if (TryInlineGotoSlot(
-                        [sw]() { return sw->DefaultBody(); },
-                        [sw](SNode *n) { sw->SetDefaultBody(n); },
-                        root, refs))
-                    return true;
-                return false;
-            }
-            if (auto *lbl = node->dyn_cast<SLabel>()) {
-                if (CrossScopeInlineRecursive(lbl->Body(), root, refs))
-                    return true;
-                return TryInlineGotoSlot(
-                    [lbl]() { return lbl->Body(); },
-                    [lbl](SNode *n) { lbl->SetBody(n); },
-                    root, refs);
+                seq.erase(seq.begin() + static_cast<ptrdiff_t>(gi));
+                seq.insert(seq.begin() + static_cast<ptrdiff_t>(gi),
+                           spliced.begin(), spliced.end());
+                refs[target] = 0;
+                return true;
             }
             return false;
         }
 
     } // anonymous namespace
 
-    bool InlineCrossScopeSingleRef(SNode *root, SNodeFactory & /*factory*/) {
-        if (!root) return false;
-
+    bool InlineCrossScopeSingleRef(std::vector< SNode * > &root,
+                                   SNodeFactory & /*factory*/) {
         std::unordered_map<std::string_view, int> refs;
         CountGotoRefs(root, refs);
 
@@ -3097,8 +3052,17 @@ namespace patchestry::ast {
         // goto, so the initial ref count bounds the loop.
         size_t max_passes = std::min(refs.size() + 1, size_t{20});
         for (size_t p = 0; p < max_passes; ++p) {
-            if (!CrossScopeInlineRecursive(root, root, refs))
-                break;
+            bool done = false;
+            ForEachSeqPostOrder(
+                root, [&](std::vector< SNode * > &seq) {
+                    if (done) return false;
+                    if (CrossScopeInlineInSeq(seq, root, refs)) {
+                        done = true;
+                        return true;
+                    }
+                    return false;
+                });
+            if (!done) break;
             any_changed = true;
             refs.clear();
             CountGotoRefs(root, refs);
@@ -3117,98 +3081,58 @@ namespace patchestry::ast {
         // Forward declaration — defined in InlineCrossScopeSingleRef namespace.
         bool SNodeAlwaysTerminates(SNode *node);
 
-        /// Chase through SLabel/SSeq nesting to find the deepest
-        /// trailing SIfThenElse that has no else branch.
+        /// Chase through SLabel nesting to find the deepest trailing
+        /// SIfThenElse that has no else branch.
         SIfThenElse *DeepTrailingIfThen(SNode *node) {
             if (!node) return nullptr;
             if (auto *ite = node->dyn_cast<SIfThenElse>())
-                return ite->ElseBranch() ? nullptr : ite;
-            if (auto *lbl = node->dyn_cast<SLabel>())
-                return DeepTrailingIfThen(lbl->Body());
-            if (auto *seq = node->dyn_cast<SSeq>()) {
-                if (seq->Empty()) return nullptr;
-                return DeepTrailingIfThen(seq->Children().back());
+                return ite->ElseList().empty() ? ite : nullptr;
+            if (auto *lbl = node->dyn_cast<SLabel>()) {
+                auto &body = lbl->BodyList();
+                return body.empty() ? nullptr
+                                    : DeepTrailingIfThen(body.back());
             }
             return nullptr;
         }
 
-        bool AbsorbInSSeq(SSeq *seq,
-                          const std::unordered_map<std::string_view, int> &refs) {
-            auto &children = seq->Children();
+        bool AbsorbInSeq(std::vector< SNode * > &children,
+                         const std::unordered_map<std::string_view, int> &refs) {
             bool changed = false;
             for (size_t i = 0; i + 1 < children.size(); ++i) {
-                // Chase into SLabel/SSeq nesting to find a deeply
-                // buried trailing if-then (no else).
+                // Chase into SLabel nesting to find a deeply buried
+                // trailing if-then (no else).
                 auto *ite = DeepTrailingIfThen(children[i]);
                 if (!ite) continue;
 
-                // Check if next sibling is an SLabel, or an SSeq/SBlock
-                // whose first element is an SLabel.  Also handle bare
-                // SBlock (label already stripped — nothing to absorb by
-                // name, but if the block has no label it can't be
-                // verified as 0-ref, so skip).
-                SLabel *lbl = nullptr;
-                bool lbl_is_direct = false;
-                size_t lbl_seq_idx = 0;
-                SSeq *lbl_parent_seq = nullptr;
-
-                if (auto *l = children[i + 1]->dyn_cast<SLabel>()) {
-                    lbl = l;
-                    lbl_is_direct = true;
-                } else if (auto *ns = children[i + 1]->dyn_cast<SSeq>()) {
-                    // Search for first SLabel in the SSeq
-                    for (size_t k = 0; k < ns->Size(); ++k) {
-                        if (auto *l2 = (*ns)[k]->dyn_cast<SLabel>()) {
-                            lbl = l2;
-                            lbl_seq_idx = k;
-                            lbl_parent_seq = ns;
-                            break;
-                        }
-                    }
-                }
+                // Next sibling must be an SLabel.
+                auto *lbl = children[i + 1]->dyn_cast<SLabel>();
                 if (!lbl) continue;
 
                 auto rc = refs.find(lbl->Name());
                 if (rc != refs.end() && rc->second > 0) continue;
                 if (!SNodeAlwaysTerminates(ite->ThenBranch())) continue;
 
-                SNode *else_body = lbl->Body();
-                ite->SetElseBranch(else_body);
+                ite->SetElseBranch(lbl->BodyList());
 
                 // Remove the absorbed SLabel.
-                if (lbl_is_direct) {
-                    seq->RemoveChild(i + 1);
-                } else if (lbl_parent_seq) {
-                    lbl_parent_seq->RemoveChild(lbl_seq_idx);
-                    if (lbl_parent_seq->Empty())
-                        seq->RemoveChild(i + 1);
-                }
+                children.erase(
+                    children.begin() + static_cast<ptrdiff_t>(i) + 1);
                 changed = true;
                 // Don't break — continue scanning for more opportunities.
             }
             return changed;
         }
 
-        bool AbsorbRecursive(SNode *node,
-                             const std::unordered_map<std::string_view, int> &refs) {
-            if (!node) return false;
-            bool changed = false;
-            node->for_each_child([&](SNode *c) {
-                if (AbsorbRecursive(c, refs)) changed = true;
-            });
-            if (auto *seq = node->dyn_cast<SSeq>()) {
-                if (AbsorbInSSeq(seq, refs)) changed = true;
-            }
-            return changed;
-        }
-
     } // anonymous namespace
 
-    bool AbsorbFallthroughIntoElse(SNode *root, SNodeFactory & /*factory*/) {
-        if (!root) return false;
+    bool AbsorbFallthroughIntoElse(std::vector< SNode * > &root,
+                                   SNodeFactory & /*factory*/) {
         std::unordered_map<std::string_view, int> refs;
         CountGotoRefs(root, refs);
-        return AbsorbRecursive(root, refs);
+        return ForEachSeqPostOrder(
+            root, [&](std::vector< SNode * > &seq) {
+                return AbsorbInSeq(seq, refs);
+            });
     }
 
     // ---------------------------------------------------------------
@@ -3239,10 +3163,10 @@ namespace patchestry::ast {
 
 
 
-        bool ScopeifyInSSeq(SSeq *seq, SNodeFactory &factory,
-                            clang::ASTContext &ctx,
-                            const std::unordered_map<std::string_view, int> &refs) {
-            auto &children = seq->Children();
+        bool ScopeifyInSeq(std::vector< SNode * > &children,
+                           SNodeFactory &factory,
+                           clang::ASTContext &ctx,
+                           const std::unordered_map<std::string_view, int> &refs) {
             bool any_change = false;
             bool changed = true;
 
@@ -3287,27 +3211,37 @@ namespace patchestry::ast {
                     if (has_label) continue;
 
                     // Build scoped body from intermediates.  MakeSeq
-                    // unwraps the size-1 case automatically.
+                    // normalizes (drops nulls).
                     std::vector<SNode *> scoped_children;
                     scoped_children.reserve(label_idx - i - 1);
                     for (size_t j = i + 1; j < label_idx; ++j)
                         scoped_children.push_back(children[j]);
-                    SNode *scoped_body =
+                    std::vector< SNode * > scoped_body =
                         factory.MakeSeq(std::move(scoped_children));
 
                     // Negate condition
                     auto *neg = NegateExpr(ctx, ite->Cond());
                     auto *new_if = factory.Make<SIfThenElse>(
-                        neg, scoped_body, nullptr);
+                        neg, scoped_body, std::vector< SNode * >{});
 
-                    // Get label body
+                    // Build the replacement: new_if followed by the
+                    // label body's children.
                     auto *lbl = children[label_idx]->as<SLabel>();
-                    SNode *label_body = lbl->Body()
-                        ? lbl->Body() : factory.Make<SBlock>();
+                    std::vector<SNode *> replacements;
+                    replacements.push_back(new_if);
+                    for (SNode *c : lbl->BodyList())
+                        replacements.push_back(c);
+                    if (lbl->BodyList().empty())
+                        replacements.push_back(factory.Make<SBlock>());
 
-                    // Replace range [i, label_idx+1) with {new_if, label_body}
-                    std::vector<SNode *> replacements = {new_if, label_body};
-                    seq->ReplaceRange(i, label_idx + 1, replacements);
+                    // Replace range [i, label_idx+1) with `replacements`.
+                    children.erase(
+                        children.begin() + static_cast<ptrdiff_t>(i),
+                        children.begin()
+                            + static_cast<ptrdiff_t>(label_idx) + 1);
+                    children.insert(
+                        children.begin() + static_cast<ptrdiff_t>(i),
+                        replacements.begin(), replacements.end());
 
                     changed = true;
                     any_change = true;
@@ -3317,32 +3251,21 @@ namespace patchestry::ast {
             return any_change;
         }
 
-        bool ScopeifyRecursive(SNode *node, SNodeFactory &factory,
-                               clang::ASTContext &ctx,
-                               const std::unordered_map<std::string_view, int> &refs) {
-            if (!node) return false;
-            bool changed = false;
-            node->for_each_child([&](SNode *c) {
-                if (ScopeifyRecursive(c, factory, ctx, refs)) changed = true;
-            });
-            if (auto *seq = node->dyn_cast<SSeq>()) {
-                if (ScopeifyInSSeq(seq, factory, ctx, refs)) changed = true;
-            }
-            return changed;
-        }
-
     } // anonymous namespace
 
-    bool ScopeifyIfGotos(SNode *root, SNodeFactory &factory,
+    bool ScopeifyIfGotos(std::vector< SNode * > &root, SNodeFactory &factory,
                          clang::ASTContext &ctx) {
-        if (!root) return false;
         bool any_changed = false;
-        // Recount refs after each pass — ScopeifyInSSeq removes gotos,
+        // Recount refs after each pass — ScopeifyInSeq removes gotos,
         // which can make previously multi-ref labels single-ref.
         for (int pass = 0; pass < 8; ++pass) {
             std::unordered_map<std::string_view, int> refs;
             CountGotoRefs(root, refs);
-            if (!ScopeifyRecursive(root, factory, ctx, refs))
+            bool did = ForEachSeqPostOrder(
+                root, [&](std::vector< SNode * > &seq) {
+                    return ScopeifyInSeq(seq, factory, ctx, refs);
+                });
+            if (!did)
                 break;
             any_changed = true;
         }
@@ -3426,16 +3349,18 @@ namespace patchestry::ast {
                 if (blk->Empty()) return false;
                 return ClangStmtIsTerminator(blk->Stmts().back());
             }
-            if (auto *lbl = node->dyn_cast<SLabel>())
-                return IsStrongTerminator(lbl->Body());
+            if (auto *lbl = node->dyn_cast<SLabel>()) {
+                auto &body = lbl->BodyList();
+                return !body.empty() && IsStrongTerminator(body.back());
+            }
             if (auto *ite = node->dyn_cast<SIfThenElse>()) {
                 // Both arms must be strong terminators.  Absorb only
                 // targets if-then-without-else, so this shape is stable.
-                return ite->ThenBranch() && ite->ElseBranch()
-                    && IsStrongTerminator(ite->ThenBranch())
-                    && IsStrongTerminator(ite->ElseBranch());
+                return !ite->ThenList().empty() && !ite->ElseList().empty()
+                    && IsStrongTerminator(ite->ThenList().back())
+                    && IsStrongTerminator(ite->ElseList().back());
             }
-            // SSeq / SWhile / SDoWhile / SFor / SSwitch:
+            // SWhile / SDoWhile / SFor / SSwitch:
             // DO NOT treat as terminators here, even if their tail
             // terminates.  AbsorbFallthroughIntoElse et al. can mutate
             // their internals in ways that invalidate the simple
@@ -3444,48 +3369,40 @@ namespace patchestry::ast {
             return false;
         }
 
-        bool RemoveDeadInSSeq(SSeq *seq) {
-            auto &children = seq->Children();
+        bool RemoveDeadInSeq(std::vector< SNode * > &children) {
             bool changed = false;
+            // Trim dead stmts inside SBlock children first — SBlocks
+            // hold no body-vectors so ForEachSeqPostOrder never visits
+            // them as a sequence on their own.
+            for (SNode *c : children)
+                if (auto *blk = c->dyn_cast<SBlock>())
+                    if (TrimDeadStmtsInSBlock(blk)) changed = true;
+
             for (size_t i = 0; i + 1 < children.size(); ++i) {
                 if (!IsStrongTerminator(children[i])) continue;
-                // children[i] is a direct primitive terminator —
-                // everything after it that contains no labels is dead.
-                size_t j = i + 1;
-                while (j < children.size()) {
-                    if (ContainsLabel(children[j])) {
-                        ++j; // keep — may contain goto targets
-                    } else {
-                        seq->RemoveChild(j);
-                        changed = true;
-                    }
+                // children[i] always terminates, so the contiguous run
+                // of label-free siblings immediately after it is
+                // unreachable.  Stop at the first label-bearing sibling:
+                // a label is a goto re-entry point, so it and everything
+                // after it can still be reached and must be kept.
+                while (i + 1 < children.size()
+                       && !ContainsLabel(children[i + 1])) {
+                    children.erase(
+                        children.begin() + static_cast<ptrdiff_t>(i) + 1);
+                    changed = true;
                 }
                 break; // only process first terminator
             }
             return changed;
         }
 
-        bool RemoveDeadRecursive(SNode *node) {
-            if (!node) return false;
-            bool changed = false;
-            if (auto *blk = node->dyn_cast<SBlock>()) {
-                if (TrimDeadStmtsInSBlock(blk)) changed = true;
-                return changed;  // SBlock has no SNode children
-            }
-            node->for_each_child([&](SNode *c) {
-                if (RemoveDeadRecursive(c)) changed = true;
-            });
-            if (auto *seq = node->dyn_cast<SSeq>()) {
-                if (RemoveDeadInSSeq(seq)) changed = true;
-            }
-            return changed;
-        }
-
     } // anonymous namespace
 
-    bool RemoveDeadSSeqChildren(SNode *root) {
-        if (!root) return false;
-        return RemoveDeadRecursive(root);
+    bool RemoveDeadSSeqChildren(std::vector< SNode * > &root) {
+        return ForEachSeqPostOrder(
+            root, [](std::vector< SNode * > &seq) {
+                return RemoveDeadInSeq(seq);
+            });
     }
 
     // ---------------------------------------------------------------
@@ -3505,182 +3422,103 @@ namespace patchestry::ast {
             std::string_view header_label;
         };
 
-        /// Recursively convert gotos to break/continue in the SNode tree.
-        /// The scope stack tracks enclosing loops.
-        bool ConvertGotosInNode(
-            SNode *node, SNodeFactory &factory,
+        /// Convert gotos to break/continue across one sequence and its
+        /// nested body-vectors.  The scope stack tracks enclosing loops;
+        /// a loop pushes its exit/header labels before its body is
+        /// processed.  An SGoto / trailing clang::GotoStmt targeting a
+        /// loop label becomes SBreak / SContinue.
+        bool ConvertGotosInSeq(
+            std::vector< SNode * > &seq, SNodeFactory &factory,
             std::vector<LoopScope> &scopes
         ) {
-            if (!node) return false;
             bool changed = false;
 
-            if (auto *seq = node->dyn_cast<SSeq>()) {
-                for (size_t i = 0; i < seq->Size(); ++i) {
-                    if (ConvertGotosInNode((*seq)[i], factory, scopes))
+            // Recurse into each child's body-vectors, pushing a loop
+            // scope around loop bodies.
+            for (SNode *child : seq) {
+                bool is_loop = false;
+                std::string_view exit_l, header_l;
+                if (auto *w = child->dyn_cast<SWhile>()) {
+                    is_loop = true;
+                    exit_l = w->ExitLabel();
+                    header_l = w->HeaderLabel();
+                } else if (auto *dw = child->dyn_cast<SDoWhile>()) {
+                    is_loop = true;
+                    exit_l = dw->ExitLabel();
+                    header_l = dw->HeaderLabel();
+                } else if (auto *f = child->dyn_cast<SFor>()) {
+                    is_loop = true;
+                    exit_l = f->ExitLabel();
+                    header_l = f->HeaderLabel();
+                }
+                if (is_loop) scopes.push_back({exit_l, header_l});
+                ForEachBodyList(child, [&](std::vector< SNode * > &body) {
+                    if (ConvertGotosInSeq(body, factory, scopes))
                         changed = true;
-                }
-                // Check SGoto children targeting loop labels.
-                for (size_t i = 0; i < seq->Size(); ++i) {
-                    auto *g = (*seq)[i]->dyn_cast<SGoto>();
-                    if (!g) continue;
-                    std::string_view target = g->Target();
-                    for (auto it = scopes.rbegin(); it != scopes.rend(); ++it) {
-                        if (!it->exit_label.empty() && target == it->exit_label) {
-                            seq->ReplaceChild(i, factory.Make<SBreak>());
-                            changed = true;
-                            break;
-                        }
-                        if (!it->header_label.empty() && target == it->header_label) {
-                            seq->ReplaceChild(i, factory.Make<SContinue>());
-                            changed = true;
-                            break;
-                        }
-                    }
-                }
-                // Check SBlock children whose trailing GotoStmt targets a loop label.
-                // Since SBlock holds clang::Stmt* and we need to insert SNode (SBreak),
-                // we split: remove the goto from the SBlock, insert SBreak after it.
-                for (size_t i = 0; i < seq->Size(); ++i) {
-                    auto *block = (*seq)[i]->dyn_cast<SBlock>();
-                    if (!block || block->Empty()) continue;
-                    auto *last = block->Stmts().back();
-                    auto *goto_stmt = llvm::dyn_cast<clang::GotoStmt>(last);
-                    if (!goto_stmt || !goto_stmt->getLabel()) continue;
-
-                    std::string_view target = goto_stmt->getLabel()->getName();
-                    for (auto it = scopes.rbegin(); it != scopes.rend(); ++it) {
-                        if (!it->exit_label.empty() && target == it->exit_label) {
-                            block->Stmts().pop_back();
-                            seq->InsertChild(i + 1, factory.Make<SBreak>());
-                            ++i; // skip the just-inserted SBreak
-                            changed = true;
-                            break;
-                        }
-                        if (!it->header_label.empty() && target == it->header_label) {
-                            block->Stmts().pop_back();
-                            seq->InsertChild(i + 1, factory.Make<SContinue>());
-                            ++i; // skip the just-inserted SContinue
-                            changed = true;
-                            break;
-                        }
-                    }
-                }
-                return changed;
+                });
+                if (is_loop) scopes.pop_back();
             }
 
-            if (auto *ite = node->dyn_cast<SIfThenElse>()) {
-                // Check if then/else branches target a loop label.
-                // Handle both SGoto SNodes and SBlocks with trailing GotoStmt.
-                // Track which arms were replaced to skip redundant recursion.
-                bool then_replaced = false, else_replaced = false;
-                for (int arm = 0; arm < 2; ++arm) {
-                    SNode *branch = arm == 0
-                        ? ite->ThenBranch() : ite->ElseBranch();
-                    if (!branch) continue;
-
-                    std::string_view target;
-
-                    // Case 1: branch is SGoto SNode.
-                    if (auto *g = branch->dyn_cast<SGoto>()) {
-                        target = g->Target();
-                    }
-                    // Case 2: branch is SBlock with trailing GotoStmt.
-                    else if (auto *block = branch->dyn_cast<SBlock>()) {
-                        if (!block->Empty()) {
-                            if (auto *gs = llvm::dyn_cast<clang::GotoStmt>(
-                                    block->Stmts().back()))
-                                if (gs->getLabel())
-                                    target = gs->getLabel()->getName();
+            // Replace SGoto / trailing-GotoStmt children that target an
+            // enclosing loop's exit or header label.
+            for (size_t i = 0; i < seq.size(); ++i) {
+                if (auto *g = seq[i]->dyn_cast<SGoto>()) {
+                    std::string_view target = g->Target();
+                    for (auto it = scopes.rbegin(); it != scopes.rend(); ++it) {
+                        if (!it->exit_label.empty()
+                            && target == it->exit_label) {
+                            seq[i] = factory.Make<SBreak>();
+                            changed = true;
+                            break;
+                        }
+                        if (!it->header_label.empty()
+                            && target == it->header_label) {
+                            seq[i] = factory.Make<SContinue>();
+                            changed = true;
+                            break;
                         }
                     }
+                    continue;
+                }
 
-                    if (target.empty()) continue;
+                auto *block = seq[i]->dyn_cast<SBlock>();
+                if (!block || block->Empty()) continue;
+                auto *goto_stmt =
+                    llvm::dyn_cast<clang::GotoStmt>(block->Stmts().back());
+                if (!goto_stmt || !goto_stmt->getLabel()) continue;
 
-                    for (auto sit = scopes.rbegin(); sit != scopes.rend(); ++sit) {
-                        SNode *replacement = nullptr;
-                        if (!sit->exit_label.empty() && target == sit->exit_label)
-                            replacement = factory.Make<SBreak>();
-                        else if (!sit->header_label.empty() && target == sit->header_label)
-                            replacement = factory.Make<SContinue>();
-                        if (!replacement) continue;
-
-                        if (branch->isa<SGoto>()) {
-                            // Direct replacement.
-                            if (arm == 0) ite->SetThenBranch(replacement);
-                            else ite->SetElseBranch(replacement);
-                        } else {
-                            // SBlock: remove trailing goto, wrap block + break/continue.
-                            auto *block = branch->as<SBlock>();
-                            block->Stmts().pop_back();
-                            // MakeSeq drops the now-empty SBlock (no
-                            // label) and unwraps to just `replacement`,
-                            // so the explicit Empty() branch collapses.
-                            SNode *new_arm = factory.MakeSeq({block, replacement});
-                            if (arm == 0) ite->SetThenBranch(new_arm);
-                            else ite->SetElseBranch(new_arm);
-                        }
-                        if (arm == 0) then_replaced = true;
-                        else else_replaced = true;
+                std::string_view target = goto_stmt->getLabel()->getName();
+                for (auto it = scopes.rbegin(); it != scopes.rend(); ++it) {
+                    if (!it->exit_label.empty() && target == it->exit_label) {
+                        block->Stmts().pop_back();
+                        seq.insert(
+                            seq.begin() + static_cast<ptrdiff_t>(i) + 1,
+                            factory.Make<SBreak>());
+                        ++i; // skip the just-inserted SBreak
+                        changed = true;
+                        break;
+                    }
+                    if (!it->header_label.empty()
+                        && target == it->header_label) {
+                        block->Stmts().pop_back();
+                        seq.insert(
+                            seq.begin() + static_cast<ptrdiff_t>(i) + 1,
+                            factory.Make<SContinue>());
+                        ++i; // skip the just-inserted SContinue
                         changed = true;
                         break;
                     }
                 }
-                // Recurse only into branches that were NOT already replaced.
-                if (!then_replaced) {
-                    if (ConvertGotosInNode(ite->ThenBranch(), factory, scopes))
-                        changed = true;
-                }
-                if (!else_replaced) {
-                    if (ConvertGotosInNode(ite->ElseBranch(), factory, scopes))
-                        changed = true;
-                }
-                return changed;
             }
-
-            if (auto *w = node->dyn_cast<SWhile>()) {
-                scopes.push_back({w->ExitLabel(), w->HeaderLabel()});
-                if (ConvertGotosInNode(w->Body(), factory, scopes))
-                    changed = true;
-                scopes.pop_back();
-                return changed;
-            }
-            if (auto *dw = node->dyn_cast<SDoWhile>()) {
-                scopes.push_back({dw->ExitLabel(), dw->HeaderLabel()});
-                if (ConvertGotosInNode(dw->Body(), factory, scopes))
-                    changed = true;
-                scopes.pop_back();
-                return changed;
-            }
-            if (auto *f = node->dyn_cast<SFor>()) {
-                scopes.push_back({f->ExitLabel(), f->HeaderLabel()});
-                if (ConvertGotosInNode(f->Body(), factory, scopes))
-                    changed = true;
-                scopes.pop_back();
-                return changed;
-            }
-
-            if (auto *sw = node->dyn_cast<SSwitch>()) {
-                for (auto &c : sw->Cases()) {
-                    if (ConvertGotosInNode(c.body(), factory, scopes))
-                        changed = true;
-                }
-                if (ConvertGotosInNode(sw->DefaultBody(), factory, scopes))
-                    changed = true;
-                return changed;
-            }
-            if (auto *lbl = node->dyn_cast<SLabel>()) {
-                return ConvertGotosInNode(lbl->Body(), factory, scopes);
-            }
-
-            return false;
+            return changed;
         }
 
     } // anonymous namespace
 
-    bool ConvertGotoToBreakContinue(SNode *root, SNodeFactory &factory) {
-        if (!root) return false;
+    bool ConvertGotoToBreakContinue(std::vector< SNode * > &root,
+                                    SNodeFactory &factory) {
         std::vector<LoopScope> scopes;
-        return ConvertGotosInNode(root, factory, scopes);
+        return ConvertGotosInSeq(root, factory, scopes);
     }
 
     // ---------------------------------------------------------------
@@ -3711,70 +3549,38 @@ namespace patchestry::ast {
             return true;
         }
 
-        /// Check if a label body is a return-terminating block safe for
-        /// duplication.  Returns the SBlock if:
-        ///   - body is an SBlock passing IsSafeReturnBlock, OR
-        ///   - body is an SSeq whose last child is such an SBlock
-        ///     AND all prior children are also safe SBlocks (no control flow).
-        /// Returns nullptr otherwise.
+        /// If `body` is an SBlock passing IsSafeReturnBlock, return it.
         SBlock *ExtractReturnBlock(SNode *body) {
             if (!body) return nullptr;
             if (auto *block = body->dyn_cast<SBlock>()) {
                 if (IsSafeReturnBlock(block)) return block;
-                return nullptr;
-            }
-            if (auto *seq = body->dyn_cast<SSeq>()) {
-                if (seq->Empty()) return nullptr;
-                auto *last = seq->Children().back()->dyn_cast<SBlock>();
-                if (last && IsSafeReturnBlock(last)) return last;
-                return nullptr;
             }
             return nullptr;
+        }
+
+        /// Sequence form: the last element of `body` is the candidate
+        /// return-terminating block.
+        SBlock *ExtractReturnBlockSeq(const std::vector<SNode *> &body) {
+            if (body.empty()) return nullptr;
+            return ExtractReturnBlock(body.back());
         }
 
         /// Info about a label's position in the SNode tree.
         struct LabelEntry {
             SLabel *label;
-            SSeq *parent_seq;   // parent SSeq (or nullptr if not in SSeq)
-            size_t index;       // position in parent_seq
+            std::vector<SNode *> *parent_seq;  // body-vector holding the label
+            size_t index;                      // position in parent_seq
         };
 
         /// Build global label→LabelEntry map.
-        void CollectLabels(SNode *node,
-                           std::unordered_map<std::string_view, LabelEntry> &labels,
-                           SSeq *parent = nullptr, size_t idx = 0) {
-            if (!node) return;
-            if (auto *lbl = node->dyn_cast<SLabel>()) {
-                labels[lbl->Name()] = {lbl, parent, idx};
-                CollectLabels(lbl->Body(), labels, parent, idx);
-                return;
-            }
-            if (auto *seq = node->dyn_cast<SSeq>()) {
-                for (size_t i = 0; i < seq->Size(); ++i)
-                    CollectLabels((*seq)[i], labels, seq, i);
-                return;
-            }
-            if (auto *ite = node->dyn_cast<SIfThenElse>()) {
-                CollectLabels(ite->ThenBranch(), labels);
-                CollectLabels(ite->ElseBranch(), labels);
-                return;
-            }
-            if (auto *w = node->dyn_cast<SWhile>()) {
-                CollectLabels(w->Body(), labels);
-                return;
-            }
-            if (auto *dw = node->dyn_cast<SDoWhile>()) {
-                CollectLabels(dw->Body(), labels);
-                return;
-            }
-            if (auto *f = node->dyn_cast<SFor>()) {
-                CollectLabels(f->Body(), labels);
-                return;
-            }
-            if (auto *sw = node->dyn_cast<SSwitch>()) {
-                for (auto &c : sw->Cases()) CollectLabels(c.body(), labels);
-                CollectLabels(sw->DefaultBody(), labels);
-                return;
+        void CollectLabels(std::vector<SNode *> &seq,
+                           std::unordered_map<std::string_view, LabelEntry> &labels) {
+            for (size_t i = 0; i < seq.size(); ++i) {
+                if (auto *lbl = seq[i]->dyn_cast<SLabel>())
+                    labels[lbl->Name()] = {lbl, &seq, i};
+                ForEachBodyList(seq[i], [&](std::vector<SNode *> &body) {
+                    CollectLabels(body, labels);
+                });
             }
         }
 
@@ -3789,17 +3595,18 @@ namespace patchestry::ast {
             size_t max_stmts = 6
         ) {
             if (!entry.parent_seq) return false;
-            auto *seq = entry.parent_seq;
+            auto &seq = *entry.parent_seq;
 
             out.clear();
-            for (size_t j = entry.index; j < seq->Size(); ++j) {
-                auto *child = (*seq)[j];
+            for (size_t j = entry.index; j < seq.size(); ++j) {
+                auto *child = seq[j];
 
                 // Extract stmts from SLabel(body=SBlock) or bare SBlock.
                 SBlock *block = nullptr;
                 if (auto *lbl = child->dyn_cast<SLabel>()) {
-                    if (lbl->Body())
-                        block = lbl->Body()->dyn_cast<SBlock>();
+                    auto &b = lbl->BodyList();
+                    if (b.size() == 1)
+                        block = b[0]->dyn_cast<SBlock>();
                 } else if (auto *blk = child->dyn_cast<SBlock>()) {
                     block = blk;
                 } else {
@@ -3837,13 +3644,13 @@ namespace patchestry::ast {
             return clang::ReturnStmt::Create(ctx, VirtualLoc(ctx), sr->Value(), nullptr);
         }
 
+        bool FlattenTerminatingSeq(
+            const std::vector<SNode *> &body, clang::ASTContext &ctx,
+            std::vector<clang::Stmt *> &out, size_t max_stmts);
+
         /// Try to flatten a terminating SNode body into clang::Stmts.
-        /// Handles patterns:
-        ///   - SBlock ending in return → copy stmts
-        ///   - SReturn → build ReturnStmt
-        ///   - SSeq{SBlock..., SReturn} → collect stmts + return
-        ///   - SSeq{SBlock..., SIfThenElse(c, term, term)} → stmts + IfStmt
-        /// Returns false if the body is too complex to flatten.
+        /// Handles SBlock ending in return, SReturn, SLabel (unwrap),
+        /// and SIfThenElse where both arms terminate.
         bool FlattenTerminatingBody(
             SNode *body, clang::ASTContext &ctx,
             std::vector<clang::Stmt *> &out,
@@ -3855,9 +3662,10 @@ namespace patchestry::ast {
                 out.push_back(MakeReturn(ctx, sr));
                 return out.size() <= max_stmts;
             }
-            // SLabel: unwrap and flatten the inner body.
+            // SLabel: unwrap and flatten the inner body sequence.
             if (auto *lbl = body->dyn_cast<SLabel>()) {
-                return FlattenTerminatingBody(lbl->Body(), ctx, out, max_stmts);
+                return FlattenTerminatingSeq(
+                    lbl->BodyList(), ctx, out, max_stmts);
             }
             if (auto *blk = body->dyn_cast<SBlock>()) {
                 if (IsSafeReturnBlock(blk, max_stmts)) {
@@ -3866,77 +3674,67 @@ namespace patchestry::ast {
                 }
                 return false;
             }
-            if (auto *seq = body->dyn_cast<SSeq>()) {
-                if (seq->Empty()) return false;
-                // Collect SBlock prefix children.
-                for (size_t i = 0; i + 1 < seq->Size(); ++i) {
-                    auto *child = (*seq)[i]->dyn_cast<SBlock>();
-                    if (!child) return false;
-                    for (auto *s : child->Stmts()) {
-                        if (llvm::isa<clang::GotoStmt>(s)
-                            || llvm::isa<clang::LabelStmt>(s))
-                            return false;
-                        out.push_back(s);
-                        if (out.size() > max_stmts) return false;
-                    }
-                }
-                auto *last = seq->Children().back();
-                // Last child is SReturn.
-                if (auto *sr = last->dyn_cast<SReturn>()) {
-                    out.push_back(MakeReturn(ctx, sr));
-                    return out.size() <= max_stmts;
-                }
-                // Last child is SBlock ending in return.
-                if (auto *lb = last->dyn_cast<SBlock>()) {
-                    if (IsSafeReturnBlock(lb, max_stmts)) {
-                        for (auto *s : lb->Stmts()) out.push_back(s);
-                        return out.size() <= max_stmts;
-                    }
+            // SIfThenElse where both arms terminate.
+            if (auto *ite = body->dyn_cast<SIfThenElse>()) {
+                if (!ite->Cond() || ite->ThenList().empty())
                     return false;
+                std::vector<clang::Stmt *> then_stmts, else_stmts;
+                if (!FlattenTerminatingSeq(
+                        ite->ThenList(), ctx, then_stmts, max_stmts))
+                    return false;
+                clang::Stmt *then_body = nullptr;
+                if (then_stmts.size() == 1) {
+                    then_body = then_stmts[0];
+                } else {
+                    auto loc = VirtualLoc(ctx);
+                    then_body = clang::CompoundStmt::Create(
+                        ctx, then_stmts, clang::FPOptionsOverride(),
+                        loc, loc);
                 }
-                // Last child is SIfThenElse where both arms terminate.
-                if (auto *ite = last->dyn_cast<SIfThenElse>()) {
-                    if (!ite->Cond() || !ite->ThenBranch())
+                clang::Stmt *else_body = nullptr;
+                if (!ite->ElseList().empty()) {
+                    if (!FlattenTerminatingSeq(
+                            ite->ElseList(), ctx, else_stmts, max_stmts))
                         return false;
-                    // Flatten both arms recursively.
-                    std::vector<clang::Stmt *> then_stmts, else_stmts;
-                    if (!FlattenTerminatingBody(
-                            ite->ThenBranch(), ctx, then_stmts, max_stmts))
-                        return false;
-                    clang::Stmt *then_body = nullptr;
-                    if (then_stmts.size() == 1)
-                        then_body = then_stmts[0];
-                    else {
+                    if (else_stmts.size() == 1) {
+                        else_body = else_stmts[0];
+                    } else {
                         auto loc = VirtualLoc(ctx);
-                        then_body = clang::CompoundStmt::Create(
-                            ctx, then_stmts, clang::FPOptionsOverride(),
+                        else_body = clang::CompoundStmt::Create(
+                            ctx, else_stmts, clang::FPOptionsOverride(),
                             loc, loc);
                     }
-                    clang::Stmt *else_body = nullptr;
-                    if (ite->ElseBranch()) {
-                        if (!FlattenTerminatingBody(
-                                ite->ElseBranch(), ctx, else_stmts, max_stmts))
-                            return false;
-                        if (else_stmts.size() == 1)
-                            else_body = else_stmts[0];
-                        else {
-                            auto loc = VirtualLoc(ctx);
-                            else_body = clang::CompoundStmt::Create(
-                                ctx, else_stmts, clang::FPOptionsOverride(),
-                                loc, loc);
-                        }
-                    }
-                    auto loc = VirtualLoc(ctx);
-                    auto *new_if = clang::IfStmt::Create(
-                        ctx, loc, clang::IfStatementKind::Ordinary,
-                        nullptr, nullptr, ite->Cond(), loc, loc,
-                        then_body, loc, else_body);
-                    out.push_back(new_if);
-                    return out.size() <= max_stmts;
                 }
-                return false;
+                auto loc = VirtualLoc(ctx);
+                auto *new_if = clang::IfStmt::Create(
+                    ctx, loc, clang::IfStatementKind::Ordinary,
+                    nullptr, nullptr, ite->Cond(), loc, loc,
+                    then_body, loc, else_body);
+                out.push_back(new_if);
+                return out.size() <= max_stmts;
             }
             return false;
+        }
+
+        /// Flatten a terminating sequence: SBlock prefix children
+        /// followed by a terminating last element.
+        bool FlattenTerminatingSeq(
+            const std::vector<SNode *> &body, clang::ASTContext &ctx,
+            std::vector<clang::Stmt *> &out, size_t max_stmts
+        ) {
+            if (body.empty()) return false;
+            for (size_t i = 0; i + 1 < body.size(); ++i) {
+                auto *child = body[i]->dyn_cast<SBlock>();
+                if (!child) return false;
+                for (auto *s : child->Stmts()) {
+                    if (llvm::isa<clang::GotoStmt>(s)
+                        || llvm::isa<clang::LabelStmt>(s))
+                        return false;
+                    out.push_back(s);
+                    if (out.size() > max_stmts) return false;
+                }
+            }
+            return FlattenTerminatingBody(body.back(), ctx, out, max_stmts);
         }
 
         /// Check if the last stmt in an SBlock is a GotoStmt targeting
@@ -3959,7 +3757,8 @@ namespace patchestry::ast {
             if (it == labels.end()) return false;
 
             // Try 1: label body is directly a return-terminating block.
-            auto *ret_block = ExtractReturnBlock(it->second.label->Body());
+            auto *ret_block =
+                ExtractReturnBlockSeq(it->second.label->BodyList());
             if (ret_block && ret_block != block) {
                 block->Stmts().pop_back();
                 for (auto *s : ret_block->Stmts())
@@ -4013,18 +3812,17 @@ namespace patchestry::ast {
                 auto it = labels.find(target);
                 if (it == labels.end()) return false;
 
-                SNode *body = it->second.label->Body();
-                if (!body) return false;
+                auto &body = it->second.label->BodyList();
+                if (body.empty()) return false;
 
                 // Try direct: body is return-terminating (no goto inside).
-                auto *ret_block = ExtractReturnBlock(body);
-                if (ret_block) {
+                if (auto *ret_block = ExtractReturnBlockSeq(body)) {
                     for (auto *s : ret_block->Stmts())
                         out.push_back(s);
                     return out.size() <= max_stmts;
                 }
 
-                // Try fallthrough tail from label's SSeq position.
+                // Try fallthrough tail from label's sequence position.
                 std::vector<clang::Stmt *> tail;
                 if (CollectReturnTail(it->second, tail)) {
                     for (auto *s : tail) out.push_back(s);
@@ -4033,64 +3831,40 @@ namespace patchestry::ast {
 
                 // Try flattening complex terminating body (SIfThenElse etc.)
                 std::vector<clang::Stmt *> flat;
-                if (FlattenTerminatingBody(body, ctx, flat, max_stmts)) {
+                if (FlattenTerminatingSeq(body, ctx, flat, max_stmts)) {
                     for (auto *s : flat) out.push_back(s);
                     return out.size() <= max_stmts;
                 }
 
-                // Check if body ends in a goto (passthrough).  The goto
-                // may be a clang::GotoStmt trailing an SBlock, or an
-                // SGoto SNode at the end of an SSeq.  Collect the
-                // non-goto stmts, then follow the chain.
+                // Body must end in a goto (passthrough).  Collect the
+                // non-goto stmts from the prefix SBlocks, then follow
+                // the chain to the next label.
                 std::string_view next_target;
-
-                if (auto *b = body->dyn_cast<SBlock>()) {
-                    if (b->Empty()) return false;
-                    auto *last_s = b->Stmts().back();
-                    auto *gs2 = llvm::dyn_cast<clang::GotoStmt>(last_s);
-                    if (!gs2 || !gs2->getLabel()) return false;
-                    for (size_t i = 0; i + 1 < b->Size(); ++i) {
-                        if (llvm::isa<clang::LabelStmt>(b->Stmts()[i]))
+                for (size_t ci = 0; ci + 1 < body.size(); ++ci) {
+                    auto *child_blk = body[ci]->dyn_cast<SBlock>();
+                    if (!child_blk) return false;
+                    for (auto *s : child_blk->Stmts()) {
+                        if (llvm::isa<clang::LabelStmt>(s))
                             return false;
-                        out.push_back(b->Stmts()[i]);
+                        out.push_back(s);
                         if (out.size() > max_stmts) return false;
                     }
+                }
+                SNode *last = body.back();
+                if (auto *sg = last->dyn_cast<SGoto>()) {
+                    next_target = sg->Target();
+                } else if (auto *lb = last->dyn_cast<SBlock>()) {
+                    if (lb->Empty()) return false;
+                    auto *gs2 = llvm::dyn_cast<clang::GotoStmt>(
+                        lb->Stmts().back());
+                    if (!gs2 || !gs2->getLabel()) return false;
                     next_target = gs2->getLabel()->getName();
-                } else if (auto *seq = body->dyn_cast<SSeq>()) {
-                    if (seq->Empty()) return false;
-                    // Last child may be SGoto or SBlock with trailing goto.
-                    auto *last_child = seq->Children().back();
-                    if (auto *sg = last_child->dyn_cast<SGoto>()) {
-                        next_target = sg->Target();
-                    } else if (auto *lb = last_child->dyn_cast<SBlock>()) {
-                        if (lb->Empty()) return false;
-                        auto *gs2 = llvm::dyn_cast<clang::GotoStmt>(
-                            lb->Stmts().back());
-                        if (!gs2 || !gs2->getLabel()) return false;
-                        next_target = gs2->getLabel()->getName();
-                    } else {
-                        return false;
-                    }
-                    // Collect stmts from earlier SSeq children (SBlocks)
-                    // before the trailing block to preserve execution order.
-                    for (size_t ci = 0; ci + 1 < seq->Size(); ++ci) {
-                        auto *child_blk = (*seq)[ci]->dyn_cast<SBlock>();
-                        if (!child_blk) return false;
-                        for (auto *s : child_blk->Stmts()) {
-                            if (llvm::isa<clang::LabelStmt>(s))
-                                return false;
-                            out.push_back(s);
-                            if (out.size() > max_stmts) return false;
-                        }
-                    }
                     // Collect non-goto stmts from the trailing block.
-                    if (auto *lb = last_child->dyn_cast<SBlock>()) {
-                        for (size_t i = 0; i + 1 < lb->Size(); ++i) {
-                            if (llvm::isa<clang::LabelStmt>(lb->Stmts()[i]))
-                                return false;
-                            out.push_back(lb->Stmts()[i]);
-                            if (out.size() > max_stmts) return false;
-                        }
+                    for (size_t i = 0; i + 1 < lb->Size(); ++i) {
+                        if (llvm::isa<clang::LabelStmt>(lb->Stmts()[i]))
+                            return false;
+                        out.push_back(lb->Stmts()[i]);
+                        if (out.size() > max_stmts) return false;
                     }
                 } else {
                     return false;
@@ -4201,140 +3975,85 @@ namespace patchestry::ast {
             return changed;
         }
 
-        /// Replace goto-to-return in a single node, recursing into children.
-        bool ReplaceGotoWithReturn(
-            SNode *node, SNodeFactory &factory,
+        /// Replace goto-to-return across one sequence and its nested
+        /// body-vectors.  SBlock children get trailing-goto and
+        /// if-guarded-goto rewrites; bare SGoto children are replaced
+        /// with a cloned copy of the target label's return body.
+        bool ReplaceGotoInSeq(
+            std::vector<SNode *> &seq, SNodeFactory &factory,
             clang::ASTContext &ctx,
             const std::unordered_map<std::string_view, LabelEntry> &labels
         ) {
-            if (!node) return false;
             bool changed = false;
 
-            // SBlock: check trailing goto AND non-trailing if-guarded gotos.
-            if (auto *block = node->dyn_cast<SBlock>()) {
-                if (TryReplaceBlockTrailingGoto(block, factory, ctx, labels))
-                    changed = true;
-                if (TryReplaceIfGuardedGotos(block, ctx, labels))
-                    changed = true;
-                return changed;
+            for (SNode *child : seq) {
+                if (auto *block = child->dyn_cast<SBlock>()) {
+                    if (TryReplaceBlockTrailingGoto(
+                            block, factory, ctx, labels))
+                        changed = true;
+                    if (TryReplaceIfGuardedGotos(block, ctx, labels))
+                        changed = true;
+                }
+                ForEachBodyList(child, [&](std::vector<SNode *> &body) {
+                    if (ReplaceGotoInSeq(body, factory, ctx, labels))
+                        changed = true;
+                });
             }
 
-            if (auto *seq = node->dyn_cast<SSeq>()) {
-                for (size_t i = 0; i < seq->Size(); ++i) {
-                    if (ReplaceGotoWithReturn((*seq)[i], factory, ctx, labels))
-                        changed = true;
-                }
-                // Also check SGoto SNode children (from SelectAndMarkGotoEdge).
-                for (size_t i = 0; i < seq->Size(); ++i) {
-                    auto *g = (*seq)[i]->dyn_cast<SGoto>();
-                    if (!g) continue;
-                    auto it = labels.find(g->Target());
-                    if (it == labels.end()) continue;
+            // Bare SGoto children (from SelectAndMarkGotoEdge) → clone
+            // of the target label's return body.
+            for (size_t i = 0; i < seq.size(); ++i) {
+                auto *g = seq[i]->dyn_cast<SGoto>();
+                if (!g) continue;
+                auto it = labels.find(g->Target());
+                if (it == labels.end()) continue;
 
-                    // Try direct return block first.
-                    auto *ret_block = ExtractReturnBlock(
-                        it->second.label->Body());
-                    if (ret_block) {
-                        auto *clone = factory.Make<SBlock>();
-                        clone->SetLabel(ret_block->Label());
-                        for (auto *s : ret_block->Stmts())
-                            clone->AddStmt(s);
-                        seq->ReplaceChild(i, clone);
-                        changed = true;
-                        continue;
-                    }
-                    // Try fallthrough tail.
-                    std::vector<clang::Stmt *> tail;
-                    if (CollectReturnTail(it->second, tail)) {
-                        auto *clone = factory.Make<SBlock>();
-                        for (auto *s : tail)
-                            clone->AddStmt(s);
-                        seq->ReplaceChild(i, clone);
-                        changed = true;
-                        continue;
-                    }
-                    // Try goto chain resolution.
-                    std::vector<clang::Stmt *> chain;
-                    if (ResolveGotoChain(g->Target(), labels, ctx, chain)) {
-                        auto *clone = factory.Make<SBlock>();
-                        for (auto *s : chain)
-                            clone->AddStmt(s);
-                        seq->ReplaceChild(i, clone);
-                        changed = true;
-                    }
-                }
-                return changed;
-            }
-
-            if (auto *ite = node->dyn_cast<SIfThenElse>()) {
-                if (ReplaceGotoWithReturn(ite->ThenBranch(), factory, ctx, labels))
+                // Try direct return block first.
+                auto *ret_block =
+                    ExtractReturnBlockSeq(it->second.label->BodyList());
+                if (ret_block) {
+                    auto *clone = factory.Make<SBlock>();
+                    clone->SetLabel(ret_block->Label());
+                    for (auto *s : ret_block->Stmts())
+                        clone->AddStmt(s);
+                    seq[i] = clone;
                     changed = true;
-                if (ReplaceGotoWithReturn(ite->ElseBranch(), factory, ctx, labels))
+                    continue;
+                }
+                // Try fallthrough tail.
+                std::vector<clang::Stmt *> tail;
+                if (CollectReturnTail(it->second, tail)) {
+                    auto *clone = factory.Make<SBlock>();
+                    for (auto *s : tail)
+                        clone->AddStmt(s);
+                    seq[i] = clone;
                     changed = true;
-                // Check if then/else branch is a bare SGoto to a
-                // chain-resolvable target.
-                if (auto *tg = ite->ThenBranch()
-                        ? ite->ThenBranch()->dyn_cast<SGoto>() : nullptr) {
-                    std::vector<clang::Stmt *> chain;
-                    if (ResolveGotoChain(tg->Target(), labels, ctx, chain)) {
-                        auto *clone = factory.Make<SBlock>();
-                        for (auto *s : chain) clone->AddStmt(s);
-                        ite->SetThenBranch(clone);
-                        changed = true;
-                    }
+                    continue;
                 }
-                if (auto *eg = ite->ElseBranch()
-                        ? ite->ElseBranch()->dyn_cast<SGoto>() : nullptr) {
-                    std::vector<clang::Stmt *> chain;
-                    if (ResolveGotoChain(eg->Target(), labels, ctx, chain)) {
-                        auto *clone = factory.Make<SBlock>();
-                        for (auto *s : chain) clone->AddStmt(s);
-                        ite->SetElseBranch(clone);
-                        changed = true;
-                    }
-                }
-                return changed;
-            }
-            if (auto *w = node->dyn_cast<SWhile>()) {
-                return ReplaceGotoWithReturn(w->Body(), factory, ctx, labels);
-            }
-            if (auto *dw = node->dyn_cast<SDoWhile>()) {
-                return ReplaceGotoWithReturn(dw->Body(), factory, ctx, labels);
-            }
-            if (auto *f = node->dyn_cast<SFor>()) {
-                return ReplaceGotoWithReturn(f->Body(), factory, ctx, labels);
-            }
-            if (auto *sw = node->dyn_cast<SSwitch>()) {
-                for (auto &c : sw->Cases()) {
-                    if (ReplaceGotoWithReturn(c.body(), factory, ctx, labels))
-                        changed = true;
-                }
-                if (ReplaceGotoWithReturn(sw->DefaultBody(), factory, ctx, labels))
+                // Try goto chain resolution.
+                std::vector<clang::Stmt *> chain;
+                if (ResolveGotoChain(g->Target(), labels, ctx, chain)) {
+                    auto *clone = factory.Make<SBlock>();
+                    for (auto *s : chain)
+                        clone->AddStmt(s);
+                    seq[i] = clone;
                     changed = true;
-                return changed;
+                }
             }
-            if (auto *lbl = node->dyn_cast<SLabel>()) {
-                return ReplaceGotoWithReturn(lbl->Body(), factory, ctx, labels);
-            }
-
-            return false;
+            return changed;
         }
 
     } // anonymous namespace
 
-    bool ConvertGotoToReturn(SNode *root, SNodeFactory &factory,
+    bool ConvertGotoToReturn(std::vector<SNode *> &root, SNodeFactory &factory,
                              clang::ASTContext &ctx) {
-        if (!root) return false;
-
         std::unordered_map<std::string_view, LabelEntry> labels;
         CollectLabels(root, labels);
 
         // Single pass: chain resolution (ResolveGotoChain) already
         // follows multi-hop goto chains in one shot, so iterating
         // here would duplicate epilogue bodies exponentially.
-        bool any_changed = ReplaceGotoWithReturn(root, factory, ctx, labels);
-
-        return any_changed;
+        return ReplaceGotoInSeq(root, factory, ctx, labels);
     }
 
     // ---------------------------------------------------------------
@@ -4373,45 +4092,27 @@ namespace patchestry::ast {
                 for (auto *s : blk->Stmts()) walk(s);
                 return;
             }
-            if (auto *seq = node->dyn_cast<SSeq>()) {
-                for (auto *c : seq->Children()) CountAllGotoRefs(c, refs);
-                return;
-            }
-            if (auto *ite = node->dyn_cast<SIfThenElse>()) {
-                CountAllGotoRefs(ite->ThenBranch(), refs);
-                CountAllGotoRefs(ite->ElseBranch(), refs);
-                return;
-            }
-            if (auto *w = node->dyn_cast<SWhile>()) {
-                CountAllGotoRefs(w->Body(), refs); return;
-            }
-            if (auto *dw = node->dyn_cast<SDoWhile>()) {
-                CountAllGotoRefs(dw->Body(), refs); return;
-            }
-            if (auto *f = node->dyn_cast<SFor>()) {
-                CountAllGotoRefs(f->Body(), refs); return;
-            }
-            if (auto *sw = node->dyn_cast<SSwitch>()) {
-                for (auto &c : sw->Cases()) CountAllGotoRefs(c.body(), refs);
-                CountAllGotoRefs(sw->DefaultBody(), refs);
-                return;
-            }
-            if (auto *lbl = node->dyn_cast<SLabel>()) {
-                CountAllGotoRefs(lbl->Body(), refs);
-                return;
-            }
+            // All other kinds: recurse uniformly via the visitor API.
+            node->for_each_child([&](SNode *c) { CountAllGotoRefs(c, refs); });
         }
 
-        // Remove unreferenced SLabel children from SSeq nodes.
+        void CountAllGotoRefs(
+            const std::vector<SNode *> &seq,
+            std::unordered_set<std::string_view> &refs
+        ) {
+            for (auto *c : seq) CountAllGotoRefs(c, refs);
+        }
+
+        // Remove unreferenced SLabel children from a sequence.
         bool RemoveDeadLabelsInSeq(
-            SSeq *seq,
+            std::vector<SNode *> &seq,
             const std::unordered_set<std::string_view> &refs
         ) {
             bool changed = false;
-            for (size_t i = 0; i < seq->Size(); ) {
-                auto *lbl = (*seq)[i]->dyn_cast<SLabel>();
+            for (size_t i = 0; i < seq.size(); ) {
+                auto *lbl = seq[i]->dyn_cast<SLabel>();
                 if (lbl && refs.count(lbl->Name()) == 0) {
-                    seq->RemoveChild(i);
+                    seq.erase(seq.begin() + static_cast<ptrdiff_t>(i));
                     changed = true;
                 } else {
                     ++i;
@@ -4420,47 +4121,15 @@ namespace patchestry::ast {
             return changed;
         }
 
-        bool RemoveDeadLabelsRecursive(
-            SNode *node,
-            const std::unordered_set<std::string_view> &refs
-        ) {
-            if (!node) return false;
-            bool changed = false;
-            if (auto *seq = node->dyn_cast<SSeq>()) {
-                for (size_t i = 0; i < seq->Size(); ++i)
-                    if (RemoveDeadLabelsRecursive((*seq)[i], refs))
-                        changed = true;
-                if (RemoveDeadLabelsInSeq(seq, refs))
-                    changed = true;
-                return changed;
-            }
-            if (auto *ite = node->dyn_cast<SIfThenElse>()) {
-                if (RemoveDeadLabelsRecursive(ite->ThenBranch(), refs)) changed = true;
-                if (RemoveDeadLabelsRecursive(ite->ElseBranch(), refs)) changed = true;
-                return changed;
-            }
-            if (auto *w = node->dyn_cast<SWhile>())
-                return RemoveDeadLabelsRecursive(w->Body(), refs);
-            if (auto *dw = node->dyn_cast<SDoWhile>())
-                return RemoveDeadLabelsRecursive(dw->Body(), refs);
-            if (auto *sw = node->dyn_cast<SSwitch>()) {
-                for (auto &c : sw->Cases())
-                    if (RemoveDeadLabelsRecursive(c.body(), refs)) changed = true;
-                if (RemoveDeadLabelsRecursive(sw->DefaultBody(), refs)) changed = true;
-                return changed;
-            }
-            if (auto *lbl = node->dyn_cast<SLabel>())
-                return RemoveDeadLabelsRecursive(lbl->Body(), refs);
-            return false;
-        }
-
     } // anonymous namespace
 
-    bool RemoveUnreferencedLabels(SNode *root, SNodeFactory &) {
-        if (!root) return false;
+    bool RemoveUnreferencedLabels(std::vector<SNode *> &root, SNodeFactory &) {
         std::unordered_set<std::string_view> refs;
         CountAllGotoRefs(root, refs);
-        return RemoveDeadLabelsRecursive(root, refs);
+        return ForEachSeqPostOrder(
+            root, [&](std::vector<SNode *> &seq) {
+                return RemoveDeadLabelsInSeq(seq, refs);
+            });
     }
 
     // ---------------------------------------------------------------
@@ -4482,34 +4151,44 @@ namespace patchestry::ast {
 
         constexpr size_t kMaxCloneStmts = 8;
 
+        // Aggregate clone budget for a single switch.  kMaxCloneStmts
+        // bounds one clone; this bounds the sum across all case arms so
+        // a switch with many arms all targeting the same label can't
+        // clone a medium body into every arm.
+        constexpr size_t kMaxSwitchCloneTotal = 24;
+
+        size_t CountCloneStmts(const SNode *node);
+
+        /// Count approximate clang::Stmt-equivalent size of a sequence.
+        size_t CountCloneSeq(const std::vector<SNode *> &seq) {
+            size_t n = 0;
+            for (auto *c : seq) {
+                n += CountCloneStmts(c);
+                if (n > kMaxCloneStmts) return n;
+            }
+            return n;
+        }
+
         /// Count approximate clang::Stmt-equivalent size of a subtree.
         size_t CountCloneStmts(const SNode *node) {
             if (!node) return 0;
             if (auto *blk = node->dyn_cast<SBlock>())
                 return blk->Size();
-            if (auto *seq = node->dyn_cast<SSeq>()) {
-                size_t n = 0;
-                for (auto *c : seq->Children()) {
-                    n += CountCloneStmts(c);
-                    if (n > kMaxCloneStmts) return n;
-                }
-                return n;
-            }
             if (auto *ite = node->dyn_cast<SIfThenElse>()) {
-                return 1 + CountCloneStmts(ite->ThenBranch())
-                         + CountCloneStmts(ite->ElseBranch());
+                return 1 + CountCloneSeq(ite->ThenList())
+                         + CountCloneSeq(ite->ElseList());
             }
             if (auto *sw = node->dyn_cast<SSwitch>()) {
                 size_t n = 1;
                 for (auto &c : sw->Cases()) {
-                    n += CountCloneStmts(c.body());
+                    n += CountCloneSeq(c.body_list);
                     if (n > kMaxCloneStmts) return n;
                 }
-                n += CountCloneStmts(sw->DefaultBody());
+                n += CountCloneSeq(sw->DefaultBodyList());
                 return n;
             }
             if (auto *lbl = node->dyn_cast<SLabel>())
-                return 1 + CountCloneStmts(lbl->Body());
+                return 1 + CountCloneSeq(lbl->BodyList());
             return 1; // goto / break / continue / return
         }
 
@@ -4531,20 +4210,6 @@ namespace patchestry::ast {
                     if (has_label(s)) return false;
                 return true;
             }
-            if (auto *seq = node->dyn_cast<SSeq>()) {
-                for (auto *c : seq->Children())
-                    if (!SubtreeIsSafeToClone(c)) return false;
-                return true;
-            }
-            if (auto *ite = node->dyn_cast<SIfThenElse>()) {
-                return SubtreeIsSafeToClone(ite->ThenBranch())
-                    && SubtreeIsSafeToClone(ite->ElseBranch());
-            }
-            if (auto *sw = node->dyn_cast<SSwitch>()) {
-                for (auto &c : sw->Cases())
-                    if (!SubtreeIsSafeToClone(c.body())) return false;
-                return SubtreeIsSafeToClone(sw->DefaultBody());
-            }
             // Reject SLabel (would duplicate definition) and all loops.
             switch (node->Kind()) {
                 case SNodeKind::kLabel:
@@ -4553,8 +4218,28 @@ namespace patchestry::ast {
                 case SNodeKind::kFor:
                     return false;
                 default:
-                    return true; // SGoto / SBreak / SContinue / SReturn
+                    break;
             }
+            // SSeq / SIfThenElse / SSwitch: safe iff every child is safe.
+            // Leaves (SGoto/SBreak/SContinue/SReturn) have no children
+            // and fall through to safe.
+            bool safe = true;
+            node->for_each_child([&](SNode *c) {
+                if (safe && !SubtreeIsSafeToClone(c)) safe = false;
+            });
+            return safe;
+        }
+
+        SNode *CloneSNode(SNode *src, SNodeFactory &factory);
+
+        /// Deep-clone a sequence (drops null clone results).
+        std::vector<SNode *> CloneSeq(const std::vector<SNode *> &src,
+                                      SNodeFactory &factory) {
+            std::vector<SNode *> out;
+            out.reserve(src.size());
+            for (auto *c : src)
+                if (auto *cl = CloneSNode(c, factory)) out.push_back(cl);
+            return out;
         }
 
         /// Deep-clone a subtree.  Pre-condition: SubtreeIsSafeToClone(src).
@@ -4568,25 +4253,19 @@ namespace patchestry::ast {
                 for (auto *s : blk->Stmts()) out->AddStmt(s);
                 return out;
             }
-            if (auto *seq = src->dyn_cast<SSeq>()) {
-                std::vector<SNode *> cloned;
-                cloned.reserve(seq->Size());
-                for (auto *c : seq->Children())
-                    cloned.push_back(CloneSNode(c, factory));
-                return factory.MakeSeq(std::move(cloned));
-            }
             if (auto *ite = src->dyn_cast<SIfThenElse>()) {
                 return factory.Make<SIfThenElse>(
                     ite->Cond(),
-                    CloneSNode(ite->ThenBranch(), factory),
-                    CloneSNode(ite->ElseBranch(), factory));
+                    CloneSeq(ite->ThenList(), factory),
+                    CloneSeq(ite->ElseList(), factory));
             }
             if (auto *sw = src->dyn_cast<SSwitch>()) {
                 auto *out = factory.Make<SSwitch>(sw->Discriminant());
                 for (auto &c : sw->Cases())
-                    out->AddCase(c.value, CloneSNode(c.body(), factory));
-                if (sw->DefaultBody())
-                    out->SetDefaultBody(CloneSNode(sw->DefaultBody(), factory));
+                    out->AddCase(c.value, CloneSeq(c.body_list, factory));
+                if (!sw->DefaultBodyList().empty())
+                    out->SetDefaultBody(
+                        CloneSeq(sw->DefaultBodyList(), factory));
                 return out;
             }
             if (auto *g = src->dyn_cast<SGoto>())
@@ -4598,6 +4277,15 @@ namespace patchestry::ast {
             if (auto *ret = src->dyn_cast<SReturn>())
                 return factory.Make<SReturn>(ret->Value());
             return nullptr;
+        }
+
+        bool NeedsTerminatorBreak(const SNode *node);
+
+        /// Sequence form: a sequence needs a break iff its last element
+        /// does (an empty sequence falls through → needs a break).
+        bool NeedsTerminatorBreakSeq(const std::vector<SNode *> &seq) {
+            if (seq.empty()) return true;
+            return NeedsTerminatorBreak(seq.back());
         }
 
         /// True iff \p node already ends in a terminator that transfers
@@ -4620,17 +4308,25 @@ namespace patchestry::ast {
                     return false;
                 return true;
             }
-            if (auto *seq = node->dyn_cast<SSeq>()) {
-                if (seq->Empty()) return true;
-                return NeedsTerminatorBreak(seq->Children().back());
-            }
+            if (auto *lbl = node->dyn_cast<SLabel>())
+                return NeedsTerminatorBreakSeq(lbl->BodyList());
             return true;
         }
 
+        std::string_view TrailingGotoTarget(const SNode *body);
+
+        /// Return the trailing goto target name if the sequence ends in
+        /// a goto.  Empty otherwise.
+        std::string_view TrailingGotoTargetSeq(
+            const std::vector<SNode *> &body
+        ) {
+            if (body.empty()) return {};
+            return TrailingGotoTarget(body.back());
+        }
+
         /// Return the trailing goto target name if \p body ends in a
-        /// goto (bare SGoto, SBlock with trailing GotoStmt, SSeq whose
-        /// last child is one of those, or SLabel wrapping any of those).
-        /// Empty otherwise.
+        /// goto (bare SGoto, SBlock with trailing GotoStmt, or SLabel
+        /// wrapping any of those).  Empty otherwise.
         std::string_view TrailingGotoTarget(const SNode *body) {
             if (!body) return {};
             if (auto *g = body->dyn_cast<SGoto>()) return g->Target();
@@ -4641,125 +4337,82 @@ namespace patchestry::ast {
                     return gs->getLabel()->getName();
                 return {};
             }
-            if (auto *seq = body->dyn_cast<SSeq>()) {
-                if (seq->Empty()) return {};
-                return TrailingGotoTarget(seq->Children().back());
-            }
             if (auto *lbl = body->dyn_cast<SLabel>()) {
-                return TrailingGotoTarget(lbl->Body());
+                return TrailingGotoTargetSeq(lbl->BodyList());
             }
             return {};
         }
 
-        /// Try to clone \p target_label's body.  Returns nullptr if
-        /// unsafe or too large.
-        SNode *TryCloneLabelBody(
+        /// Try to clone \p target_label's body.  Returns an empty vector
+        /// if unsafe or too large.
+        std::vector<SNode *> TryCloneLabelBody(
             std::string_view target_label,
             const std::unordered_map<std::string_view, LabelEntry> &labels,
             SNodeFactory &factory
         ) {
             auto it = labels.find(target_label);
-            if (it == labels.end()) return nullptr;
-            SNode *label_body = it->second.label->Body();
-            if (!label_body) return nullptr;
-            if (CountCloneStmts(label_body) > kMaxCloneStmts) return nullptr;
-            if (!SubtreeIsSafeToClone(label_body)) return nullptr;
-            return CloneSNode(label_body, factory);
+            if (it == labels.end()) return {};
+            auto &label_body = it->second.label->BodyList();
+            if (label_body.empty()) return {};
+            if (CountCloneSeq(label_body) > kMaxCloneStmts) return {};
+            for (auto *c : label_body)
+                if (!SubtreeIsSafeToClone(c)) return {};
+            return CloneSeq(label_body, factory);
         }
 
         /// Build a replacement case body by splicing \p clone in place
         /// of the trailing goto in \p existing.  Returns the new body
-        /// node (possibly a fresh SSeq) or nullptr on failure.
-        ///
-        /// Handles:
-        ///   - existing is SGoto → clone (+ break)
-        ///   - existing is SBlock ending in GotoStmt → SSeq(trimmed_block, clone, break?)
-        ///   - existing is SSeq ending in SGoto → SSeq(prefix_children..., clone, break?)
-        ///   - existing is SSeq ending in SBlock-with-trailing-goto → recurse
-        SNode *BuildSplicedBody(
-            SNode *existing, SNode *clone, SNodeFactory &factory
+        /// sequence, or an empty vector on failure.
+        std::vector<SNode *> BuildSplicedSeq(
+            const std::vector<SNode *> &existing,
+            const std::vector<SNode *> &clone, SNodeFactory &factory
         ) {
-            if (!existing || !clone) return nullptr;
+            if (existing.empty() || clone.empty()) return {};
 
-            bool need_break = NeedsTerminatorBreak(clone);
-            auto wrap_with_break = [&](SNode *n) -> SNode * {
-                if (!need_break) return n;
-                return factory.MakeSeq({n, factory.Make<SBreak>()});
+            bool need_break = NeedsTerminatorBreakSeq(clone);
+            SNode *last = existing.back();
+            std::vector<SNode *> out(existing.begin(), existing.end() - 1);
+
+            auto append_clone = [&]() {
+                for (auto *c : clone) out.push_back(c);
+                if (need_break) out.push_back(factory.Make<SBreak>());
             };
 
-            // Pure SGoto — replace with clone (+ break).
-            if (existing->dyn_cast<SGoto>()) {
-                return wrap_with_break(clone);
+            // Last element is a bare SGoto — drop it, append clone.
+            if (last->dyn_cast<SGoto>()) {
+                append_clone();
+                return out;
             }
 
-            // SBlock whose last stmt is GotoStmt.
-            if (auto *blk = existing->dyn_cast<SBlock>()) {
-                if (blk->Empty()) return nullptr;
-                if (!llvm::isa<clang::GotoStmt>(blk->Stmts().back()))
-                    return nullptr;
-                if (blk->Size() == 1) {
-                    // Pure redirect wrapped in a block — replace whole.
-                    return wrap_with_break(clone);
+            // Last element is an SBlock whose last stmt is a GotoStmt.
+            if (auto *blk = last->dyn_cast<SBlock>()) {
+                if (blk->Empty()
+                    || !llvm::isa<clang::GotoStmt>(blk->Stmts().back()))
+                    return {};
+                if (blk->Size() > 1) {
+                    auto *trimmed = factory.Make<SBlock>();
+                    trimmed->SetLabel(blk->Label());
+                    for (size_t i = 0; i + 1 < blk->Size(); ++i)
+                        trimmed->AddStmt(blk->Stmts()[i]);
+                    out.push_back(trimmed);
                 }
-                // Build a new SBlock without the trailing goto, then
-                // wrap in SSeq(new_block, clone, break?).
-                auto *trimmed = factory.Make<SBlock>();
-                trimmed->SetLabel(blk->Label());
-                for (size_t i = 0; i + 1 < blk->Size(); ++i)
-                    trimmed->AddStmt(blk->Stmts()[i]);
-                std::vector<SNode *> spliced{trimmed, clone};
-                if (need_break) spliced.push_back(factory.Make<SBreak>());
-                return factory.MakeSeq(std::move(spliced));
+                append_clone();
+                return out;
             }
 
-            // SLabel wrapping any of the above: splice inside, keep the
-            // label node.  Mutate via SetBody so the label identity is
-            // preserved (outside gotos may still reference this label).
-            if (auto *lbl = existing->dyn_cast<SLabel>()) {
-                SNode *inner = BuildSplicedBody(lbl->Body(), clone, factory);
-                if (!inner) return nullptr;
-                lbl->SetBody(inner);
-                return lbl;
+            // Last element is an SLabel wrapping a trailing goto: splice
+            // inside the label body, keeping the label node itself so
+            // outside gotos still resolve.
+            if (auto *lbl = last->dyn_cast<SLabel>()) {
+                std::vector<SNode *> inner =
+                    BuildSplicedSeq(lbl->BodyList(), clone, factory);
+                if (inner.empty()) return {};
+                lbl->BodyList() = std::move(inner);
+                out.push_back(lbl);
+                return out;
             }
 
-            // SSeq whose last child carries the trailing goto.
-            if (auto *seq = existing->dyn_cast<SSeq>()) {
-                if (seq->Empty()) return nullptr;
-                SNode *last = seq->Children().back();
-
-                auto build_out = [&](SNode *trimmed_last) -> SNode * {
-                    std::vector<SNode *> out;
-                    out.reserve(seq->Size() + 2);
-                    for (size_t i = 0; i + 1 < seq->Size(); ++i)
-                        out.push_back(seq->Children()[i]);
-                    if (trimmed_last) out.push_back(trimmed_last);
-                    out.push_back(clone);
-                    if (need_break) out.push_back(factory.Make<SBreak>());
-                    return factory.MakeSeq(std::move(out));
-                };
-
-                // Case A: last child is bare SGoto → drop it.
-                if (last->dyn_cast<SGoto>()) return build_out(nullptr);
-
-                // Case B: last child is SBlock with trailing GotoStmt.
-                if (auto *blk = last->dyn_cast<SBlock>()) {
-                    if (!blk->Empty()
-                        && llvm::isa<clang::GotoStmt>(blk->Stmts().back())) {
-                        SNode *trimmed = nullptr;
-                        if (blk->Size() > 1) {
-                            auto *t = factory.Make<SBlock>();
-                            t->SetLabel(blk->Label());
-                            for (size_t i = 0; i + 1 < blk->Size(); ++i)
-                                t->AddStmt(blk->Stmts()[i]);
-                            trimmed = t;
-                        }
-                        return build_out(trimmed);
-                    }
-                }
-                return nullptr;
-            }
-
-            return nullptr;
+            return {};
         }
 
         bool DuplicateInSwitch(
@@ -4767,25 +4420,36 @@ namespace patchestry::ast {
             const std::unordered_map<std::string_view, LabelEntry> &labels
         ) {
             bool changed = false;
+            // Aggregate clone budget across every arm of this switch.
+            size_t cloned_total = 0;
             for (auto &c : sw->Cases()) {
-                auto target = TrailingGotoTarget(c.body());
+                auto target = TrailingGotoTargetSeq(c.body_list);
                 if (target.empty()) continue;
-                SNode *clone = TryCloneLabelBody(target, labels, factory);
-                if (!clone) continue;
-                SNode *spliced = BuildSplicedBody(c.body(), clone, factory);
-                if (!spliced) continue;
-                c.set_body(spliced);
-                spliced->SetParent(sw);
+                std::vector<SNode *> clone =
+                    TryCloneLabelBody(target, labels, factory);
+                if (clone.empty()) continue;
+                size_t clone_size = CountCloneSeq(clone);
+                if (cloned_total + clone_size > kMaxSwitchCloneTotal)
+                    continue;
+                std::vector<SNode *> spliced =
+                    BuildSplicedSeq(c.body_list, clone, factory);
+                if (spliced.empty()) continue;
+                c.body_list = std::move(spliced);
+                cloned_total += clone_size;
                 changed = true;
             }
-            if (SNode *def = sw->DefaultBody()) {
-                auto target = TrailingGotoTarget(def);
+            if (!sw->DefaultBodyList().empty()) {
+                auto target = TrailingGotoTargetSeq(sw->DefaultBodyList());
                 if (!target.empty()) {
-                    SNode *clone = TryCloneLabelBody(target, labels, factory);
-                    if (clone) {
-                        if (SNode *spliced = BuildSplicedBody(
-                                def, clone, factory)) {
-                            sw->SetDefaultBody(spliced);
+                    std::vector<SNode *> clone =
+                        TryCloneLabelBody(target, labels, factory);
+                    if (!clone.empty()
+                        && cloned_total + CountCloneSeq(clone)
+                               <= kMaxSwitchCloneTotal) {
+                        std::vector<SNode *> spliced = BuildSplicedSeq(
+                            sw->DefaultBodyList(), clone, factory);
+                        if (!spliced.empty()) {
+                            sw->DefaultBodyList() = std::move(spliced);
                             changed = true;
                         }
                     }
@@ -4816,7 +4480,7 @@ namespace patchestry::ast {
         /// Debug assertion: every remaining goto target resolves to a
         /// live SLabel.  Runs only in debug builds; aborts on failure
         /// so misbehaviour is caught before a broken TU ships.
-        void VerifyGotoLabelPairing(SNode *root) {
+        void VerifyGotoLabelPairing(std::vector<SNode *> &root) {
 #ifndef NDEBUG
             std::unordered_map<std::string_view, LabelEntry> labels;
             CollectLabels(root, labels);
@@ -4837,8 +4501,8 @@ namespace patchestry::ast {
 
     } // anonymous namespace
 
-    bool DuplicateSwitchCaseTargets(SNode *root, SNodeFactory &factory) {
-        if (!root) return false;
+    bool DuplicateSwitchCaseTargets(std::vector<SNode *> &root,
+                                    SNodeFactory &factory) {
         bool any_changed = false;
         // Re-scan labels on each iteration: a previous duplication may
         // expose new opportunities (e.g., cloning a label body that
@@ -4847,7 +4511,10 @@ namespace patchestry::ast {
         for (int pass = 0; pass < 4; ++pass) {
             std::unordered_map<std::string_view, LabelEntry> labels;
             CollectLabels(root, labels);
-            if (!WalkAndDuplicate(root, factory, labels)) break;
+            bool did = false;
+            for (SNode *c : root)
+                if (WalkAndDuplicate(c, factory, labels)) did = true;
+            if (!did) break;
             any_changed = true;
         }
         if (any_changed) VerifyGotoLabelPairing(root);

--- a/lib/patchestry/AST/CFGStructure.cpp
+++ b/lib/patchestry/AST/CFGStructure.cpp
@@ -26,9 +26,8 @@ namespace patchestry::ast {
                               std::unordered_map<std::string_view, int> &refs) {
         if (!node) return;
 
-        // Two leaf cases that the generic for_each_child can't express:
-        //   - SGoto contributes a ref to its target label (no SNode children).
-        //   - SStmt holds a raw clang::Stmt*; embedded GotoStmt also counts.
+        // Leaf cases for_each_child can't express: SGoto's target label
+        // and clang::GotoStmt embedded in an SStmt's raw Stmt.
         if (auto *g = node->dyn_cast<SGoto>()) {
             refs[g->Target()]++;
             return;
@@ -57,17 +56,14 @@ namespace patchestry::ast {
         for (auto *c : seq) CountGotoRefs(c, refs);
     }
 
-    // Append every element of `src` onto `dst`.  Helper for the
-    // SSeq-free model where a "sequence" is a std::vector<SNode*>.
+    // Append every element of `src` onto `dst`.
     static void SeqAppend(std::vector< SNode * > &dst,
                           const std::vector< SNode * > &src) {
         dst.insert(dst.end(), src.begin(), src.end());
     }
 
-    // Spill a list of raw clang::Stmt* into individual SStmt SNodes,
-    // appended to `out`.  A "block" of statements is a run of SStmt
-    // siblings in a body vector — the SBlock replacement (Phase 3
-    // piece 2).  Null statements are dropped.
+    // Spill raw clang::Stmt* into individual SStmt SNodes appended to
+    // `out`.  Null statements are dropped.
     static void AppendStmts(SNodeFactory &factory,
                             std::vector< SNode * > &out,
                             const std::vector< clang::Stmt * > &stmts) {
@@ -77,9 +73,7 @@ namespace patchestry::ast {
 
     // Invoke fn(std::vector<SNode*>&) on each body-vector slot held by
     // `node` (SLabel/loop bodies, if-then/else arms, switch case lists).
-    // SGoto/SStmt/SBreak/SContinue/SReturn carry no body-vectors.
-    // This replaces the old SSeq-based child sequencing now that the
-    // SSeq node kind no longer exists.
+    // Leaf kinds carry no body-vectors.
     template< typename Fn >
     static void ForEachBodyList(SNode *node, Fn &&fn) {
         if (!node) return;
@@ -645,10 +639,8 @@ namespace patchestry::ast {
         // Ensure labels are preserved on active representative nodes.
         // When IdentifyInternal collapses nodes into a representative,
         // the rule-supplied SNode may not include the representative's
-        // own label.  Wrap it now so goto targets remain valid.
-        //
-        // Check recursively: the label might be inside an SSeq child
-        // (e.g., after the explicit-goto pass wrapped the node).
+        // own label.  Wrap it now so goto targets remain valid.  Check
+        // recursively: the label might be inside a child node.
         auto has_label = [](const std::vector<SNode *> &snodes,
                             std::string_view name) -> bool {
             std::function<bool(const SNode *)> check = [&](const SNode *n) -> bool {
@@ -738,7 +730,7 @@ namespace patchestry::ast {
     // Pattern: Node A has exactly 1 successor B, and B has exactly 1
     //          predecessor A.  A is not a conditional or switch.
     //          Neither is already collapsed.
-    // Action:  Merge into SSeq, collapse via IdentifyInternal.
+    // Action:  Merge into a sequence, collapse via IdentifyInternal.
     // ---------------------------------------------------------------
 
     bool CFGStructure::RuleBlockCat(size_t id) {
@@ -1512,7 +1504,7 @@ namespace patchestry::ast {
     // Loop helper: build the body SNode for a loop.
     //
     // Collects body nodes (excluding the header) in RPO-ish order,
-    // strips terminals from interior nodes, and wraps in SSeq.
+    // strips terminals from interior nodes.
     // ---------------------------------------------------------------
 
     std::vector< SNode * > CFGStructure::BuildLoopBodySNode(
@@ -2462,12 +2454,9 @@ namespace patchestry::ast {
     }
 
     // ---------------------------------------------------------------
-    // InlineResidualGotos — post-structuring cleanup
-    //
-    // Walks SSeq nodes looking for SGoto children whose target SLabel
-    // is a sibling in the same SSeq and is only referenced by that
-    // one goto.  Replaces the goto with the label's body and removes
-    // the label node.
+    // InlineResidualGotos — post-structuring cleanup.  Replaces an
+    // SGoto whose target SLabel is a sibling referenced only by that
+    // goto with the label's body, and removes the label.
     // ---------------------------------------------------------------
 
     namespace {
@@ -2596,7 +2585,7 @@ namespace patchestry::ast {
                             clang::ASTContext &ctx) {
             bool changed = false;
             bool local_changed = true;
-            // Cap restarts to avoid O(N²) on large SSeq (e.g., 100+
+            // Cap restarts to avoid O(N²) on large sequences (e.g., 100+
             // uncollapsed leaf nodes from a partially-structured graph).
             int restart_budget = 50;
 
@@ -2832,7 +2821,7 @@ namespace patchestry::ast {
     // InlineCrossScopeSingleRef — cross-scope single-ref label inliner
     //
     // Extends InlineResidualGotos to the case where the goto and its
-    // target label live in *different* SSeq nodes.  When a label has
+    // target label live in *different* sibling sequences.  When a label has
     // exactly one goto reference, its body always terminates, and no
     // fallthrough can reach the label, the body is moved (not cloned)
     // into the goto's slot and the label node is deleted.
@@ -2938,26 +2927,11 @@ namespace patchestry::ast {
             return found;
         }
 
-        /// Locate an SLabel by name anywhere in the tree, returning
-        /// the enclosing SSeq and the label's index within it.  Only
-        /// labels that are *direct children of an SSeq* are returned —
-        /// labels embedded as bodies of if/while/switch or as the sole
-        /// child of an SLabel do not qualify.
-        ///
-        /// The SSeq-position restriction is intentional and load-bearing:
-        ///   - Inlining checks (preceding-sibling-terminates) need a
-        ///     genuine sibling list, not a single-slot body.
-        ///   - The body's break/continue stmts have lexical scope
-        ///     determined by enclosing loops; moving a body that
-        ///     contains break/continue across loop boundaries would
-        ///     change which loop the terminator refers to.
-        ///
-        /// Layer C Stage 2d migrates only the descent dispatch to
-        /// for_each_child for consistency with Stages 2a–c.  Widening
-        /// the search to non-SSeq positions (Benefit 3 from the
-        /// migration analysis) needs the vector slot storage from
-        /// Stage 3+ before it can be done with the right safety
-        /// analysis — deferred to a follow-up policy change.
+        /// Locate an SLabel by name, returning the sibling sequence it
+        /// lives in and its index.  Only labels in a genuine sibling
+        /// sequence qualify — this is load-bearing: inlining checks need
+        /// a real sibling list, and moving a body containing break/
+        /// continue across loop boundaries would change its target loop.
         struct LabelLoc {
             std::vector< SNode * > *parent = nullptr;
             size_t idx = 0;
@@ -3140,7 +3114,7 @@ namespace patchestry::ast {
     // ---------------------------------------------------------------
     // ScopeifyIfGotos — convert if(cond) goto L; stmts; L: → if(!cond){stmts}
     //
-    // Scan SSeq children for: children[i] = SIfThenElse(cond, SGoto("L"), null)
+    // Scan siblings for: children[i] = SIfThenElse(cond, SGoto("L"), null)
     // followed by intermediate children, then children[j] = SLabel("L", body).
     // When label "L" has exactly one goto reference and no intermediate
     // children contain SLabel nodes, negate the condition, wrap the
@@ -3184,7 +3158,7 @@ namespace patchestry::ast {
 
                     auto target = goto_node->Target();
 
-                    // Find target SLabel in same SSeq (forward only)
+                    // Find target SLabel in same sequence (forward only)
                     size_t label_idx = children.size();
                     for (size_t j = i + 1; j < children.size(); ++j) {
                         if (auto *lbl = children[j]->dyn_cast<SLabel>()) {
@@ -3273,25 +3247,17 @@ namespace patchestry::ast {
     }
 
     // ---------------------------------------------------------------
-    // RemoveDeadSSeqChildren — strip unreachable SSeq children
-    //
-    // Walk SSeq nodes bottom-up.  When child[i] always terminates
-    // (SNodeAlwaysTerminates), remove children [i+1..end) that are
-    // NOT SLabel nodes.  SLabel nodes are preserved because they may
-    // be goto targets from other scopes — removing them without a
-    // full reference count would break goto/label pairing.
+    // RemoveDeadSSeqChildren — strip unreachable siblings.  Bottom-up:
+    // when child[i] always terminates, remove siblings [i+1..end) that
+    // are not SLabel nodes.  SLabels are preserved — they may be goto
+    // targets from other scopes.
     // ---------------------------------------------------------------
 
     namespace {
 
         /// Check if an SNode contains any SLabel (directly or nested).
-        /// Note: this scan uses the visitor API and therefore now also
-        /// descends through SWhile/SDoWhile/SFor/SSwitch/SLabel bodies
-        /// — the previous implementation only descended through SSeq
-        /// and SIfThenElse, which was a latent under-scan that could
-        /// false-negative on labels nested inside loop/switch arms.
-        /// Conservative direction (more "yes, has label" answers) so
-        /// safe with respect to the dead-code removal caller.
+        /// Scans all body slots via the visitor API; over-reporting is
+        /// safe for the dead-code removal caller.
         bool ContainsLabel(SNode *node) {
             if (!node) return false;
             if (node->dyn_cast<SLabel>()) return true;
@@ -3302,29 +3268,17 @@ namespace patchestry::ast {
             return found;
         }
 
-        /// Strict terminator check for dead-code removal purposes.
-        ///
-        /// `SNodeAlwaysTerminates` marks any SSeq whose last child
-        /// terminates as a "terminator" — but after AbsorbFallthroughIntoElse
-        /// or similar post-passes move content between siblings, an SSeq
-        /// that "always terminates" by that forward-flow check may still
-        /// be part of a larger flow where subsequent siblings are reached
-        /// via fall-through from an earlier if-then-else arm that was
-        /// modified in-place.  To avoid dropping live code we only treat
-        /// these as strong terminators:
+        /// Strict terminator check for dead-code removal.  Unlike a
+        /// "tail terminates" check, this only accepts nodes that stay
+        /// terminating under post-passes that move content between
+        /// siblings:
         ///   - primitive terminators (SReturn/SBreak/SContinue/SGoto)
         ///   - SStmt whose clang::Stmt is itself terminal
         ///   - SLabel wrapping any of the above
         ///   - SIfThenElse where BOTH branches are strong terminators
-        ///     (safe: AbsorbFallthroughIntoElse only fires on if-then
-        ///     with NO else, so an if-then-else with both arms
-        ///     terminating is structurally stable under post-passes).
-        /// SSeq / loops / switch are still excluded because their
-        /// internal flow can be mutated in ways the forward "tail
-        /// terminates" check doesn't capture.  The SIfThenElse case
-        /// recovers the legitimate `if(c) return x; else return y;`
-        /// dead-code-after pattern without reintroducing the fragility
-        /// that caused the pb_decode_inner CALL_LOST regression.
+        /// Sequences / loops / switch are excluded: their internal flow
+        /// can be mutated in ways a forward "tail terminates" check
+        /// doesn't capture (cf. pb_decode_inner CALL_LOST regression).
         bool IsStrongTerminator(SNode *node) {
             if (!node) return false;
             if (node->dyn_cast<SReturn>()) return true;
@@ -3498,7 +3452,7 @@ namespace patchestry::ast {
     // ConvertGotoToReturn — replace goto-to-return patterns
     //
     // When an SGoto targets a label whose body is a single SReturn
-    // (or an SSeq whose last child is SReturn with no other control
+    // (or a sequence whose last child is SReturn with no other control
     // flow), replace the goto with a cloned SReturn.
     // ---------------------------------------------------------------
 
@@ -3617,7 +3571,7 @@ namespace patchestry::ast {
                 } else if (auto *lbl = child->dyn_cast<SLabel>()) {
                     // Only a label whose body is a non-empty run of
                     // SStmt nodes contributes (matches the prior
-                    // single-SBlock-body restriction).
+                    // single-statement-body restriction).
                     auto &b = lbl->BodyList();
                     bool all_stmt = !b.empty();
                     for (auto *bc : b)
@@ -4180,7 +4134,7 @@ namespace patchestry::ast {
                 default:
                     break;
             }
-            // SSeq / SIfThenElse / SSwitch: safe iff every child is safe.
+            // Sequence / SIfThenElse / SSwitch: safe iff every child is safe.
             // Leaves (SGoto/SBreak/SContinue/SReturn) have no children
             // and fall through to safe.
             bool safe = true;

--- a/lib/patchestry/AST/CFGStructure.cpp
+++ b/lib/patchestry/AST/CFGStructure.cpp
@@ -28,12 +28,12 @@ namespace patchestry::ast {
 
         // Two leaf cases that the generic for_each_child can't express:
         //   - SGoto contributes a ref to its target label (no SNode children).
-        //   - SBlock holds raw clang::Stmt*; embedded GotoStmt also counts.
+        //   - SStmt holds a raw clang::Stmt*; embedded GotoStmt also counts.
         if (auto *g = node->dyn_cast<SGoto>()) {
             refs[g->Target()]++;
             return;
         }
-        if (auto *blk = node->dyn_cast<SBlock>()) {
+        if (auto *st = node->dyn_cast<SStmt>()) {
             std::function< void(clang::Stmt *) > walk =
                 [&](clang::Stmt *s) {
                 if (!s) return;
@@ -43,7 +43,7 @@ namespace patchestry::ast {
                 }
                 for (auto *child : s->children()) walk(child);
             };
-            for (auto *s : blk->Stmts()) walk(s);
+            walk(st->Stmt());
             return;
         }
 
@@ -64,9 +64,20 @@ namespace patchestry::ast {
         dst.insert(dst.end(), src.begin(), src.end());
     }
 
+    // Spill a list of raw clang::Stmt* into individual SStmt SNodes,
+    // appended to `out`.  A "block" of statements is a run of SStmt
+    // siblings in a body vector — the SBlock replacement (Phase 3
+    // piece 2).  Null statements are dropped.
+    static void AppendStmts(SNodeFactory &factory,
+                            std::vector< SNode * > &out,
+                            const std::vector< clang::Stmt * > &stmts) {
+        for (auto *s : stmts)
+            if (s) out.push_back(factory.Make< SStmt >(s));
+    }
+
     // Invoke fn(std::vector<SNode*>&) on each body-vector slot held by
     // `node` (SLabel/loop bodies, if-then/else arms, switch case lists).
-    // SGoto/SBlock/SBreak/SContinue/SReturn carry no body-vectors.
+    // SGoto/SStmt/SBreak/SContinue/SReturn carry no body-vectors.
     // This replaces the old SSeq-based child sequencing now that the
     // SSeq node kind no longer exists.
     template< typename Fn >
@@ -834,14 +845,12 @@ namespace patchestry::ast {
         size_t id, SNode *child) {
         auto &a = graph_.Node(id);
         // Prefix: a's prior content — either a pre-structured sequence
-        // from an earlier rule, or a fresh SBlock wrapping a.stmts.
+        // from an earlier rule, or a.stmts spilled as SStmt siblings.
         std::vector< SNode * > result;
         if (!a.structured.empty()) {
             result = a.structured;
-        } else if (!a.stmts.empty()) {
-            auto *a_blk = factory_.Make<SBlock>();
-            for (auto *s : a.stmts) a_blk->AddStmt(s);
-            result.push_back(a_blk);
+        } else {
+            AppendStmts(factory_, result, a.stmts);
         }
         if (child) result.push_back(child);
         if (!a.original_label.empty()) {
@@ -1532,7 +1541,7 @@ namespace patchestry::ast {
         std::sort(interior.begin(), interior.end());
 
         if (interior.empty()) {
-            return { factory_.Make<SBlock>() }; // empty body
+            return {}; // empty body
         }
 
         // Helper: for a conditional interior node, if one successor
@@ -1652,13 +1661,9 @@ namespace patchestry::ast {
         }
 
         // Merge pass: look for SIfThenElse(cond, SGoto(L), null) nodes
-        // targeting the same label and combine with ||.  Skip empty
-        // SBlock nodes between them (remnants of conditional routing nodes).
-        auto is_empty_block = [](SNode *n) -> bool {
-            auto *blk = n->dyn_cast<SBlock>();
-            return blk && blk->Stmts().empty();
-        };
-
+        // targeting the same label and combine with ||.  In the spilled
+        // model empty blocks no longer exist, so adjacent if-gotos merge
+        // directly.
         for (size_t i = 0; i < children.size(); ++i) {
             auto *ite1 = children[i]->dyn_cast<SIfThenElse>();
             if (!ite1 || ite1->ElseBranch() || !ite1->ThenBranch())
@@ -1666,11 +1671,8 @@ namespace patchestry::ast {
             auto *g1 = ite1->ThenBranch()->dyn_cast<SGoto>();
             if (!g1) continue;
 
-            // Scan forward, skipping empty blocks, looking for
-            // another if-goto to the same target.
+            // The next sibling is the merge candidate.
             size_t j = i + 1;
-            while (j < children.size() && is_empty_block(children[j]))
-                ++j;
             if (j >= children.size()) continue;
 
             auto *ite2 = children[j]->dyn_cast<SIfThenElse>();
@@ -1692,18 +1694,11 @@ namespace patchestry::ast {
                 factory_.Make<SGoto>(g1->Target()),
                 nullptr);
             children[i] = merged;
-            // Remove empty blocks between i and j, plus j itself.
+            // Remove the merged-in sibling j.
             children.erase(children.begin() + static_cast<ptrdiff_t>(i + 1),
                            children.begin() + static_cast<ptrdiff_t>(j + 1));
             --i;  // retry from same position (might merge 3+)
         }
-
-        // Remove any remaining empty blocks.  MakeSeq drops empty
-        // unlabeled SBlocks too, but the explicit pre-filter keeps
-        // the merged-if-goto loop above from chasing emptied slots.
-        children.erase(
-            std::remove_if(children.begin(), children.end(), is_empty_block),
-            children.end());
 
         return factory_.MakeSeq(std::move(children));
     }
@@ -1761,10 +1756,8 @@ namespace patchestry::ast {
             std::vector<SNode *> inner_children;
             if (!h.structured.empty()) {
                 SeqAppend(inner_children, h.structured);
-            } else if (!h.stmts.empty()) {
-                auto *h_blk = factory_.Make<SBlock>();
-                for (auto *s : h.stmts) h_blk->AddStmt(s);
-                inner_children.push_back(h_blk);
+            } else {
+                AppendStmts(factory_, inner_children, h.stmts);
             }
 
             // Header conditional: if(branch_cond) goto taken_label;
@@ -1825,9 +1818,7 @@ namespace patchestry::ast {
             if (!h.structured.empty()) {
                 SeqAppend(inner, h.structured);
             } else {
-                auto *h_blk = factory_.Make<SBlock>();
-                for (auto *s : h.stmts) h_blk->AddStmt(s);
-                inner.push_back(h_blk);
+                AppendStmts(factory_, inner, h.stmts);
             }
 
             // 2. Exit test: if (exit_cond) break;
@@ -1921,9 +1912,7 @@ namespace patchestry::ast {
             if (!h.structured.empty()) {
                 SeqAppend(full_body, h.structured);
             } else {
-                auto *h_blk = factory_.Make<SBlock>();
-                for (auto *s : h.stmts) h_blk->AddStmt(s);
-                full_body.push_back(h_blk);
+                AppendStmts(factory_, full_body, h.stmts);
             }
         }
         SeqAppend(full_body, loop_body);
@@ -2024,9 +2013,7 @@ namespace patchestry::ast {
             if (!h.structured.empty()) {
                 SeqAppend(full_body, h.structured);
             } else {
-                auto *h_blk = factory_.Make<SBlock>();
-                for (auto *s : h.stmts) h_blk->AddStmt(s);
-                full_body.push_back(h_blk);
+                AppendStmts(factory_, full_body, h.stmts);
             }
         }
         SeqAppend(full_body, loop_body);
@@ -2225,7 +2212,7 @@ namespace patchestry::ast {
                         if (!sn.original_label.empty())
                             return { factory_.Make<SGoto>(
                                 factory_.Intern(sn.original_label)) };
-                        return { factory_.Make<SBlock>() };
+                        return {};
                     };
 
                     std::vector< SNode * > then_body = build_branch(t_id);
@@ -2270,7 +2257,7 @@ namespace patchestry::ast {
                     LOG(WARNING) << "RuleBlockSwitch: target node "
                                  << target << " missing label for goto"
                                  << " — emitting empty case body\n";
-                    case_body = { factory_.Make<SBlock>() };
+                    case_body = {};
                 } else {
                     const std::string &lbl = tn.original_label;
                     case_body = { factory_.Make<SGoto>(factory_.Intern(lbl)) };
@@ -2290,11 +2277,7 @@ namespace patchestry::ast {
 
         // A's pre-switch stmts go before the switch.
         std::vector< SNode * > result;
-        if (!a.stmts.empty()) {
-            auto *a_blk = factory_.Make<SBlock>();
-            for (auto *s : a.stmts) a_blk->AddStmt(s);
-            result.push_back(a_blk);
-        }
+        AppendStmts(factory_, result, a.stmts);
         result.push_back(sw);
 
         // Preserve A's label.
@@ -2420,8 +2403,9 @@ namespace patchestry::ast {
     }
 
     // ---------------------------------------------------------------
-    // BuildLeafSNode — wrap a CNode's stmts in an SBlock, optionally
-    //                   wrapped in an SLabel if the node has a label.
+    // BuildLeafSNode — spill a CNode's stmts into SStmt siblings,
+    //                  optionally wrapped in an SLabel if the node
+    //                  has a label.
     // ---------------------------------------------------------------
 
     std::vector< SNode * > CFGStructure::BuildLeafSNode(
@@ -2432,27 +2416,38 @@ namespace patchestry::ast {
         // return its existing structured sequence.
         if (!node.structured.empty()) return node.structured;
 
-        auto *blk = factory_.Make<SBlock>();
-        for (auto *s : node.stmts) {
-            blk->AddStmt(s);
-        }
-
-        // Append terminal (goto/if-goto) so the existing emitter path
-        // can reconstruct control flow for unstructured remainders.
+        // Terminal (goto/if-goto) is appended so the emitter can
+        // reconstruct control flow for unstructured remainders.
         // Skipped for non-tail nodes in a sequential merge where the
         // edge is absorbed — the terminal would be a dead goto.
-        if (include_terminal && node.terminal) {
-            blk->AddStmt(node.terminal);
+        const bool has_content = !node.stmts.empty()
+            || (include_terminal && node.terminal);
+
+        // An empty unlabeled leaf contributes nothing.
+        if (!has_content && node.original_label.empty()) {
+            return {};
         }
 
-        SNode *result = blk;
+        // An empty labeled leaf keeps its SLabel (it is still a goto
+        // target) but with an empty body, rendered as `label: ;`.
+        if (!has_content) {
+            return { factory_.Make<SLabel>(
+                factory_.Intern(node.original_label),
+                std::vector< SNode * >{}) };
+        }
+
+        std::vector< SNode * > body;
+        AppendStmts(factory_, body, node.stmts);
+        if (include_terminal && node.terminal) {
+            body.push_back(factory_.Make<SStmt>(node.terminal));
+        }
 
         if (!node.original_label.empty()) {
-            result = factory_.Make<SLabel>(
-                factory_.Intern(node.original_label), blk);
+            return { factory_.Make<SLabel>(
+                factory_.Intern(node.original_label), std::move(body)) };
         }
 
-        return { result };
+        return body;
     }
 
     // ---------------------------------------------------------------
@@ -2479,7 +2474,7 @@ namespace patchestry::ast {
 
         // Try to inline gotos in a single sequence.  Returns true if changed.
         bool InlineGotosInSeq(
-            std::vector< SNode * > &seq, SNodeFactory &factory,
+            std::vector< SNode * > &seq, SNodeFactory & /*factory*/,
             const std::unordered_map<std::string_view, int> &refs
         ) {
             bool changed = false;
@@ -2493,11 +2488,12 @@ namespace patchestry::ast {
             }
 
             // Scan children for SGoto nodes that can be inlined.
-            // Only inline when:
-            //   (a) label is the immediate next sibling (forward goto, no skipped code), OR
-            //   (b) all siblings between goto and label are empty SBlocks (nothing skipped)
-            // This prevents changing control-flow semantics by executing code
-            // that the goto would have jumped over.
+            // Only inline when the label is the immediate next sibling
+            // (forward goto, no skipped code).  This prevents changing
+            // control-flow semantics by executing code the goto would
+            // have jumped over.  (In the spilled model empty placeholder
+            // blocks no longer exist, so immediate adjacency is the only
+            // "nothing skipped" case.)
             for (size_t i = 0; i < seq.size(); ++i) {
                 auto *g = seq[i]->dyn_cast<SGoto>();
                 if (!g) continue;
@@ -2515,25 +2511,15 @@ namespace patchestry::ast {
                 // Backward gotos: skip — inlining would re-order execution.
                 if (label_idx <= i) continue;
 
-                // Check that all siblings between goto (i) and label (label_idx)
-                // are empty SBlocks — i.e., the goto doesn't skip any real code.
-                bool can_inline = true;
-                for (size_t k = i + 1; k < label_idx; ++k) {
-                    auto *blk = seq[k]->dyn_cast<SBlock>();
-                    if (!blk || !blk->Empty()) {
-                        can_inline = false;
-                        break;
-                    }
-                }
-                if (!can_inline) continue;
+                // The goto must skip no real code: the label must be
+                // the immediate next sibling.
+                if (label_idx != i + 1) continue;
 
                 auto *lbl = seq[label_idx]->as<SLabel>();
 
                 // Splice the label's body (a vector) into the goto's
-                // slot, dropping the goto, the empty blocks between,
-                // and the label node itself.
+                // slot, dropping the goto and the label node itself.
                 std::vector< SNode * > repl = lbl->BodyList();
-                if (repl.empty()) repl.push_back(factory.Make<SBlock>());
 
                 seq.erase(seq.begin() + static_cast<ptrdiff_t>(i),
                           seq.begin() + static_cast<ptrdiff_t>(label_idx) + 1);
@@ -2558,21 +2544,21 @@ namespace patchestry::ast {
     // ---------------------------------------------------------------
     // EliminateGotoToNextLabel — SNode post-pass
     //
-    // Walk SSeq children.  For each child followed by an SLabel,
-    // chase through nesting (SLabel body → SSeq last child → SBlock
-    // trailing stmt) to find the deepest trailing stmt.  If it's a
-    // goto (SGoto or clang::GotoStmt) targeting the next label, or
-    // an IfStmt with one arm being such a goto, eliminate it.
+    // Walk a sibling sequence.  For each child followed by an SLabel,
+    // chase through nesting (SLabel body → last child → SStmt) to find
+    // the deepest trailing stmt.  If it's a goto (SGoto or
+    // clang::GotoStmt) targeting the next label, or an IfStmt with one
+    // arm being such a goto, eliminate it.
     // ---------------------------------------------------------------
 
     namespace {
 
-        /// Chase through SLabel/SSeq/SBlock to find the deepest trailing
+        /// Chase through SLabel/SStmt to find the deepest trailing
         /// SNode or clang::Stmt.  Returns {leaf_snode, clang_stmt_or_null}.
         /// The leaf_snode is the SNode containing the trailing stmt.
         struct TrailingInfo {
-            SNode *container = nullptr;  // innermost SNode (SBlock, SGoto, etc.)
-            clang::Stmt *stmt = nullptr; // if container is SBlock, its last stmt
+            SNode *container = nullptr;  // innermost SNode (SStmt, SGoto, etc.)
+            clang::Stmt *stmt = nullptr; // if container is SStmt, its stmt
         };
 
         TrailingInfo DeepTrailingSNode(SNode *node) {
@@ -2582,9 +2568,8 @@ namespace patchestry::ast {
                 if (body.empty()) return {};
                 return DeepTrailingSNode(body.back());
             }
-            if (auto *blk = node->dyn_cast<SBlock>()) {
-                if (blk->Empty()) return {};
-                return {blk, blk->Stmts().back()};
+            if (auto *st = node->dyn_cast<SStmt>()) {
+                return {st, st->Stmt()};
             }
             // SGoto, SIfThenElse, etc. — the node itself is the trailing
             return {node, nullptr};
@@ -2663,17 +2648,41 @@ namespace patchestry::ast {
                         break;
                     }
 
-                    // --- Check clang::GotoStmt in SBlock ---
+                    // --- Check clang::GotoStmt / IfStmt held by an SStmt ---
                     if (info.stmt) {
-                        auto clang_tgt = ClangGotoTarget(info.stmt);
-                        if (!clang_tgt.empty() && clang_tgt == next_name) {
-                            // Remove the trailing GotoStmt from the SBlock
-                            auto *blk = info.container->dyn_cast<SBlock>();
-                            if (blk && !blk->Empty()) {
-                                blk->Stmts().pop_back();
-                                local_changed = true; changed = true;
-                                break;
+                        auto *st = info.container->dyn_cast<SStmt>();
+
+                        // Erase the trailing SStmt container, whether it
+                        // is a direct child or nested at the tail of an
+                        // SLabel body chain.
+                        auto erase_container = [&]() {
+                            if (info.container == children[i]) {
+                                children.erase(
+                                    children.begin()
+                                    + static_cast<ptrdiff_t>(i));
+                                return;
                             }
+                            std::function<bool(SNode *)> rec;
+                            rec = [&](SNode *n) -> bool {
+                                auto *l = n->dyn_cast<SLabel>();
+                                if (!l) return false;
+                                auto &body = l->BodyList();
+                                if (body.empty()) return false;
+                                if (body.back() == info.container) {
+                                    body.pop_back();
+                                    return true;
+                                }
+                                return rec(body.back());
+                            };
+                            rec(children[i]);
+                        };
+
+                        auto clang_tgt = ClangGotoTarget(info.stmt);
+                        if (st && !clang_tgt.empty() && clang_tgt == next_name) {
+                            // goto L; L: → drop the trailing goto SStmt
+                            erase_container();
+                            local_changed = true; changed = true;
+                            break;
                         }
 
                         // --- Check clang::IfStmt with goto arm ---
@@ -2681,7 +2690,7 @@ namespace patchestry::ast {
                             auto else_tgt = ClangGotoTarget(ifs->getElse());
                             auto then_tgt = ClangGotoTarget(ifs->getThen());
 
-                            if (!else_tgt.empty() && else_tgt == next_name) {
+                            if (st && !else_tgt.empty() && else_tgt == next_name) {
                                 // else goto L; L: → drop else arm
                                 auto loc = ifs->getIfLoc();
                                 auto *new_if = clang::IfStmt::Create(
@@ -2689,26 +2698,20 @@ namespace patchestry::ast {
                                     nullptr, nullptr,
                                     ifs->getCond(), loc, loc,
                                     ifs->getThen(), loc, nullptr);
-                                auto *blk = info.container->dyn_cast<SBlock>();
-                                if (blk && !blk->Empty()) {
-                                    blk->Stmts().back() = new_if;
-                                    local_changed = true; changed = true;
-                                    break;
-                                }
+                                st->SetStmt(new_if);
+                                local_changed = true; changed = true;
+                                break;
                             }
 
-                            if (!then_tgt.empty() && then_tgt == next_name
+                            if (st && !then_tgt.empty() && then_tgt == next_name
                                 && !ifs->getElse()) {
                                 // if(c) goto L; L: → nop (remove the if-stmt)
-                                auto *blk = info.container->dyn_cast<SBlock>();
-                                if (blk && !blk->Empty()) {
-                                    blk->Stmts().pop_back();
-                                    local_changed = true; changed = true;
-                                    break;
-                                }
+                                erase_container();
+                                local_changed = true; changed = true;
+                                break;
                             }
 
-                            if (!then_tgt.empty() && then_tgt == next_name
+                            if (st && !then_tgt.empty() && then_tgt == next_name
                                 && ifs->getElse()) {
                                 // if(c) goto L; else S; L: → if(!c) S
                                 auto *neg = NegateExpr(ctx, ifs->getCond());
@@ -2718,12 +2721,9 @@ namespace patchestry::ast {
                                     nullptr, nullptr,
                                     neg, loc, loc,
                                     ifs->getElse(), loc, nullptr);
-                                auto *blk = info.container->dyn_cast<SBlock>();
-                                if (blk && !blk->Empty()) {
-                                    blk->Stmts().back() = new_if;
-                                    local_changed = true; changed = true;
-                                    break;
-                                }
+                                st->SetStmt(new_if);
+                                local_changed = true; changed = true;
+                                break;
                             }
                         }
                     }
@@ -2769,9 +2769,13 @@ namespace patchestry::ast {
                         }
                         if (!then_tgt.empty() && then_tgt == next_name
                             && ite->ElseBranch() && ite->Cond()) {
+                            // if(c) goto L; else { S... }; L: → if(!c) { S... }
+                            // The whole else list becomes the new then list —
+                            // ElseBranch() alone would drop all but the first
+                            // sibling in the spilled (SStmt) model.
                             auto *neg = NegateExpr(ctx, ite->Cond());
                             auto *new_ite = factory.Make<SIfThenElse>(
-                                neg, ite->ElseBranch(), nullptr);
+                                neg, ite->ElseList(), std::vector< SNode * >{});
                             // Replace in parent
                             if (info.container == children[i]) {
                                 children[i] = new_ite;
@@ -2878,9 +2882,8 @@ namespace patchestry::ast {
             if (node->dyn_cast<SContinue>()) return true;
             if (node->dyn_cast<SGoto>()) return true;
 
-            if (auto *blk = node->dyn_cast<SBlock>()) {
-                if (blk->Empty()) return false;
-                return ClangStmtIsTerminator(blk->Stmts().back());
+            if (auto *st = node->dyn_cast<SStmt>()) {
+                return ClangStmtIsTerminator(st->Stmt());
             }
             if (auto *lbl = node->dyn_cast<SLabel>()) {
                 return SeqAlwaysTerminates(lbl->BodyList());
@@ -2919,12 +2922,11 @@ namespace patchestry::ast {
             if (!node) return false;
             if (node->dyn_cast<SLabel>()) return true;
 
-            // SBlock may hold a clang::LabelStmt — check too.
-            // (SBlock has no SNode children, so we return early.)
-            if (auto *blk = node->dyn_cast<SBlock>()) {
-                for (auto *s : blk->Stmts())
-                    if (llvm::isa<clang::LabelStmt>(s)) return true;
-                return false;
+            // An SStmt may hold a clang::LabelStmt — check too.
+            // (SStmt has no SNode children, so we return early.)
+            if (auto *st = node->dyn_cast<SStmt>()) {
+                return st->Stmt()
+                    && llvm::isa<clang::LabelStmt>(st->Stmt());
             }
 
             // Uniform recursion via the visitor API: any descendant
@@ -3151,8 +3153,8 @@ namespace patchestry::ast {
             if (!node) return false;
             if (node->dyn_cast<SLabel>()) return true;
             // Note: this scan deliberately does NOT inspect clang::LabelStmt
-            // inside SBlock (unlike SubtreeHasLabel).  Preserving that
-            // narrower scope; the SBlock leaf has no SNode children so
+            // inside an SStmt (unlike SubtreeHasLabel).  Preserving that
+            // narrower scope; the SStmt leaf has no SNode children so
             // the visitor simply returns false for it.
             bool found = false;
             node->for_each_child([&](SNode *c) {
@@ -3231,8 +3233,6 @@ namespace patchestry::ast {
                     replacements.push_back(new_if);
                     for (SNode *c : lbl->BodyList())
                         replacements.push_back(c);
-                    if (lbl->BodyList().empty())
-                        replacements.push_back(factory.Make<SBlock>());
 
                     // Replace range [i, label_idx+1) with `replacements`.
                     children.erase(
@@ -3302,20 +3302,6 @@ namespace patchestry::ast {
             return found;
         }
 
-        /// Trim dead stmts inside an SBlock after the first terminator.
-        bool TrimDeadStmtsInSBlock(SBlock *blk) {
-            auto &stmts = blk->Stmts();
-            for (size_t i = 0; i < stmts.size(); ++i) {
-                if (!ClangStmtIsTerminator(stmts[i])) continue;
-                if (i + 1 >= stmts.size()) return false;
-                stmts.erase(
-                    stmts.begin() + static_cast< ptrdiff_t >(i) + 1,
-                    stmts.end());
-                return true;
-            }
-            return false;
-        }
-
         /// Strict terminator check for dead-code removal purposes.
         ///
         /// `SNodeAlwaysTerminates` marks any SSeq whose last child
@@ -3327,7 +3313,7 @@ namespace patchestry::ast {
         /// modified in-place.  To avoid dropping live code we only treat
         /// these as strong terminators:
         ///   - primitive terminators (SReturn/SBreak/SContinue/SGoto)
-        ///   - SBlock whose last clang::Stmt is itself terminal
+        ///   - SStmt whose clang::Stmt is itself terminal
         ///   - SLabel wrapping any of the above
         ///   - SIfThenElse where BOTH branches are strong terminators
         ///     (safe: AbsorbFallthroughIntoElse only fires on if-then
@@ -3345,9 +3331,8 @@ namespace patchestry::ast {
             if (node->dyn_cast<SBreak>()) return true;
             if (node->dyn_cast<SContinue>()) return true;
             if (node->dyn_cast<SGoto>()) return true;
-            if (auto *blk = node->dyn_cast<SBlock>()) {
-                if (blk->Empty()) return false;
-                return ClangStmtIsTerminator(blk->Stmts().back());
+            if (auto *st = node->dyn_cast<SStmt>()) {
+                return ClangStmtIsTerminator(st->Stmt());
             }
             if (auto *lbl = node->dyn_cast<SLabel>()) {
                 auto &body = lbl->BodyList();
@@ -3371,12 +3356,8 @@ namespace patchestry::ast {
 
         bool RemoveDeadInSeq(std::vector< SNode * > &children) {
             bool changed = false;
-            // Trim dead stmts inside SBlock children first — SBlocks
-            // hold no body-vectors so ForEachSeqPostOrder never visits
-            // them as a sequence on their own.
-            for (SNode *c : children)
-                if (auto *blk = c->dyn_cast<SBlock>())
-                    if (TrimDeadStmtsInSBlock(blk)) changed = true;
+            // Dead statements after a terminator are now dead SStmt
+            // siblings — the loop below trims them at the sibling level.
 
             for (size_t i = 0; i + 1 < children.size(); ++i) {
                 if (!IsStrongTerminator(children[i])) continue;
@@ -3409,7 +3390,7 @@ namespace patchestry::ast {
     // ConvertGotoToBreakContinue — replace gotos to loop exit/header
     //
     // Walks the SNode tree with a scope stack of enclosing loops.
-    // For each trailing clang::GotoStmt in an SBlock:
+    // For each SStmt holding a clang::GotoStmt:
     //   - target matches loop ExitLabel → replace with SBreak
     //   - target matches loop HeaderLabel → replace with SContinue
     // Also handles SGoto SNodes from SelectAndMarkGotoEdge.
@@ -3481,30 +3462,22 @@ namespace patchestry::ast {
                     continue;
                 }
 
-                auto *block = seq[i]->dyn_cast<SBlock>();
-                if (!block || block->Empty()) continue;
+                auto *st = seq[i]->dyn_cast<SStmt>();
+                if (!st) continue;
                 auto *goto_stmt =
-                    llvm::dyn_cast<clang::GotoStmt>(block->Stmts().back());
+                    llvm::dyn_cast_or_null<clang::GotoStmt>(st->Stmt());
                 if (!goto_stmt || !goto_stmt->getLabel()) continue;
 
                 std::string_view target = goto_stmt->getLabel()->getName();
                 for (auto it = scopes.rbegin(); it != scopes.rend(); ++it) {
                     if (!it->exit_label.empty() && target == it->exit_label) {
-                        block->Stmts().pop_back();
-                        seq.insert(
-                            seq.begin() + static_cast<ptrdiff_t>(i) + 1,
-                            factory.Make<SBreak>());
-                        ++i; // skip the just-inserted SBreak
+                        seq[i] = factory.Make<SBreak>();
                         changed = true;
                         break;
                     }
                     if (!it->header_label.empty()
                         && target == it->header_label) {
-                        block->Stmts().pop_back();
-                        seq.insert(
-                            seq.begin() + static_cast<ptrdiff_t>(i) + 1,
-                            factory.Make<SContinue>());
-                        ++i; // skip the just-inserted SContinue
+                        seq[i] = factory.Make<SContinue>();
                         changed = true;
                         break;
                     }
@@ -3531,45 +3504,67 @@ namespace patchestry::ast {
 
     namespace {
 
-        /// Check if an SBlock is a safe, return-terminating block that
-        /// can be duplicated at goto sites.  Must:
+        /// True if a clang::Stmt tree contains a CallExpr.
+        bool StmtTreeHasCall(const clang::Stmt *s) {
+            if (!s) return false;
+            if (llvm::isa<clang::CallExpr>(s)) return true;
+            for (const auto *c : s->children())
+                if (StmtTreeHasCall(c)) return true;
+            return false;
+        }
+
+        /// True if any stmt in the vector contains a CallExpr.
+        bool StmtVecHasCall(const std::vector<clang::Stmt *> &v) {
+            for (auto *s : v)
+                if (StmtTreeHasCall(s)) return true;
+            return false;
+        }
+
+        /// Check whether the maximal trailing run of SStmt siblings in
+        /// `body` forms a safe, return-terminating block that can be
+        /// duplicated at goto sites, collecting its statements into
+        /// `out`.  The run must:
+        ///   - be non-empty
         ///   - end with clang::ReturnStmt
         ///   - have ≤ max_stmts statements
         ///   - contain no GotoStmt or LabelStmt (no new label references)
-        bool IsSafeReturnBlock(SBlock *block, size_t max_stmts = 8) {
-            if (!block || block->Empty()) return false;
-            if (block->Size() > max_stmts) return false;
-            if (!llvm::isa<clang::ReturnStmt>(block->Stmts().back()))
+        ///   - contain no CallExpr — duplicating a call inflates the
+        ///     output with extra call sites that do not exist in the
+        ///     input P-Code; such a body stays shared behind its goto
+        bool ExtractReturnTail(const std::vector<SNode *> &body,
+                               std::vector<clang::Stmt *> &out,
+                               size_t max_stmts = 8) {
+            out.clear();
+            size_t start = body.size();
+            while (start > 0 && body[start - 1]->dyn_cast<SStmt>())
+                --start;
+            if (start == body.size()) return false; // no trailing SStmt run
+            for (size_t j = start; j < body.size(); ++j)
+                out.push_back(body[j]->as<SStmt>()->Stmt());
+            if (out.size() > max_stmts) { out.clear(); return false; }
+            if (out.empty()
+                || !llvm::isa<clang::ReturnStmt>(out.back())) {
+                out.clear();
                 return false;
-            for (auto *s : block->Stmts()) {
-                if (llvm::isa<clang::GotoStmt>(s)
-                    || llvm::isa<clang::LabelStmt>(s))
+            }
+            for (auto *s : out) {
+                if (!s || llvm::isa<clang::GotoStmt>(s)
+                    || llvm::isa<clang::LabelStmt>(s)
+                    || StmtTreeHasCall(s)) {
+                    out.clear();
                     return false;
+                }
             }
             return true;
         }
 
-        /// If `body` is an SBlock passing IsSafeReturnBlock, return it.
-        SBlock *ExtractReturnBlock(SNode *body) {
-            if (!body) return nullptr;
-            if (auto *block = body->dyn_cast<SBlock>()) {
-                if (IsSafeReturnBlock(block)) return block;
-            }
-            return nullptr;
-        }
-
-        /// Sequence form: the last element of `body` is the candidate
-        /// return-terminating block.
-        SBlock *ExtractReturnBlockSeq(const std::vector<SNode *> &body) {
-            if (body.empty()) return nullptr;
-            return ExtractReturnBlock(body.back());
-        }
-
-        /// Info about a label's position in the SNode tree.
+        /// Info about a label's position in the SNode tree.  Only the
+        /// owning sequence is recorded — the label's index within it is
+        /// re-derived on demand, since goto-to-return splicing shifts
+        /// sibling positions during the pass.
         struct LabelEntry {
             SLabel *label;
             std::vector<SNode *> *parent_seq;  // body-vector holding the label
-            size_t index;                      // position in parent_seq
         };
 
         /// Build global label→LabelEntry map.
@@ -3577,7 +3572,7 @@ namespace patchestry::ast {
                            std::unordered_map<std::string_view, LabelEntry> &labels) {
             for (size_t i = 0; i < seq.size(); ++i) {
                 if (auto *lbl = seq[i]->dyn_cast<SLabel>())
-                    labels[lbl->Name()] = {lbl, &seq, i};
+                    labels[lbl->Name()] = {lbl, &seq};
                 ForEachBodyList(seq[i], [&](std::vector<SNode *> &body) {
                     CollectLabels(body, labels);
                 });
@@ -3585,10 +3580,11 @@ namespace patchestry::ast {
         }
 
         /// Collect the fallthrough tail stmts starting from a label's
-        /// position in its parent SSeq.  Follows consecutive SLabel/SBlock
-        /// siblings, collecting their stmts.  Returns true if the tail
-        /// ends with ReturnStmt and total stmts ≤ max_stmts.  All stmts
-        /// must be safe (no GotoStmt/LabelStmt except the label markers).
+        /// position in its parent sequence.  Follows consecutive SStmt
+        /// siblings and all-SStmt-bodied SLabel siblings, collecting
+        /// their stmts.  Returns true if the tail ends with ReturnStmt
+        /// and total stmts ≤ max_stmts.  All stmts must be safe (no
+        /// GotoStmt/LabelStmt except the label markers).
         bool CollectReturnTail(
             const LabelEntry &entry,
             std::vector<clang::Stmt *> &out,
@@ -3597,30 +3593,40 @@ namespace patchestry::ast {
             if (!entry.parent_seq) return false;
             auto &seq = *entry.parent_seq;
 
+            // Re-derive the label's current index — splicing earlier in
+            // this pass may have shifted it.
+            size_t start = seq.size();
+            for (size_t k = 0; k < seq.size(); ++k)
+                if (seq[k] == entry.label) { start = k; break; }
+            if (start == seq.size()) return false;
+
             out.clear();
-            for (size_t j = entry.index; j < seq.size(); ++j) {
+            auto collect = [&](clang::Stmt *s) -> bool {
+                if (llvm::isa<clang::GotoStmt>(s)
+                    || llvm::isa<clang::LabelStmt>(s))
+                    return false; // unsafe stmt — hard fail
+                out.push_back(s);
+                return out.size() <= max_stmts;
+            };
+
+            for (size_t j = start; j < seq.size(); ++j) {
                 auto *child = seq[j];
 
-                // Extract stmts from SLabel(body=SBlock) or bare SBlock.
-                SBlock *block = nullptr;
-                if (auto *lbl = child->dyn_cast<SLabel>()) {
+                if (auto *st = child->dyn_cast<SStmt>()) {
+                    if (!collect(st->Stmt())) return false;
+                } else if (auto *lbl = child->dyn_cast<SLabel>()) {
+                    // Only a label whose body is a non-empty run of
+                    // SStmt nodes contributes (matches the prior
+                    // single-SBlock-body restriction).
                     auto &b = lbl->BodyList();
-                    if (b.size() == 1)
-                        block = b[0]->dyn_cast<SBlock>();
-                } else if (auto *blk = child->dyn_cast<SBlock>()) {
-                    block = blk;
+                    bool all_stmt = !b.empty();
+                    for (auto *bc : b)
+                        if (!bc->dyn_cast<SStmt>()) { all_stmt = false; break; }
+                    if (!all_stmt) break;
+                    for (auto *bc : b)
+                        if (!collect(bc->as<SStmt>()->Stmt())) return false;
                 } else {
-                    break; // non-label/non-block sibling — stop
-                }
-
-                if (!block) break;
-
-                for (auto *s : block->Stmts()) {
-                    if (llvm::isa<clang::GotoStmt>(s)
-                        || llvm::isa<clang::LabelStmt>(s))
-                        return false; // unsafe stmt
-                    out.push_back(s);
-                    if (out.size() > max_stmts) return false;
+                    break; // non-label/non-stmt sibling — stop
                 }
             }
 
@@ -3649,7 +3655,7 @@ namespace patchestry::ast {
             std::vector<clang::Stmt *> &out, size_t max_stmts);
 
         /// Try to flatten a terminating SNode body into clang::Stmts.
-        /// Handles SBlock ending in return, SReturn, SLabel (unwrap),
+        /// Handles SStmt holding a return, SReturn, SLabel (unwrap),
         /// and SIfThenElse where both arms terminate.
         bool FlattenTerminatingBody(
             SNode *body, clang::ASTContext &ctx,
@@ -3667,12 +3673,13 @@ namespace patchestry::ast {
                 return FlattenTerminatingSeq(
                     lbl->BodyList(), ctx, out, max_stmts);
             }
-            if (auto *blk = body->dyn_cast<SBlock>()) {
-                if (IsSafeReturnBlock(blk, max_stmts)) {
-                    for (auto *s : blk->Stmts()) out.push_back(s);
-                    return out.size() <= max_stmts;
-                }
-                return false;
+            if (auto *st = body->dyn_cast<SStmt>()) {
+                auto *s = st->Stmt();
+                if (!s || !llvm::isa<clang::ReturnStmt>(s)
+                    || StmtTreeHasCall(s))
+                    return false;
+                out.push_back(s);
+                return out.size() <= max_stmts;
             }
             // SIfThenElse where both arms terminate.
             if (auto *ite = body->dyn_cast<SIfThenElse>()) {
@@ -3716,7 +3723,7 @@ namespace patchestry::ast {
             return false;
         }
 
-        /// Flatten a terminating sequence: SBlock prefix children
+        /// Flatten a terminating sequence: SStmt prefix children
         /// followed by a terminating last element.
         bool FlattenTerminatingSeq(
             const std::vector<SNode *> &body, clang::ASTContext &ctx,
@@ -3724,76 +3731,23 @@ namespace patchestry::ast {
         ) {
             if (body.empty()) return false;
             for (size_t i = 0; i + 1 < body.size(); ++i) {
-                auto *child = body[i]->dyn_cast<SBlock>();
+                auto *child = body[i]->dyn_cast<SStmt>();
                 if (!child) return false;
-                for (auto *s : child->Stmts()) {
-                    if (llvm::isa<clang::GotoStmt>(s)
-                        || llvm::isa<clang::LabelStmt>(s))
-                        return false;
-                    out.push_back(s);
-                    if (out.size() > max_stmts) return false;
-                }
+                auto *s = child->Stmt();
+                if (llvm::isa<clang::GotoStmt>(s)
+                    || llvm::isa<clang::LabelStmt>(s))
+                    return false;
+                out.push_back(s);
+                if (out.size() > max_stmts) return false;
             }
             return FlattenTerminatingBody(body.back(), ctx, out, max_stmts);
         }
 
-        /// Check if the last stmt in an SBlock is a GotoStmt targeting
-        /// a return-terminating label.  If so, replace with the return stmts.
-        /// First tries the label's direct body (ExtractReturnBlock), then
-        /// falls back to collecting the fallthrough tail through consecutive
-        /// labels in the parent SSeq (CollectReturnTail).
-        bool TryReplaceBlockTrailingGoto(
-            SBlock *block, SNodeFactory &/*factory*/,
-            clang::ASTContext &ctx,
-            const std::unordered_map<std::string_view, LabelEntry> &labels
-        ) {
-            if (!block || block->Empty()) return false;
-            auto *last = block->Stmts().back();
-            auto *goto_stmt = llvm::dyn_cast<clang::GotoStmt>(last);
-            if (!goto_stmt || !goto_stmt->getLabel()) return false;
-
-            std::string_view target = goto_stmt->getLabel()->getName();
-            auto it = labels.find(target);
-            if (it == labels.end()) return false;
-
-            // Try 1: label body is directly a return-terminating block.
-            auto *ret_block =
-                ExtractReturnBlockSeq(it->second.label->BodyList());
-            if (ret_block && ret_block != block) {
-                block->Stmts().pop_back();
-                for (auto *s : ret_block->Stmts())
-                    block->AddStmt(s);
-                return true;
-            }
-
-            // Try 2: follow the fallthrough chain through consecutive
-            // labels in the parent SSeq to collect a return-terminating tail.
-            std::vector<clang::Stmt *> tail;
-            if (CollectReturnTail(it->second, tail)) {
-                block->Stmts().pop_back();
-                for (auto *s : tail)
-                    block->AddStmt(s);
-                return true;
-            }
-
-            // Try 3: resolve goto chains (label body ends in another
-            // goto → follow until a return-terminating body).
-            std::vector<clang::Stmt *> chain;
-            if (ResolveGotoChain(target, labels, ctx, chain)) {
-                block->Stmts().pop_back();
-                for (auto *s : chain)
-                    block->AddStmt(s);
-                return true;
-            }
-
-            return false;
-        }
-
         /// Follow a goto chain through labels collecting stmts until
         /// a return-terminating body is reached.  Each link in the
-        /// chain is a label whose SBlock body ends in a GotoStmt to
-        /// the next link.  Returns true if a return-terminated
-        /// sequence was assembled within the budget.
+        /// chain is a label whose body ends in a goto to the next
+        /// link.  Returns true if a return-terminated sequence was
+        /// assembled within the budget.
         ///
         /// Example chain:  goto L1 → L1:{s1; goto L2} → L2:{s2; return v;}
         /// Result:          out = {s1, s2, return v;}
@@ -3816,10 +3770,10 @@ namespace patchestry::ast {
                 if (body.empty()) return false;
 
                 // Try direct: body is return-terminating (no goto inside).
-                if (auto *ret_block = ExtractReturnBlockSeq(body)) {
-                    for (auto *s : ret_block->Stmts())
-                        out.push_back(s);
-                    return out.size() <= max_stmts;
+                std::vector<clang::Stmt *> direct;
+                if (ExtractReturnTail(body, direct, max_stmts)) {
+                    for (auto *s : direct) out.push_back(s);
+                    return out.size() <= max_stmts && !StmtVecHasCall(out);
                 }
 
                 // Try fallthrough tail from label's sequence position.
@@ -3837,35 +3791,26 @@ namespace patchestry::ast {
                 }
 
                 // Body must end in a goto (passthrough).  Collect the
-                // non-goto stmts from the prefix SBlocks, then follow
-                // the chain to the next label.
+                // non-label stmts from the prefix SStmt siblings, then
+                // follow the chain to the next label.
                 std::string_view next_target;
                 for (size_t ci = 0; ci + 1 < body.size(); ++ci) {
-                    auto *child_blk = body[ci]->dyn_cast<SBlock>();
-                    if (!child_blk) return false;
-                    for (auto *s : child_blk->Stmts()) {
-                        if (llvm::isa<clang::LabelStmt>(s))
-                            return false;
-                        out.push_back(s);
-                        if (out.size() > max_stmts) return false;
-                    }
+                    auto *child_st = body[ci]->dyn_cast<SStmt>();
+                    if (!child_st) return false;
+                    auto *s = child_st->Stmt();
+                    if (llvm::isa<clang::LabelStmt>(s))
+                        return false;
+                    out.push_back(s);
+                    if (out.size() > max_stmts) return false;
                 }
                 SNode *last = body.back();
                 if (auto *sg = last->dyn_cast<SGoto>()) {
                     next_target = sg->Target();
-                } else if (auto *lb = last->dyn_cast<SBlock>()) {
-                    if (lb->Empty()) return false;
-                    auto *gs2 = llvm::dyn_cast<clang::GotoStmt>(
-                        lb->Stmts().back());
+                } else if (auto *st = last->dyn_cast<SStmt>()) {
+                    auto *gs2 = llvm::dyn_cast_or_null<clang::GotoStmt>(
+                        st->Stmt());
                     if (!gs2 || !gs2->getLabel()) return false;
                     next_target = gs2->getLabel()->getName();
-                    // Collect non-goto stmts from the trailing block.
-                    for (size_t i = 0; i + 1 < lb->Size(); ++i) {
-                        if (llvm::isa<clang::LabelStmt>(lb->Stmts()[i]))
-                            return false;
-                        out.push_back(lb->Stmts()[i]);
-                        if (out.size() > max_stmts) return false;
-                    }
                 } else {
                     return false;
                 }
@@ -3932,53 +3877,73 @@ namespace patchestry::ast {
                 ctx, stmts, clang::FPOptionsOverride(), loc, loc);
         }
 
-        /// Scan all stmts in an SBlock for clang::IfStmt whose then/else
-        /// arm is a GotoStmt targeting a return-terminating label.
-        /// Replaces the goto arm with the label's body wrapped in a
-        /// CompoundStmt.  Handles bare gotos and CompoundStmt-wrapped gotos.
-        bool TryReplaceIfGuardedGotos(
-            SBlock *block,
+        /// For a clang::IfStmt whose then/else arm is a GotoStmt
+        /// targeting a return-terminating label, replace the goto arm
+        /// with the label's body wrapped in a CompoundStmt.  Handles
+        /// bare gotos and CompoundStmt-wrapped gotos.
+        bool TryReplaceIfGuardedGoto(
+            clang::IfStmt *ifs,
             clang::ASTContext &ctx,
             const std::unordered_map<std::string_view, LabelEntry> &labels
         ) {
-            if (!block || block->Empty()) return false;
             bool changed = false;
 
-            for (size_t i = 0; i < block->Stmts().size(); ++i) {
-                auto *ifs = llvm::dyn_cast<clang::IfStmt>(block->Stmts()[i]);
-                if (!ifs) continue;
-
-                // Check then-arm.
-                auto then_info = ExtractIfArmGoto(ifs->getThen());
-                if (then_info.gs) {
-                    std::vector<clang::Stmt *> body;
-                    if (ResolveGotoReturnBody(then_info.gs, labels, ctx, body)) {
-                        auto *replacement = BuildReplacementArm(
-                            ctx, then_info.compound, body);
-                        ifs->setThen(replacement);
-                        changed = true;
-                    }
+            // Check then-arm.
+            auto then_info = ExtractIfArmGoto(ifs->getThen());
+            if (then_info.gs) {
+                std::vector<clang::Stmt *> body;
+                if (ResolveGotoReturnBody(then_info.gs, labels, ctx, body)) {
+                    ifs->setThen(BuildReplacementArm(
+                        ctx, then_info.compound, body));
+                    changed = true;
                 }
+            }
 
-                // Check else-arm.
-                auto else_info = ExtractIfArmGoto(ifs->getElse());
-                if (else_info.gs) {
-                    std::vector<clang::Stmt *> body;
-                    if (ResolveGotoReturnBody(else_info.gs, labels, ctx, body)) {
-                        auto *replacement = BuildReplacementArm(
-                            ctx, else_info.compound, body);
-                        ifs->setElse(replacement);
-                        changed = true;
-                    }
+            // Check else-arm.
+            auto else_info = ExtractIfArmGoto(ifs->getElse());
+            if (else_info.gs) {
+                std::vector<clang::Stmt *> body;
+                if (ResolveGotoReturnBody(else_info.gs, labels, ctx, body)) {
+                    ifs->setElse(BuildReplacementArm(
+                        ctx, else_info.compound, body));
+                    changed = true;
                 }
             }
             return changed;
         }
 
+        /// Resolve a goto `target` into the return-terminating stmts
+        /// that should replace the goto.  Tries the label body's
+        /// trailing SStmt run, then the fallthrough tail across sibling
+        /// labels, then multi-hop goto-chain resolution.
+        bool ResolveReturnStmts(
+            std::string_view target,
+            const std::unordered_map<std::string_view, LabelEntry> &labels,
+            clang::ASTContext &ctx,
+            std::vector<clang::Stmt *> &out
+        ) {
+            auto it = labels.find(target);
+            if (it == labels.end()) return false;
+
+            out.clear();
+            if (ExtractReturnTail(it->second.label->BodyList(), out))
+                return true;
+            out.clear();
+            if (CollectReturnTail(it->second, out))
+                return true;
+            out.clear();
+            if (ResolveGotoChain(target, labels, ctx, out))
+                return true;
+            out.clear();
+            return false;
+        }
+
         /// Replace goto-to-return across one sequence and its nested
-        /// body-vectors.  SBlock children get trailing-goto and
-        /// if-guarded-goto rewrites; bare SGoto children are replaced
-        /// with a cloned copy of the target label's return body.
+        /// body-vectors.  An SStmt holding a clang::IfStmt with a goto
+        /// arm gets the arm rewritten in place; an SStmt holding a
+        /// GotoStmt — or a bare SGoto — that targets a return-terminating
+        /// label is replaced by the label's return body, spilled as
+        /// SStmt siblings.
         bool ReplaceGotoInSeq(
             std::vector<SNode *> &seq, SNodeFactory &factory,
             clang::ASTContext &ctx,
@@ -3986,59 +3951,51 @@ namespace patchestry::ast {
         ) {
             bool changed = false;
 
+            // Recurse into nested body-vectors first.
             for (SNode *child : seq) {
-                if (auto *block = child->dyn_cast<SBlock>()) {
-                    if (TryReplaceBlockTrailingGoto(
-                            block, factory, ctx, labels))
-                        changed = true;
-                    if (TryReplaceIfGuardedGotos(block, ctx, labels))
-                        changed = true;
-                }
                 ForEachBodyList(child, [&](std::vector<SNode *> &body) {
                     if (ReplaceGotoInSeq(body, factory, ctx, labels))
                         changed = true;
                 });
             }
 
-            // Bare SGoto children (from SelectAndMarkGotoEdge) → clone
-            // of the target label's return body.
-            for (size_t i = 0; i < seq.size(); ++i) {
-                auto *g = seq[i]->dyn_cast<SGoto>();
-                if (!g) continue;
-                auto it = labels.find(g->Target());
-                if (it == labels.end()) continue;
+            // Rewrite if-guarded goto arms in place (mutates the
+            // clang::IfStmt; does not alter the sibling list).
+            for (SNode *child : seq) {
+                if (auto *st = child->dyn_cast<SStmt>())
+                    if (auto *ifs = llvm::dyn_cast_or_null<clang::IfStmt>(
+                            st->Stmt()))
+                        if (TryReplaceIfGuardedGoto(ifs, ctx, labels))
+                            changed = true;
+            }
 
-                // Try direct return block first.
-                auto *ret_block =
-                    ExtractReturnBlockSeq(it->second.label->BodyList());
-                if (ret_block) {
-                    auto *clone = factory.Make<SBlock>();
-                    clone->SetLabel(ret_block->Label());
-                    for (auto *s : ret_block->Stmts())
-                        clone->AddStmt(s);
-                    seq[i] = clone;
-                    changed = true;
+            // Replace goto-holding siblings (SStmt(GotoStmt) or bare
+            // SGoto) with the resolved return body.
+            for (size_t i = 0; i < seq.size(); ++i) {
+                std::string_view target;
+                if (auto *st = seq[i]->dyn_cast<SStmt>()) {
+                    if (auto *gs = llvm::dyn_cast_or_null<clang::GotoStmt>(
+                            st->Stmt()))
+                        if (gs->getLabel())
+                            target = gs->getLabel()->getName();
+                } else if (auto *g = seq[i]->dyn_cast<SGoto>()) {
+                    target = g->Target();
+                }
+                if (target.empty()) continue;
+
+                std::vector<clang::Stmt *> body;
+                if (!ResolveReturnStmts(target, labels, ctx, body))
                     continue;
-                }
-                // Try fallthrough tail.
-                std::vector<clang::Stmt *> tail;
-                if (CollectReturnTail(it->second, tail)) {
-                    auto *clone = factory.Make<SBlock>();
-                    for (auto *s : tail)
-                        clone->AddStmt(s);
-                    seq[i] = clone;
-                    changed = true;
-                    continue;
-                }
-                // Try goto chain resolution.
-                std::vector<clang::Stmt *> chain;
-                if (ResolveGotoChain(g->Target(), labels, ctx, chain)) {
-                    auto *clone = factory.Make<SBlock>();
-                    for (auto *s : chain)
-                        clone->AddStmt(s);
-                    seq[i] = clone;
-                    changed = true;
-                }
+
+                std::vector<SNode *> repl;
+                AppendStmts(factory, repl, body);
+                if (repl.empty()) continue;
+
+                seq.erase(seq.begin() + static_cast<ptrdiff_t>(i));
+                seq.insert(seq.begin() + static_cast<ptrdiff_t>(i),
+                           repl.begin(), repl.end());
+                i += repl.size() - 1; // skip the just-inserted siblings
+                changed = true;
             }
             return changed;
         }
@@ -4068,7 +4025,7 @@ namespace patchestry::ast {
     namespace {
 
         // Collect ALL label references: SGoto targets + clang::GotoStmt
-        // targets inside SBlock stmts.
+        // targets inside SStmt stmts.
         void CountAllGotoRefs(
             const SNode *node,
             std::unordered_set<std::string_view> &refs
@@ -4078,8 +4035,8 @@ namespace patchestry::ast {
                 refs.insert(g->Target());
                 return;
             }
-            if (auto *blk = node->dyn_cast<SBlock>()) {
-                // Recursively walk clang::Stmt trees for GotoStmt.
+            if (auto *st = node->dyn_cast<SStmt>()) {
+                // Recursively walk the clang::Stmt tree for GotoStmt.
                 std::function<void(clang::Stmt *)> walk =
                     [&](clang::Stmt *s) {
                     if (!s) return;
@@ -4089,7 +4046,7 @@ namespace patchestry::ast {
                     }
                     for (auto *child : s->children()) walk(child);
                 };
-                for (auto *s : blk->Stmts()) walk(s);
+                walk(st->Stmt());
                 return;
             }
             // All other kinds: recurse uniformly via the visitor API.
@@ -4172,8 +4129,8 @@ namespace patchestry::ast {
         /// Count approximate clang::Stmt-equivalent size of a subtree.
         size_t CountCloneStmts(const SNode *node) {
             if (!node) return 0;
-            if (auto *blk = node->dyn_cast<SBlock>())
-                return blk->Size();
+            if (node->dyn_cast<SStmt>())
+                return 1;
             if (auto *ite = node->dyn_cast<SIfThenElse>()) {
                 return 1 + CountCloneSeq(ite->ThenList())
                          + CountCloneSeq(ite->ElseList());
@@ -4197,18 +4154,21 @@ namespace patchestry::ast {
         /// SFor (loops would be duplicated, changing complexity).
         bool SubtreeIsSafeToClone(const SNode *node) {
             if (!node) return true;
-            if (auto *blk = node->dyn_cast<SBlock>()) {
-                std::function<bool(const clang::Stmt *)> has_label =
-                    [&](const clang::Stmt *st) -> bool {
-                        if (!st) return false;
-                        if (llvm::isa<clang::LabelStmt>(st)) return true;
-                        for (const auto *c : st->children())
-                            if (has_label(c)) return true;
+            if (auto *st = node->dyn_cast<SStmt>()) {
+                // Reject an SStmt that defines a label (cloning would
+                // duplicate the definition) or contains a call (cloning
+                // a call inflates the output with extra call sites that
+                // do not exist in the input P-Code).
+                std::function<bool(const clang::Stmt *)> has_unsafe =
+                    [&](const clang::Stmt *cs) -> bool {
+                        if (!cs) return false;
+                        if (llvm::isa<clang::LabelStmt>(cs)) return true;
+                        if (llvm::isa<clang::CallExpr>(cs)) return true;
+                        for (const auto *c : cs->children())
+                            if (has_unsafe(c)) return true;
                         return false;
                     };
-                for (auto *s : blk->Stmts())
-                    if (has_label(s)) return false;
-                return true;
+                return !has_unsafe(st->Stmt());
             }
             // Reject SLabel (would duplicate definition) and all loops.
             switch (node->Kind()) {
@@ -4244,15 +4204,11 @@ namespace patchestry::ast {
 
         /// Deep-clone a subtree.  Pre-condition: SubtreeIsSafeToClone(src).
         /// clang::Stmt* pointers are shared — clang::Stmt has no single
-        /// parent, so aliasing the same stmt in two SBlocks is legal.
+        /// parent, so aliasing the same stmt in two SStmt nodes is legal.
         SNode *CloneSNode(SNode *src, SNodeFactory &factory) {
             if (!src) return nullptr;
-            if (auto *blk = src->dyn_cast<SBlock>()) {
-                auto *out = factory.Make<SBlock>();
-                out->SetLabel(blk->Label());
-                for (auto *s : blk->Stmts()) out->AddStmt(s);
-                return out;
-            }
+            if (auto *st = src->dyn_cast<SStmt>())
+                return factory.Make<SStmt>(st->Stmt());
             if (auto *ite = src->dyn_cast<SIfThenElse>()) {
                 return factory.Make<SIfThenElse>(
                     ite->Cond(),
@@ -4298,9 +4254,8 @@ namespace patchestry::ast {
                 || node->dyn_cast<SContinue>()
                 || node->dyn_cast<SGoto>())
                 return false;
-            if (auto *blk = node->dyn_cast<SBlock>()) {
-                if (blk->Empty()) return true;
-                auto *last = blk->Stmts().back();
+            if (auto *st = node->dyn_cast<SStmt>()) {
+                auto *last = st->Stmt();
                 if (llvm::isa<clang::ReturnStmt>(last)
                     || llvm::isa<clang::BreakStmt>(last)
                     || llvm::isa<clang::ContinueStmt>(last)
@@ -4325,15 +4280,14 @@ namespace patchestry::ast {
         }
 
         /// Return the trailing goto target name if \p body ends in a
-        /// goto (bare SGoto, SBlock with trailing GotoStmt, or SLabel
+        /// goto (bare SGoto, SStmt holding a GotoStmt, or SLabel
         /// wrapping any of those).  Empty otherwise.
         std::string_view TrailingGotoTarget(const SNode *body) {
             if (!body) return {};
             if (auto *g = body->dyn_cast<SGoto>()) return g->Target();
-            if (auto *blk = body->dyn_cast<SBlock>()) {
-                if (blk->Empty()) return {};
-                if (auto *gs = llvm::dyn_cast<clang::GotoStmt>(
-                        blk->Stmts().back()))
+            if (auto *st = body->dyn_cast<SStmt>()) {
+                if (auto *gs = llvm::dyn_cast_or_null<clang::GotoStmt>(
+                        st->Stmt()))
                     return gs->getLabel()->getName();
                 return {};
             }
@@ -4384,18 +4338,12 @@ namespace patchestry::ast {
                 return out;
             }
 
-            // Last element is an SBlock whose last stmt is a GotoStmt.
-            if (auto *blk = last->dyn_cast<SBlock>()) {
-                if (blk->Empty()
-                    || !llvm::isa<clang::GotoStmt>(blk->Stmts().back()))
+            // Last element is an SStmt holding a GotoStmt — drop it,
+            // append clone.  (Any non-goto prefix statements are
+            // already separate SStmt siblings retained in `out`.)
+            if (auto *st = last->dyn_cast<SStmt>()) {
+                if (!llvm::isa<clang::GotoStmt>(st->Stmt()))
                     return {};
-                if (blk->Size() > 1) {
-                    auto *trimmed = factory.Make<SBlock>();
-                    trimmed->SetLabel(blk->Label());
-                    for (size_t i = 0; i + 1 < blk->Size(); ++i)
-                        trimmed->AddStmt(blk->Stmts()[i]);
-                    out.push_back(trimmed);
-                }
                 append_clone();
                 return out;
             }

--- a/lib/patchestry/AST/CGraph.cpp
+++ b/lib/patchestry/AST/CGraph.cpp
@@ -22,10 +22,11 @@ namespace patchestry::ast {
     // structured block (structural).
     // ---------------------------------------------------------------
     size_t CGraph::IdentifyInternal(const std::vector<size_t> &ids,
-                                        CNode::BlockType type, SNode *snode) {
+                                        CNode::BlockType type,
+                                        std::vector< SNode * > snodes) {
         if (ids.empty()) return CNode::kNone;
         size_t rep = ids[0];
-        nodes[rep].structured = snode;
+        nodes[rep].structured = std::move(snodes);
         nodes[rep].block_type = type;
 
         std::unordered_set<size_t> idset(ids.begin(), ids.end());

--- a/lib/patchestry/AST/CfgDotEmitter.cpp
+++ b/lib/patchestry/AST/CfgDotEmitter.cpp
@@ -70,11 +70,9 @@ namespace patchestry::ast {
             };
 
             switch (node->Kind()) {
-            case SNodeKind::kBlock: {
-                auto *blk = node->as<SBlock>();
-                for (const auto *s : blk->Stmts()) {
-                    pad(); os << StmtToOneLine(s) << "\\l";
-                }
+            case SNodeKind::kStmt: {
+                pad();
+                os << StmtToOneLine(node->as<SStmt>()->Stmt()) << "\\l";
                 break;
             }
             case SNodeKind::kIfThenElse: {
@@ -343,8 +341,8 @@ namespace patchestry::ast {
 
         size_t total = 0;
         switch (root->Kind()) {
-        case SNodeKind::kBlock:
-            return root->as<SBlock>()->Stmts().size();
+        case SNodeKind::kStmt:
+            return 1;
         case SNodeKind::kWhile:
             total += CountCommaChainStmts(root->as<SWhile>()->Cond());
             break;
@@ -385,9 +383,8 @@ namespace patchestry::ast {
                                           std::unordered_set<const clang::Stmt *> &out) {
         if (!root) return;
         switch (root->Kind()) {
-        case SNodeKind::kBlock:
-            for (auto *s : root->as<SBlock>()->Stmts())
-                if (s) out.insert(s);
+        case SNodeKind::kStmt:
+            if (auto *s = root->as<SStmt>()->Stmt()) out.insert(s);
             break;
         case SNodeKind::kIfThenElse:
             // The condition may embed stmts via comma-operator.

--- a/lib/patchestry/AST/CfgDotEmitter.cpp
+++ b/lib/patchestry/AST/CfgDotEmitter.cpp
@@ -352,7 +352,7 @@ namespace patchestry::ast {
         case SNodeKind::kSwitch:
             // Count 1 for the discriminant — compensates for the original
             // SwitchStmt that FoldSwitch strips from the head block's stmts.
-            total += root->as<SSwitch>()->Discriminant() ? 1 : 0;
+            total += root->as<SSwitch>()->Discriminant() ? size_t{ 1 } : size_t{ 0 };
             break;
         default:
             break;

--- a/lib/patchestry/AST/CfgDotEmitter.cpp
+++ b/lib/patchestry/AST/CfgDotEmitter.cpp
@@ -77,18 +77,15 @@ namespace patchestry::ast {
                 }
                 break;
             }
-            case SNodeKind::kSeq: {
-                for (const auto *child : node->as<SSeq>()->Children())
-                    DumpSNode(child, os, indent);
-                break;
-            }
             case SNodeKind::kIfThenElse: {
                 auto *ite = node->as<SIfThenElse>();
                 pad(); os << "if (" << StmtToOneLine(ite->Cond()) << ") {\\l";
-                DumpSNode(ite->ThenBranch(), os, indent + 1);
-                if (ite->ElseBranch()) {
+                for (const auto *c : ite->ThenList())
+                    DumpSNode(c, os, indent + 1);
+                if (!ite->ElseList().empty()) {
                     pad(); os << "} else {\\l";
-                    DumpSNode(ite->ElseBranch(), os, indent + 1);
+                    for (const auto *c : ite->ElseList())
+                        DumpSNode(c, os, indent + 1);
                 }
                 pad(); os << "}\\l";
                 break;
@@ -96,21 +93,24 @@ namespace patchestry::ast {
             case SNodeKind::kWhile: {
                 auto *w = node->as<SWhile>();
                 pad(); os << "while (" << StmtToOneLine(w->Cond()) << ") {\\l";
-                DumpSNode(w->Body(), os, indent + 1);
+                for (const auto *c : w->BodyList())
+                    DumpSNode(c, os, indent + 1);
                 pad(); os << "}\\l";
                 break;
             }
             case SNodeKind::kDoWhile: {
                 auto *dw = node->as<SDoWhile>();
                 pad(); os << "do {\\l";
-                DumpSNode(dw->Body(), os, indent + 1);
+                for (const auto *c : dw->BodyList())
+                    DumpSNode(c, os, indent + 1);
                 pad(); os << "} while (" << StmtToOneLine(dw->Cond()) << ");\\l";
                 break;
             }
             case SNodeKind::kFor: {
                 auto *f = node->as<SFor>();
                 pad(); os << "for (...) {\\l";
-                DumpSNode(f->Body(), os, indent + 1);
+                for (const auto *c : f->BodyList())
+                    DumpSNode(c, os, indent + 1);
                 pad(); os << "}\\l";
                 break;
             }
@@ -134,7 +134,8 @@ namespace patchestry::ast {
             case SNodeKind::kLabel: {
                 auto *lbl = node->as<SLabel>();
                 pad(); os << lbl->Name() << ":\\l";
-                DumpSNode(lbl->Body(), os, indent);
+                for (const auto *c : lbl->BodyList())
+                    DumpSNode(c, os, indent);
                 break;
             }
             case SNodeKind::kGoto: {
@@ -189,16 +190,17 @@ namespace patchestry::ast {
             for (const auto *s : n.stmts) {
                 os << StmtToOneLine(s) << "\\l";
             }
-            if (n.structured) {
+            if (!n.structured.empty()) {
                 if (!n.stmts.empty()) os << "---\\l";
-                DumpSNode(n.structured, os, 0);
+                for (const auto *s : n.structured)
+                    DumpSNode(s, os, 0);
             }
 
             // Show synthesized control flow from edge metadata.
             // This is more useful for debugging than the raw terminal
             // stmt, since it reflects the current graph state (edges
             // may have been added/removed/marked by fold rules).
-            if (!n.structured) {
+            if (n.structured.empty()) {
                 auto node_label = [&](size_t id) -> std::string {
                     if (id < g.nodes.size() && !g.nodes[id].label.empty())
                         return g.nodes[id].label;
@@ -339,45 +341,29 @@ namespace patchestry::ast {
     size_t CountSNodeStmts(const SNode *root) {
         if (!root) return 0;
 
+        size_t total = 0;
         switch (root->Kind()) {
         case SNodeKind::kBlock:
             return root->as<SBlock>()->Stmts().size();
-        case SNodeKind::kSeq: {
-            size_t total = 0;
-            for (const auto *child : root->as<SSeq>()->Children())
-                total += CountSNodeStmts(child);
-            return total;
-        }
-        case SNodeKind::kIfThenElse: {
-            auto *ite = root->as<SIfThenElse>();
-            return CountSNodeStmts(ite->ThenBranch())
-                 + CountSNodeStmts(ite->ElseBranch());
-        }
         case SNodeKind::kWhile:
-            return CountCommaChainStmts(root->as<SWhile>()->Cond())
-                 + CountSNodeStmts(root->as<SWhile>()->Body());
+            total += CountCommaChainStmts(root->as<SWhile>()->Cond());
+            break;
         case SNodeKind::kDoWhile:
-            return CountCommaChainStmts(root->as<SDoWhile>()->Cond())
-                 + CountSNodeStmts(root->as<SDoWhile>()->Body());
-        case SNodeKind::kFor:
-            return CountSNodeStmts(root->as<SFor>()->Body());
-        case SNodeKind::kSwitch: {
-            auto *sw = root->as<SSwitch>();
+            total += CountCommaChainStmts(root->as<SDoWhile>()->Cond());
+            break;
+        case SNodeKind::kSwitch:
             // Count 1 for the discriminant — compensates for the original
             // SwitchStmt that FoldSwitch strips from the head block's stmts.
-            size_t total = sw->Discriminant() ? 1 : 0;
-            for (const auto &c : sw->Cases())
-                for (const auto *b : c.body_list)
-                    total += CountSNodeStmts(b);
-            for (const auto *b : sw->DefaultBodyList())
-                total += CountSNodeStmts(b);
-            return total;
-        }
-        case SNodeKind::kLabel:
-            return CountSNodeStmts(root->as<SLabel>()->Body());
+            total += root->as<SSwitch>()->Discriminant() ? 1 : 0;
+            break;
         default:
-            return 0;
+            break;
         }
+        // Recurse uniformly into every SNode child slot.
+        root->for_each_child([&](const SNode *c) {
+            total += CountSNodeStmts(c);
+        });
+        return total;
     }
 
     size_t CountCGraphStmts(const detail::CGraph &g) {
@@ -385,9 +371,8 @@ namespace patchestry::ast {
         for (const auto &n : g.nodes) {
             if (n.IsCollapsed()) continue;
             total += n.stmts.size();
-            if (n.structured) {
-                total += CountSNodeStmts(n.structured);
-            }
+            for (const auto *s : n.structured)
+                total += CountSNodeStmts(s);
         }
         return total;
     }
@@ -404,52 +389,30 @@ namespace patchestry::ast {
             for (auto *s : root->as<SBlock>()->Stmts())
                 if (s) out.insert(s);
             break;
-        case SNodeKind::kSeq:
-            for (const auto *child : root->as<SSeq>()->Children())
-                CollectSNodeStmtPtrsImpl(child, out);
+        case SNodeKind::kIfThenElse:
+            // The condition may embed stmts via comma-operator.
+            if (auto *c = root->as<SIfThenElse>()->Cond()) out.insert(c);
             break;
-        case SNodeKind::kIfThenElse: {
-            auto *ite = root->as<SIfThenElse>();
-            // The condition may embed stmts via comma-operator
-            if (ite->Cond()) out.insert(ite->Cond());
-            CollectSNodeStmtPtrsImpl(ite->ThenBranch(), out);
-            CollectSNodeStmtPtrsImpl(ite->ElseBranch(), out);
+        case SNodeKind::kWhile:
+            if (auto *c = root->as<SWhile>()->Cond()) out.insert(c);
             break;
-        }
-        case SNodeKind::kWhile: {
-            auto *w = root->as<SWhile>();
-            if (w->Cond()) out.insert(w->Cond());
-            CollectSNodeStmtPtrsImpl(w->Body(), out);
+        case SNodeKind::kDoWhile:
+            if (auto *c = root->as<SDoWhile>()->Cond()) out.insert(c);
             break;
-        }
-        case SNodeKind::kDoWhile: {
-            auto *dw = root->as<SDoWhile>();
-            if (dw->Cond()) out.insert(dw->Cond());
-            CollectSNodeStmtPtrsImpl(dw->Body(), out);
+        case SNodeKind::kFor:
+            if (auto *c = root->as<SFor>()->Cond()) out.insert(c);
             break;
-        }
-        case SNodeKind::kFor: {
-            auto *f = root->as<SFor>();
-            if (f->Cond()) out.insert(f->Cond());
-            CollectSNodeStmtPtrsImpl(f->Body(), out);
-            break;
-        }
-        case SNodeKind::kSwitch: {
-            auto *sw = root->as<SSwitch>();
-            if (sw->Discriminant()) out.insert(sw->Discriminant());
-            for (const auto &c : sw->Cases())
-                for (const auto *b : c.body_list)
-                    CollectSNodeStmtPtrsImpl(b, out);
-            for (const auto *b : sw->DefaultBodyList())
-                CollectSNodeStmtPtrsImpl(b, out);
-            break;
-        }
-        case SNodeKind::kLabel:
-            CollectSNodeStmtPtrsImpl(root->as<SLabel>()->Body(), out);
+        case SNodeKind::kSwitch:
+            if (auto *d = root->as<SSwitch>()->Discriminant())
+                out.insert(d);
             break;
         default:
             break;
         }
+        // Recurse uniformly into every SNode child slot.
+        root->for_each_child([&](const SNode *c) {
+            CollectSNodeStmtPtrsImpl(c, out);
+        });
     }
 
     void CollectSNodeStmtPtrs(const SNode *root,
@@ -463,8 +426,8 @@ namespace patchestry::ast {
             if (n.IsCollapsed()) continue;
             for (auto *s : n.stmts)
                 if (s) out.insert(s);
-            if (n.structured)
-                CollectSNodeStmtPtrsImpl(n.structured, out);
+            for (const auto *s : n.structured)
+                CollectSNodeStmtPtrsImpl(s, out);
         }
     }
 

--- a/lib/patchestry/AST/CfgDotEmitter.cpp
+++ b/lib/patchestry/AST/CfgDotEmitter.cpp
@@ -120,11 +120,13 @@ namespace patchestry::ast {
                 for (size_t i = 0; i < sw->Cases().size(); ++i) {
                     const auto &c = sw->Cases()[i];
                     pad(); os << "  case " << StmtToOneLine(c.value) << ":\\l";
-                    DumpSNode(c.body, os, indent + 2);
+                    for (const auto *b : c.body_list)
+                        DumpSNode(b, os, indent + 2);
                 }
-                if (sw->DefaultBody()) {
+                if (!sw->DefaultBodyList().empty()) {
                     pad(); os << "  default:\\l";
-                    DumpSNode(sw->DefaultBody(), os, indent + 2);
+                    for (const auto *b : sw->DefaultBodyList())
+                        DumpSNode(b, os, indent + 2);
                 }
                 pad(); os << "}\\l";
                 break;
@@ -365,8 +367,10 @@ namespace patchestry::ast {
             // SwitchStmt that FoldSwitch strips from the head block's stmts.
             size_t total = sw->Discriminant() ? 1 : 0;
             for (const auto &c : sw->Cases())
-                total += CountSNodeStmts(c.body);
-            total += CountSNodeStmts(sw->DefaultBody());
+                for (const auto *b : c.body_list)
+                    total += CountSNodeStmts(b);
+            for (const auto *b : sw->DefaultBodyList())
+                total += CountSNodeStmts(b);
             return total;
         }
         case SNodeKind::kLabel:
@@ -434,8 +438,10 @@ namespace patchestry::ast {
             auto *sw = root->as<SSwitch>();
             if (sw->Discriminant()) out.insert(sw->Discriminant());
             for (const auto &c : sw->Cases())
-                CollectSNodeStmtPtrsImpl(c.body, out);
-            CollectSNodeStmtPtrsImpl(sw->DefaultBody(), out);
+                for (const auto *b : c.body_list)
+                    CollectSNodeStmtPtrsImpl(b, out);
+            for (const auto *b : sw->DefaultBodyList())
+                CollectSNodeStmtPtrsImpl(b, out);
             break;
         }
         case SNodeKind::kLabel:

--- a/lib/patchestry/AST/ClangEmitter.cpp
+++ b/lib/patchestry/AST/ClangEmitter.cpp
@@ -127,28 +127,16 @@ namespace patchestry::ast {
                     "SIfThenElse has null condition - structuring "
                     "rule produced a branch without a guard expression");
                 auto *cond = EnsureRValue(ctx_, CloneExpr(ctx_, ite->Cond()));
-                // Layer C Stage 3c: arms are std::vector<SNode*>.
-                // Then-arm: required (NullStmt for empty list).
-                // Else-arm: optional (nullptr for empty list = no else
-                // clause; NullStmt would render as `else ;`).
                 auto *then_stmt = EmitBodyList(ite->ThenList());
-                // No else clause when the slot is empty.  Use
-                // ElseBranch() to also handle the defensive
-                // "[nullptr]" case (matches the prior gating which
-                // skipped Emit when ElseBranch() returned null).
+                // Null else_stmt for an empty slot = no else clause
+                // (a NullStmt would render as `else ;`).
                 clang::Stmt *else_stmt = nullptr;
                 if (ite->ElseBranch()) {
                     else_stmt = EmitBodyList(ite->ElseList());
                 }
 
-                // Defensive else-if unwrap: when the else slot already
-                // produces a CompoundStmt around a single IfStmt, the
-                // pretty-printer would emit `else { if(...) }` — pull
-                // the IfStmt out so it renders as `else if (...)`.
-                // With vector storage this branch is hard to hit (size 1
-                // already emits a bare IfStmt), but a multi-element list
-                // that flattens to a single IfStmt via downstream
-                // optimisation could still trigger it.  Cheap to keep.
+                // else-if unwrap: pull a lone IfStmt out of a CompoundStmt
+                // so the printer emits `else if` rather than `else { if }`.
                 if (auto *cs = llvm::dyn_cast_or_null< clang::CompoundStmt >(else_stmt)) {
                     if (cs->size() == 1 && llvm::isa< clang::IfStmt >(cs->body_front()))
                         else_stmt = cs->body_front();
@@ -161,11 +149,8 @@ namespace patchestry::ast {
                 );
             }
 
-            // Layer C Stage 3b helper: render a vector<SNode*> body
-            // into a single clang::Stmt — empty → NullStmt, size 1 →
-            // emit the lone child directly, size > 1 → CompoundStmt.
-            // Loop body slots in WhileStmt/DoStmt/ForStmt require a
-            // single Stmt, so the multi-element case must wrap.
+            // Render a body sequence into a single clang::Stmt: empty →
+            // NullStmt, size 1 → the lone child, size > 1 → CompoundStmt.
             clang::Stmt *EmitBodyList(const std::vector< SNode * > &body_list) {
                 if (body_list.empty())
                     return new (ctx_) clang::NullStmt(Loc());
@@ -229,12 +214,9 @@ namespace patchestry::ast {
                 // Build the switch body as a compound stmt with cases
                 std::vector< clang::Stmt * > body_stmts;
 
-                // Layer C Stage 3d: SCase.body_list and SSwitch.default_
-                // are std::vector<SNode*>.  Empty list = fallthrough stub
-                // (preserves the prior c.body == nullptr behaviour).
-                // Build all child stmts, then optionally append a break
-                // and wrap in CompoundStmt (CaseStmt requires a single
-                // sub-stmt slot).
+                // Build a case/default sub-stmt: empty list = fallthrough
+                // stub; otherwise emit children, append a break if needed,
+                // and wrap in CompoundStmt (the slot takes a single Stmt).
                 auto build_case_substmt = [&](const std::vector< SNode * > &body_list)
                     -> clang::Stmt * {
                     if (body_list.empty()) {
@@ -282,10 +264,8 @@ namespace patchestry::ast {
             clang::Stmt *EmitLabel(const SLabel *l) {
                 auto *label_decl = GetOrCreateLabel(l->Name());
                 emitted_labels_.insert(std::string(l->Name()));
-                // Layer C Stage 3a: SLabel.body_ is std::vector<SNode*>.
-                // Emit each child stmt and wrap in CompoundStmt only when
-                // there's more than one (LabelStmt requires a single
-                // sub-stmt slot).  Empty body → NullStmt.
+                // Emit the body; wrap in CompoundStmt only when there's
+                // more than one child (LabelStmt takes a single Stmt).
                 const auto &body_list = l->BodyList();
                 clang::Stmt *sub = nullptr;
                 if (body_list.empty()) {
@@ -493,9 +473,7 @@ namespace patchestry::ast {
 
 
 
-    // Common DeclStmt-hoisting + setBody finalization.  Used by both
-    // the SNode* and std::vector<SNode*> entry points (Layer C Stage 4
-    // extracted this so the vector overload doesn't need to duplicate it).
+    // Common DeclStmt-hoisting + setBody finalization for EmitClangAST.
     static void FinalizeFunctionBody(clang::Stmt *body,
                                      clang::FunctionDecl *fn,
                                      clang::ASTContext &ctx) {
@@ -550,8 +528,6 @@ namespace patchestry::ast {
 
     void EmitClangAST(const std::vector< SNode * > &root_children,
                       clang::FunctionDecl *fn, clang::ASTContext &ctx) {
-        // Layer C Stage 4: take the function-body slot as a vector
-        // directly so callers no longer need to wrap in an SSeq.
         Emitter emitter(ctx, fn);
         for (auto *c : root_children) emitter.CollectGotoLabelDecls(c);
 
@@ -560,13 +536,6 @@ namespace patchestry::ast {
         for (auto *c : root_children)
             if (auto *s = emitter.Emit(c)) body_stmts.push_back(s);
         FinalizeFunctionBody(detail::MakeCompound(ctx, body_stmts), fn, ctx);
-    }
-
-    void EmitClangAST(SNode *root, clang::FunctionDecl *fn,
-                      clang::ASTContext &ctx) {
-        Emitter emitter(ctx, fn);
-        emitter.CollectGotoLabelDecls(root);
-        FinalizeFunctionBody(emitter.Emit(root), fn, ctx);
     }
 
 } // namespace patchestry::ast

--- a/lib/patchestry/AST/ClangEmitter.cpp
+++ b/lib/patchestry/AST/ClangEmitter.cpp
@@ -91,8 +91,6 @@ namespace patchestry::ast {
                 if (!node) return nullptr;
 
                 switch (node->Kind()) {
-                case SNodeKind::kSeq:
-                    return EmitSeq(node->as< SSeq >());
                 case SNodeKind::kBlock:
                     return EmitBlock(node->as< SBlock >());
                 case SNodeKind::kIfThenElse:
@@ -123,15 +121,6 @@ namespace patchestry::ast {
             // corresponding label definitions. This prevents CIR goto/label mismatch.
           private:
             clang::SourceLocation Loc() const { return loc_; }
-
-            clang::Stmt *EmitSeq(const SSeq *seq) {
-                std::vector< clang::Stmt * > stmts;
-                for (const auto *child : seq->Children()) {
-                    auto *s = Emit(child);
-                    if (s) stmts.push_back(s);
-                }
-                return detail::MakeCompound(ctx_, stmts);
-            }
 
             clang::Stmt *EmitBlock(const SBlock *block) {
                 if (block->Size() == 1) return block->Stmts()[0];
@@ -372,27 +361,9 @@ namespace patchestry::ast {
                     for (auto *s : blk->Stmts()) scan(s);
                     return; // SBlock has no SNode children
                 }
-                if (auto *seq = node->dyn_cast< SSeq >()) {
-                    for (size_t i = 0; i < seq->Size(); ++i)
-                        CollectGotoLabelDecls((*seq)[i]);
-                } else if (auto *ite = node->dyn_cast< SIfThenElse >()) {
-                    CollectGotoLabelDecls(ite->ThenBranch());
-                    CollectGotoLabelDecls(ite->ElseBranch());
-                } else if (auto *sw = node->dyn_cast< SSwitch >()) {
-                    for (auto &c : sw->Cases())
-                        for (auto *b : c.body_list)
-                            CollectGotoLabelDecls(b);
-                    for (auto *b : sw->DefaultBodyList())
-                        CollectGotoLabelDecls(b);
-                } else if (auto *lbl = node->dyn_cast< SLabel >()) {
-                    CollectGotoLabelDecls(lbl->Body());
-                } else if (auto *w = node->dyn_cast< SWhile >()) {
-                    CollectGotoLabelDecls(w->Body());
-                } else if (auto *dw = node->dyn_cast< SDoWhile >()) {
-                    CollectGotoLabelDecls(dw->Body());
-                } else if (auto *f = node->dyn_cast< SFor >()) {
-                    CollectGotoLabelDecls(f->Body());
-                }
+                node->for_each_child([&](SNode *c) {
+                    CollectGotoLabelDecls(c);
+                });
             }
 
             clang::ASTContext &ctx_;

--- a/lib/patchestry/AST/ClangEmitter.cpp
+++ b/lib/patchestry/AST/ClangEmitter.cpp
@@ -91,8 +91,8 @@ namespace patchestry::ast {
                 if (!node) return nullptr;
 
                 switch (node->Kind()) {
-                case SNodeKind::kBlock:
-                    return EmitBlock(node->as< SBlock >());
+                case SNodeKind::kStmt:
+                    return node->as< SStmt >()->Stmt();
                 case SNodeKind::kIfThenElse:
                     return EmitIfThenElse(node->as< SIfThenElse >());
                 case SNodeKind::kWhile:
@@ -121,11 +121,6 @@ namespace patchestry::ast {
             // corresponding label definitions. This prevents CIR goto/label mismatch.
           private:
             clang::SourceLocation Loc() const { return loc_; }
-
-            clang::Stmt *EmitBlock(const SBlock *block) {
-                if (block->Size() == 1) return block->Stmts()[0];
-                return detail::MakeCompound(ctx_, block->Stmts());
-            }
 
             clang::Stmt *EmitIfThenElse(const SIfThenElse *ite) {
                 LOG_FATAL_IF(!ite->Cond(),
@@ -344,22 +339,22 @@ namespace patchestry::ast {
 
           public:
             // Pre-scan: collect LabelDecl objects referenced by GotoStmts
-            // in raw Clang AST (SBlock stmts).  Must be called before Emit().
+            // in raw Clang AST (SStmt stmts).  Must be called before Emit().
             void CollectGotoLabelDecls(SNode *node) {
                 if (!node) return;
-                if (auto *blk = node->dyn_cast< SBlock >()) {
-                    std::function< void(clang::Stmt *) > scan =
-                        [&](clang::Stmt *s) {
-                            if (!s) return;
-                            if (auto *gs = llvm::dyn_cast< clang::GotoStmt >(s)) {
-                                auto *ld = gs->getLabel();
-                                goto_labels_[ld->getName().str()] = ld;
-                                return;
-                            }
-                            for (auto *child : s->children()) scan(child);
-                        };
-                    for (auto *s : blk->Stmts()) scan(s);
-                    return; // SBlock has no SNode children
+                std::function< void(clang::Stmt *) > scan =
+                    [&](clang::Stmt *s) {
+                        if (!s) return;
+                        if (auto *gs = llvm::dyn_cast< clang::GotoStmt >(s)) {
+                            auto *ld = gs->getLabel();
+                            goto_labels_[ld->getName().str()] = ld;
+                            return;
+                        }
+                        for (auto *child : s->children()) scan(child);
+                    };
+                if (auto *st = node->dyn_cast< SStmt >()) {
+                    scan(st->Stmt());
+                    return; // SStmt has no SNode children
                 }
                 node->for_each_child([&](SNode *c) {
                     CollectGotoLabelDecls(c);

--- a/lib/patchestry/AST/ClangEmitter.cpp
+++ b/lib/patchestry/AST/ClangEmitter.cpp
@@ -143,13 +143,28 @@ namespace patchestry::ast {
                     "SIfThenElse has null condition - structuring "
                     "rule produced a branch without a guard expression");
                 auto *cond = EnsureRValue(ctx_, CloneExpr(ctx_, ite->Cond()));
-                auto *then_stmt = Emit(ite->ThenBranch());
-                auto *else_stmt = ite->ElseBranch() ? Emit(ite->ElseBranch()) : nullptr;
+                // Layer C Stage 3c: arms are std::vector<SNode*>.
+                // Then-arm: required (NullStmt for empty list).
+                // Else-arm: optional (nullptr for empty list = no else
+                // clause; NullStmt would render as `else ;`).
+                auto *then_stmt = EmitBodyList(ite->ThenList());
+                // No else clause when the slot is empty.  Use
+                // ElseBranch() to also handle the defensive
+                // "[nullptr]" case (matches the prior gating which
+                // skipped Emit when ElseBranch() returned null).
+                clang::Stmt *else_stmt = nullptr;
+                if (ite->ElseBranch()) {
+                    else_stmt = EmitBodyList(ite->ElseList());
+                }
 
-                if (!then_stmt) then_stmt = new (ctx_) clang::NullStmt(Loc());
-
-                // Unwrap CompoundStmt around a single IfStmt in the else
-                // branch so Clang's printer emits "else if" not "else { if".
+                // Defensive else-if unwrap: when the else slot already
+                // produces a CompoundStmt around a single IfStmt, the
+                // pretty-printer would emit `else { if(...) }` — pull
+                // the IfStmt out so it renders as `else if (...)`.
+                // With vector storage this branch is hard to hit (size 1
+                // already emits a bare IfStmt), but a multi-element list
+                // that flattens to a single IfStmt via downstream
+                // optimisation could still trigger it.  Cheap to keep.
                 if (auto *cs = llvm::dyn_cast_or_null< clang::CompoundStmt >(else_stmt)) {
                     if (cs->size() == 1 && llvm::isa< clang::IfStmt >(cs->body_front()))
                         else_stmt = cs->body_front();
@@ -162,6 +177,25 @@ namespace patchestry::ast {
                 );
             }
 
+            // Layer C Stage 3b helper: render a vector<SNode*> body
+            // into a single clang::Stmt — empty → NullStmt, size 1 →
+            // emit the lone child directly, size > 1 → CompoundStmt.
+            // Loop body slots in WhileStmt/DoStmt/ForStmt require a
+            // single Stmt, so the multi-element case must wrap.
+            clang::Stmt *EmitBodyList(const std::vector< SNode * > &body_list) {
+                if (body_list.empty())
+                    return new (ctx_) clang::NullStmt(Loc());
+                if (body_list.size() == 1) {
+                    auto *s = Emit(body_list[0]);
+                    return s ? s : new (ctx_) clang::NullStmt(Loc());
+                }
+                std::vector< clang::Stmt * > stmts;
+                stmts.reserve(body_list.size());
+                for (const auto *c : body_list)
+                    if (auto *s = Emit(c)) stmts.push_back(s);
+                return detail::MakeCompound(ctx_, stmts);
+            }
+
             clang::Stmt *EmitWhile(const SWhile *w) {
                 clang::Expr *cond = nullptr;
                 if (w->Cond()) {
@@ -171,8 +205,7 @@ namespace patchestry::ast {
                     cond = clang::IntegerLiteral::Create(
                         ctx_, llvm::APInt(32, 1), ctx_.IntTy, Loc());
                 }
-                auto *body = Emit(w->Body());
-                if (!body) body = new (ctx_) clang::NullStmt(Loc());
+                auto *body = EmitBodyList(w->BodyList());
 
                 return clang::WhileStmt::Create(
                     ctx_, nullptr, cond, body, Loc(), Loc(), Loc()
@@ -180,8 +213,7 @@ namespace patchestry::ast {
             }
 
             clang::Stmt *EmitDoWhile(const SDoWhile *dw) {
-                auto *body = Emit(dw->Body());
-                if (!body) body = new (ctx_) clang::NullStmt(Loc());
+                auto *body = EmitBodyList(dw->BodyList());
                 clang::Expr *cond = nullptr;
                 if (dw->Cond()) {
                     cond = EnsureRValue(ctx_, CloneExpr(ctx_, dw->Cond()));
@@ -195,8 +227,7 @@ namespace patchestry::ast {
             }
 
             clang::Stmt *EmitFor(const SFor *f) {
-                auto *body = Emit(f->Body());
-                if (!body) body = new (ctx_) clang::NullStmt(Loc());
+                auto *body = EmitBodyList(f->BodyList());
 
                 return new (ctx_) clang::ForStmt(
                     ctx_, f->Init(),
@@ -214,44 +245,42 @@ namespace patchestry::ast {
                 // Build the switch body as a compound stmt with cases
                 std::vector< clang::Stmt * > body_stmts;
 
+                // Layer C Stage 3d: SCase.body_list and SSwitch.default_
+                // are std::vector<SNode*>.  Empty list = fallthrough stub
+                // (preserves the prior c.body == nullptr behaviour).
+                // Build all child stmts, then optionally append a break
+                // and wrap in CompoundStmt (CaseStmt requires a single
+                // sub-stmt slot).
+                auto build_case_substmt = [&](const std::vector< SNode * > &body_list)
+                    -> clang::Stmt * {
+                    if (body_list.empty()) {
+                        // Fallthrough stub.
+                        return new (ctx_) clang::NullStmt(Loc());
+                    }
+                    std::vector< clang::Stmt * > stmts;
+                    stmts.reserve(body_list.size() + 1);
+                    for (const auto *child : body_list)
+                        if (auto *s = Emit(child)) stmts.push_back(s);
+                    if (stmts.empty())
+                        stmts.push_back(new (ctx_) clang::NullStmt(Loc()));
+                    if (!detail::EndsWithTerminator(stmts.back()))
+                        stmts.push_back(new (ctx_) clang::BreakStmt(Loc()));
+                    return detail::MakeCompound(ctx_, stmts);
+                };
+
                 for (const auto &c : sw->Cases()) {
                     auto *case_stmt = clang::CaseStmt::Create(
                         ctx_, c.value, nullptr, Loc(), Loc(), Loc()
                     );
-
-                    if (c.body == nullptr) {
-                        // Fallthrough stub: case N: (no body, falls into next case)
-                        case_stmt->setSubStmt(new (ctx_) clang::NullStmt(Loc()));
-                    } else {
-                        clang::Stmt *case_body = Emit(c.body);
-                        if (!case_body) {
-                            case_body = new (ctx_) clang::NullStmt(Loc());
-                        }
-
-                        std::vector< clang::Stmt * > case_stmts = { case_body };
-                        if (!detail::EndsWithTerminator(case_body)) {
-                            case_stmts.push_back(new (ctx_) clang::BreakStmt(Loc()));
-                        }
-                        case_stmt->setSubStmt(detail::MakeCompound(ctx_, case_stmts));
-                    }
-
+                    case_stmt->setSubStmt(build_case_substmt(c.body_list));
                     body_stmts.push_back(case_stmt);
                     switch_stmt->addSwitchCase(case_stmt);
                 }
 
-                if (sw->DefaultBody()) {
-                    clang::Stmt *def_body = Emit(sw->DefaultBody());
-                    if (!def_body) {
-                        def_body = new (ctx_) clang::NullStmt(Loc());
-                    }
-
-                    std::vector< clang::Stmt * > def_stmts = { def_body };
-                    if (!detail::EndsWithTerminator(def_body)) {
-                        def_stmts.push_back(new (ctx_) clang::BreakStmt(Loc()));
-                    }
-
-                    auto *def_stmt = new (ctx_)
-                        clang::DefaultStmt(Loc(), Loc(), detail::MakeCompound(ctx_, def_stmts));
+                if (!sw->DefaultBodyList().empty()) {
+                    auto *def_stmt = new (ctx_) clang::DefaultStmt(
+                        Loc(), Loc(),
+                        build_case_substmt(sw->DefaultBodyList()));
                     body_stmts.push_back(def_stmt);
                     switch_stmt->addSwitchCase(def_stmt);
                 }
@@ -269,7 +298,24 @@ namespace patchestry::ast {
             clang::Stmt *EmitLabel(const SLabel *l) {
                 auto *label_decl = GetOrCreateLabel(l->Name());
                 emitted_labels_.insert(std::string(l->Name()));
-                auto *sub = l->Body() ? Emit(l->Body()) : new (ctx_) clang::NullStmt(Loc());
+                // Layer C Stage 3a: SLabel.body_ is std::vector<SNode*>.
+                // Emit each child stmt and wrap in CompoundStmt only when
+                // there's more than one (LabelStmt requires a single
+                // sub-stmt slot).  Empty body → NullStmt.
+                const auto &body_list = l->BodyList();
+                clang::Stmt *sub = nullptr;
+                if (body_list.empty()) {
+                    sub = new (ctx_) clang::NullStmt(Loc());
+                } else if (body_list.size() == 1) {
+                    sub = Emit(body_list[0]);
+                    if (!sub) sub = new (ctx_) clang::NullStmt(Loc());
+                } else {
+                    std::vector< clang::Stmt * > stmts;
+                    stmts.reserve(body_list.size());
+                    for (const auto *c : body_list)
+                        if (auto *s = Emit(c)) stmts.push_back(s);
+                    sub = detail::MakeCompound(ctx_, stmts);
+                }
                 return new (ctx_) clang::LabelStmt(Loc(), label_decl, sub);
             }
 
@@ -334,8 +380,10 @@ namespace patchestry::ast {
                     CollectGotoLabelDecls(ite->ElseBranch());
                 } else if (auto *sw = node->dyn_cast< SSwitch >()) {
                     for (auto &c : sw->Cases())
-                        CollectGotoLabelDecls(c.body);
-                    CollectGotoLabelDecls(sw->DefaultBody());
+                        for (auto *b : c.body_list)
+                            CollectGotoLabelDecls(b);
+                    for (auto *b : sw->DefaultBodyList())
+                        CollectGotoLabelDecls(b);
                 } else if (auto *lbl = node->dyn_cast< SLabel >()) {
                     CollectGotoLabelDecls(lbl->Body());
                 } else if (auto *w = node->dyn_cast< SWhile >()) {
@@ -479,16 +527,13 @@ namespace patchestry::ast {
 
 
 
-    void EmitClangAST(SNode *root, clang::FunctionDecl *fn,
-                      clang::ASTContext &ctx) {
-        Emitter emitter(ctx, fn);
-        // Pre-scan: collect LabelDecl objects from raw Clang GotoStmts
-        // so EmitLabel can reuse the same objects (pointer identity match).
-        emitter.CollectGotoLabelDecls(root);
-        auto *body = emitter.Emit(root);
-        if (!body) {
-            body = detail::MakeCompound(ctx, {});
-        }
+    // Common DeclStmt-hoisting + setBody finalization.  Used by both
+    // the SNode* and std::vector<SNode*> entry points (Layer C Stage 4
+    // extracted this so the vector overload doesn't need to duplicate it).
+    static void FinalizeFunctionBody(clang::Stmt *body,
+                                     clang::FunctionDecl *fn,
+                                     clang::ASTContext &ctx) {
+        if (!body) body = detail::MakeCompound(ctx, {});
 
         // Phase 1: Hoist all existing DeclStmts to the top of the function.
         std::vector< clang::Stmt * > decl_stmts;
@@ -505,37 +550,28 @@ namespace patchestry::ast {
         }
 
         // Phase 2: Synthesize DeclStmts for any VarDecls referenced but not
-        // declared in the body. Unreachable blocks may be dropped during graph
-        // construction while retaining blocks that reference those vars.
-        // CIR crashes with "DeclRefExpr for decl not entered in LocalDeclMap"
-        // when it encounters a reference to an undeclared variable.
+        // declared in the body.  CIR crashes on undeclared local var refs.
         {
             std::unordered_set< clang::VarDecl * > referenced, declared;
             std::unordered_set< clang::Stmt * > seen1, seen2;
             CollectReferencedVars(body, referenced, seen1);
             CollectDeclaredVars(body, declared, seen2);
-            // Also count vars from hoisted DeclStmts
             for (auto *ds : decl_stmts) {
                 std::unordered_set< clang::Stmt * > seen3;
                 CollectDeclaredVars(ds, declared, seen3);
             }
-
             for (auto *vd : referenced) {
                 if (declared.count(vd)) continue;
-                // Skip function parameters — they're already in CIR's map
                 if (llvm::isa< clang::ParmVarDecl >(vd)) continue;
-                // Skip file-scope / extern globals — CIR asserts isLocalVarDecl()
                 if (!vd->isLocalVarDecl()) continue;
-                // Synthesize a DeclStmt for this missing variable
                 auto loc = VirtualLoc(ctx);
                 auto *ds = new (ctx) clang::DeclStmt(
-                    clang::DeclGroupRef(vd), loc, loc
-                );
+                    clang::DeclGroupRef(vd), loc, loc);
                 decl_stmts.push_back(ds);
             }
         }
 
-        // Build final body: hoisted decls + control flow
+        // Build final body: hoisted decls + control flow.
         std::vector< clang::Stmt * > all_stmts;
         all_stmts.insert(all_stmts.end(), decl_stmts.begin(), decl_stmts.end());
         if (auto *cs = llvm::dyn_cast_or_null< clang::CompoundStmt >(body)) {
@@ -543,10 +579,28 @@ namespace patchestry::ast {
         } else if (body) {
             all_stmts.push_back(body);
         }
-        body = detail::MakeCompound(ctx, all_stmts);
-
-        fn->setBody(body);
+        fn->setBody(detail::MakeCompound(ctx, all_stmts));
     }
 
+    void EmitClangAST(const std::vector< SNode * > &root_children,
+                      clang::FunctionDecl *fn, clang::ASTContext &ctx) {
+        // Layer C Stage 4: take the function-body slot as a vector
+        // directly so callers no longer need to wrap in an SSeq.
+        Emitter emitter(ctx, fn);
+        for (auto *c : root_children) emitter.CollectGotoLabelDecls(c);
+
+        std::vector< clang::Stmt * > body_stmts;
+        body_stmts.reserve(root_children.size());
+        for (auto *c : root_children)
+            if (auto *s = emitter.Emit(c)) body_stmts.push_back(s);
+        FinalizeFunctionBody(detail::MakeCompound(ctx, body_stmts), fn, ctx);
+    }
+
+    void EmitClangAST(SNode *root, clang::FunctionDecl *fn,
+                      clang::ASTContext &ctx) {
+        Emitter emitter(ctx, fn);
+        emitter.CollectGotoLabelDecls(root);
+        FinalizeFunctionBody(emitter.Emit(root), fn, ctx);
+    }
 
 } // namespace patchestry::ast

--- a/lib/patchestry/AST/ClangEmitter.cpp
+++ b/lib/patchestry/AST/ClangEmitter.cpp
@@ -131,7 +131,7 @@ namespace patchestry::ast {
                 // Null else_stmt for an empty slot = no else clause
                 // (a NullStmt would render as `else ;`).
                 clang::Stmt *else_stmt = nullptr;
-                if (ite->ElseBranch()) {
+                if (!ite->ElseList().empty()) {
                     else_stmt = EmitBodyList(ite->ElseList());
                 }
 

--- a/lib/patchestry/AST/SNode.cpp
+++ b/lib/patchestry/AST/SNode.cpp
@@ -57,33 +57,33 @@ namespace patchestry::ast {
     void SIfThenElse::DumpChildren(llvm::raw_ostream &os, unsigned indent) const {
         PrintIndent(os, indent + 1);
         os << "cond: <expr>\n";
-        if (then_) {
+        if (!then_.empty()) {
             PrintIndent(os, indent + 1);
             os << "then:\n";
-            then_->Dump(os, indent + 2);
+            for (const auto *c : then_) if (c) c->Dump(os, indent + 2);
         }
-        if (else_) {
+        if (!else_.empty()) {
             PrintIndent(os, indent + 1);
             os << "else:\n";
-            else_->Dump(os, indent + 2);
+            for (const auto *c : else_) if (c) c->Dump(os, indent + 2);
         }
     }
 
     void SWhile::DumpChildren(llvm::raw_ostream &os, unsigned indent) const {
         PrintIndent(os, indent + 1);
         os << "cond: <expr>\n";
-        if (body_) {
+        if (!body_.empty()) {
             PrintIndent(os, indent + 1);
             os << "body:\n";
-            body_->Dump(os, indent + 2);
+            for (const auto *c : body_) if (c) c->Dump(os, indent + 2);
         }
     }
 
     void SDoWhile::DumpChildren(llvm::raw_ostream &os, unsigned indent) const {
-        if (body_) {
+        if (!body_.empty()) {
             PrintIndent(os, indent + 1);
             os << "body:\n";
-            body_->Dump(os, indent + 2);
+            for (const auto *c : body_) if (c) c->Dump(os, indent + 2);
         }
         PrintIndent(os, indent + 1);
         os << "cond: <expr>\n";
@@ -96,10 +96,10 @@ namespace patchestry::ast {
         os << "cond: " << (cond_ ? "<expr>" : "null") << "\n";
         PrintIndent(os, indent + 1);
         os << "inc: " << (inc_ ? "<expr>" : "null") << "\n";
-        if (body_) {
+        if (!body_.empty()) {
             PrintIndent(os, indent + 1);
             os << "body:\n";
-            body_->Dump(os, indent + 2);
+            for (const auto *c : body_) if (c) c->Dump(os, indent + 2);
         }
     }
 
@@ -109,23 +109,20 @@ namespace patchestry::ast {
         for (size_t i = 0; i < cases_.size(); ++i) {
             PrintIndent(os, indent + 1);
             os << "case " << i << ":\n";
-            if (cases_[i].body) {
-                cases_[i].body->Dump(os, indent + 2);
-            }
+            for (const auto *c : cases_[i].body_list)
+                if (c) c->Dump(os, indent + 2);
         }
-        if (default_) {
+        if (!default_.empty()) {
             PrintIndent(os, indent + 1);
             os << "default:\n";
-            default_->Dump(os, indent + 2);
+            for (const auto *c : default_) if (c) c->Dump(os, indent + 2);
         }
     }
 
     void SLabel::DumpChildren(llvm::raw_ostream &os, unsigned indent) const {
         PrintIndent(os, indent + 1);
         os << "name: " << name_ << "\n";
-        if (body_) {
-            body_->Dump(os, indent + 1);
-        }
+        for (const auto *c : body_) if (c) c->Dump(os, indent + 1);
     }
 
     // ---------------------------------------------------------------

--- a/lib/patchestry/AST/SNode.cpp
+++ b/lib/patchestry/AST/SNode.cpp
@@ -13,7 +13,7 @@ namespace patchestry::ast {
 
     const char *SNode::KindName(SNodeKind k) {
         switch (k) {
-            case SNodeKind::kBlock:       return "Block";
+            case SNodeKind::kStmt:        return "Stmt";
             case SNodeKind::kIfThenElse:return "IfThenElse";
             case SNodeKind::kWhile:       return "While";
             case SNodeKind::kDoWhile:    return "DoWhile";
@@ -38,13 +38,9 @@ namespace patchestry::ast {
         DumpChildren(os, indent);
     }
 
-    void SBlock::DumpChildren(llvm::raw_ostream &os, unsigned indent) const {
-        if (!label_.empty()) {
-            PrintIndent(os, indent + 1);
-            os << "label: " << label_ << "\n";
-        }
+    void SStmt::DumpChildren(llvm::raw_ostream &os, unsigned indent) const {
         PrintIndent(os, indent + 1);
-        os << "stmts: " << stmts_.size() << "\n";
+        os << "stmt: " << (stmt_ ? "<stmt>" : "null") << "\n";
     }
 
     void SIfThenElse::DumpChildren(llvm::raw_ostream &os, unsigned indent) const {
@@ -125,12 +121,6 @@ namespace patchestry::ast {
     // std::vector<SNode*>.  MakeSeq drops nullptr children and returns
     // the resulting vector; callers store it directly into a body
     // slot, into CNode::structured, or pass it to IdentifyInternal.
-    //
-    // NOTE: empty unlabeled SBlocks are intentionally PRESERVED — they
-    // correspond to CFG nodes with no statements and downstream cleanup
-    // uses sibling position to reason about fallthrough vs goto.  The
-    // cosmetic `{ }` artifact in the emitted C is handled by
-    // RemoveEmptyBlocks at the Clang-AST level.
     // ---------------------------------------------------------------
     std::vector< SNode * > SNodeFactory::MakeSeq(std::vector< SNode * > children) {
         std::vector< SNode * > out;

--- a/lib/patchestry/AST/SNode.cpp
+++ b/lib/patchestry/AST/SNode.cpp
@@ -128,4 +128,64 @@ namespace patchestry::ast {
         }
     }
 
+    // ---------------------------------------------------------------
+    // SNodeFactory::MakeSeq — Layer C migration Stage 0
+    //
+    // Normalizes children before constructing an SSeq.  See header
+    // for rules.  Out-of-line so we can inspect SSeq's internals
+    // without forcing a chain of inline includes.
+    //
+    // NOTE: Empty unlabeled SBlocks are intentionally PRESERVED here.
+    // They are topologically meaningful — they correspond to CFG nodes
+    // with no statements, and downstream cleanup passes use sibling
+    // position to reason about fallthrough vs goto.  Dropping them at
+    // construction was tried in an earlier draft of Stage 1 and broke
+    // 4 fixtures (cwe121_eeprom_handler_write DUP_ASSIGN +
+    // decode_frame / load_descriptor_values / pb_decode_inner Fall=N)
+    // by promoting goto-only labels to sequential successors.  The
+    // cosmetic `{ }` artifact in the emitted C is handled by
+    // RemoveEmptyBlocks at the Clang-AST level, which understands
+    // topology because it operates after IR materialization.
+    // ---------------------------------------------------------------
+    SNode *SNodeFactory::MakeSeq(std::vector< SNode * > children) {
+        // Conservative normalization for Stage 1:
+        //   - Drop nullptr children.
+        //   - If size 0 → return nullptr (caller decides substitute).
+        //   - If size 1 → return the single child directly (no wrap).
+        //   - Otherwise → allocate an SSeq and AddChild each.
+        //
+        // Two more aggressive normalizations were tried and reverted:
+        //
+        //   * Dropping empty unlabeled SBlock children — broke 4 fixtures
+        //     (cwe121_eeprom_handler_write DUP_ASSIGN +
+        //      decode_frame / load_descriptor_values / pb_decode_inner Fall=N)
+        //     by promoting goto-only labels to sequential successors.
+        //     Empty SBlocks correspond to CFG nodes with no statements
+        //     and downstream cleanup uses sibling distance to reason
+        //     about fallthrough vs goto.
+        //
+        //   * Flattening nested SSeq inline — also broke the same 4
+        //     fixtures.  Flattening exposed label adjacency that
+        //     downstream EliminateGotoToNextLabel / IfStmtGotoArm
+        //     elision logic mis-handles when the label has live
+        //     non-goto predecessors.  The aggressive goto reduction it
+        //     delivered (cve_2016_6563 38→6) is real but requires a
+        //     separate fix to the elision predecessor-set check before
+        //     it can be enabled safely.
+        //
+        // Both deferrals keep Stage 1 semantics-preserving so the SSeq
+        // → vector-slot migration can land without entangling policy
+        // fixes with the structural refactor.
+        std::vector< SNode * > out;
+        out.reserve(children.size());
+        for (SNode *c : children) {
+            if (c) out.push_back(c);
+        }
+        if (out.empty()) return nullptr;
+        if (out.size() == 1) return out[0];
+        auto *seq = Make< SSeq >();
+        for (auto *c : out) seq->AddChild(c);
+        return seq;
+    }
+
 } // namespace patchestry::ast

--- a/lib/patchestry/AST/SNode.cpp
+++ b/lib/patchestry/AST/SNode.cpp
@@ -114,14 +114,7 @@ namespace patchestry::ast {
         for (const auto *c : body_) if (c) c->Dump(os, indent + 1);
     }
 
-    // ---------------------------------------------------------------
-    // SNodeFactory::MakeSeq — normalize a child sequence.
-    //
-    // Since the SSeq node kind was removed, a "sequence" is just a
-    // std::vector<SNode*>.  MakeSeq drops nullptr children and returns
-    // the resulting vector; callers store it directly into a body
-    // slot, into CNode::structured, or pass it to IdentifyInternal.
-    // ---------------------------------------------------------------
+    // Normalize a child sequence: drop nullptr children.
     std::vector< SNode * > SNodeFactory::MakeSeq(std::vector< SNode * > children) {
         std::vector< SNode * > out;
         out.reserve(children.size());

--- a/lib/patchestry/AST/SNode.cpp
+++ b/lib/patchestry/AST/SNode.cpp
@@ -13,7 +13,6 @@ namespace patchestry::ast {
 
     const char *SNode::KindName(SNodeKind k) {
         switch (k) {
-            case SNodeKind::kSeq:         return "Seq";
             case SNodeKind::kBlock:       return "Block";
             case SNodeKind::kIfThenElse:return "IfThenElse";
             case SNodeKind::kWhile:       return "While";
@@ -37,12 +36,6 @@ namespace patchestry::ast {
         PrintIndent(os, indent);
         os << KindName() << "\n";
         DumpChildren(os, indent);
-    }
-
-    void SSeq::DumpChildren(llvm::raw_ostream &os, unsigned indent) const {
-        for (const auto *child : children_) {
-            child->Dump(os, indent + 1);
-        }
     }
 
     void SBlock::DumpChildren(llvm::raw_ostream &os, unsigned indent) const {
@@ -126,63 +119,26 @@ namespace patchestry::ast {
     }
 
     // ---------------------------------------------------------------
-    // SNodeFactory::MakeSeq — Layer C migration Stage 0
+    // SNodeFactory::MakeSeq — normalize a child sequence.
     //
-    // Normalizes children before constructing an SSeq.  See header
-    // for rules.  Out-of-line so we can inspect SSeq's internals
-    // without forcing a chain of inline includes.
+    // Since the SSeq node kind was removed, a "sequence" is just a
+    // std::vector<SNode*>.  MakeSeq drops nullptr children and returns
+    // the resulting vector; callers store it directly into a body
+    // slot, into CNode::structured, or pass it to IdentifyInternal.
     //
-    // NOTE: Empty unlabeled SBlocks are intentionally PRESERVED here.
-    // They are topologically meaningful — they correspond to CFG nodes
-    // with no statements, and downstream cleanup passes use sibling
-    // position to reason about fallthrough vs goto.  Dropping them at
-    // construction was tried in an earlier draft of Stage 1 and broke
-    // 4 fixtures (cwe121_eeprom_handler_write DUP_ASSIGN +
-    // decode_frame / load_descriptor_values / pb_decode_inner Fall=N)
-    // by promoting goto-only labels to sequential successors.  The
+    // NOTE: empty unlabeled SBlocks are intentionally PRESERVED — they
+    // correspond to CFG nodes with no statements and downstream cleanup
+    // uses sibling position to reason about fallthrough vs goto.  The
     // cosmetic `{ }` artifact in the emitted C is handled by
-    // RemoveEmptyBlocks at the Clang-AST level, which understands
-    // topology because it operates after IR materialization.
+    // RemoveEmptyBlocks at the Clang-AST level.
     // ---------------------------------------------------------------
-    SNode *SNodeFactory::MakeSeq(std::vector< SNode * > children) {
-        // Conservative normalization for Stage 1:
-        //   - Drop nullptr children.
-        //   - If size 0 → return nullptr (caller decides substitute).
-        //   - If size 1 → return the single child directly (no wrap).
-        //   - Otherwise → allocate an SSeq and AddChild each.
-        //
-        // Two more aggressive normalizations were tried and reverted:
-        //
-        //   * Dropping empty unlabeled SBlock children — broke 4 fixtures
-        //     (cwe121_eeprom_handler_write DUP_ASSIGN +
-        //      decode_frame / load_descriptor_values / pb_decode_inner Fall=N)
-        //     by promoting goto-only labels to sequential successors.
-        //     Empty SBlocks correspond to CFG nodes with no statements
-        //     and downstream cleanup uses sibling distance to reason
-        //     about fallthrough vs goto.
-        //
-        //   * Flattening nested SSeq inline — also broke the same 4
-        //     fixtures.  Flattening exposed label adjacency that
-        //     downstream EliminateGotoToNextLabel / IfStmtGotoArm
-        //     elision logic mis-handles when the label has live
-        //     non-goto predecessors.  The aggressive goto reduction it
-        //     delivered (cve_2016_6563 38→6) is real but requires a
-        //     separate fix to the elision predecessor-set check before
-        //     it can be enabled safely.
-        //
-        // Both deferrals keep Stage 1 semantics-preserving so the SSeq
-        // → vector-slot migration can land without entangling policy
-        // fixes with the structural refactor.
+    std::vector< SNode * > SNodeFactory::MakeSeq(std::vector< SNode * > children) {
         std::vector< SNode * > out;
         out.reserve(children.size());
         for (SNode *c : children) {
             if (c) out.push_back(c);
         }
-        if (out.empty()) return nullptr;
-        if (out.size() == 1) return out[0];
-        auto *seq = Make< SSeq >();
-        for (auto *c : out) seq->AddChild(c);
-        return seq;
+        return out;
     }
 
 } // namespace patchestry::ast

--- a/lib/patchestry/AST/SNodeDebug.cpp
+++ b/lib/patchestry/AST/SNodeDebug.cpp
@@ -24,9 +24,8 @@ namespace patchestry::ast {
                     os << "\\n" << lbl->Name();
                 } else if (auto *g = node->dyn_cast< SGoto >()) {
                     os << "\\n-> " << g->Target();
-                } else if (auto *blk = node->dyn_cast< SBlock >()) {
-                    os << "\\n(" << blk->Size() << " stmts)";
-                    if (!blk->Label().empty()) os << "\\nlabel: " << blk->Label();
+                } else if (node->dyn_cast< SStmt >()) {
+                    os << "\\n(stmt)";
                 }
 
                 os << "\"];\n";

--- a/lib/patchestry/AST/SNodeDebug.cpp
+++ b/lib/patchestry/AST/SNodeDebug.cpp
@@ -30,67 +30,51 @@ namespace patchestry::ast {
 
                 os << "\"];\n";
 
+                // Emit one edge per child for a body slot.  Body vectors
+                // may hold many siblings, not just the first — the
+                // single-body Body()/ThenBranch() accessors would drop
+                // everything after the first child.
+                auto emit_list = [&](const std::vector< SNode * > &list,
+                                     const std::string &edge) {
+                    for (const auto *c : list) {
+                        if (!c) continue;
+                        unsigned cid = Emit(c);
+                        os << "  n" << id << " -> n" << cid;
+                        if (!edge.empty()) {
+                            os << " [label=\"" << edge << "\"]";
+                        }
+                        os << ";\n";
+                    }
+                };
+
                 switch (node->Kind()) {
                 case SNodeKind::kIfThenElse: {
                     auto *ite = node->as< SIfThenElse >();
-                    if (ite->ThenBranch()) {
-                        unsigned tid = Emit(ite->ThenBranch());
-                        os << "  n" << id << " -> n" << tid << " [label=\"then\"];\n";
-                    }
-                    if (ite->ElseBranch()) {
-                        unsigned eid = Emit(ite->ElseBranch());
-                        os << "  n" << id << " -> n" << eid << " [label=\"else\"];\n";
-                    }
+                    emit_list(ite->ThenList(), "then");
+                    emit_list(ite->ElseList(), "else");
                     break;
                 }
-                case SNodeKind::kWhile: {
-                    auto *w = node->as< SWhile >();
-                    if (w->Body()) {
-                        unsigned bid = Emit(w->Body());
-                        os << "  n" << id << " -> n" << bid << " [label=\"body\"];\n";
-                    }
+                case SNodeKind::kWhile:
+                    emit_list(node->as< SWhile >()->BodyList(), "body");
                     break;
-                }
-                case SNodeKind::kDoWhile: {
-                    auto *dw = node->as< SDoWhile >();
-                    if (dw->Body()) {
-                        unsigned bid = Emit(dw->Body());
-                        os << "  n" << id << " -> n" << bid << " [label=\"body\"];\n";
-                    }
+                case SNodeKind::kDoWhile:
+                    emit_list(node->as< SDoWhile >()->BodyList(), "body");
                     break;
-                }
-                case SNodeKind::kFor: {
-                    auto *f = node->as< SFor >();
-                    if (f->Body()) {
-                        unsigned bid = Emit(f->Body());
-                        os << "  n" << id << " -> n" << bid << " [label=\"body\"];\n";
-                    }
+                case SNodeKind::kFor:
+                    emit_list(node->as< SFor >()->BodyList(), "body");
                     break;
-                }
                 case SNodeKind::kSwitch: {
                     auto *sw = node->as< SSwitch >();
                     for (size_t i = 0; i < sw->Cases().size(); ++i) {
-                        if (auto *b = sw->Cases()[i].body()) {
-                            unsigned cid = Emit(b);
-                            os << "  n" << id << " -> n" << cid
-                               << " [label=\"case " << i << "\"];\n";
-                        }
+                        emit_list(sw->Cases()[i].body_list,
+                                  "case " + std::to_string(i));
                     }
-                    if (sw->DefaultBody()) {
-                        unsigned did = Emit(sw->DefaultBody());
-                        os << "  n" << id << " -> n" << did
-                           << " [label=\"default\"];\n";
-                    }
+                    emit_list(sw->DefaultBodyList(), "default");
                     break;
                 }
-                case SNodeKind::kLabel: {
-                    auto *lbl = node->as< SLabel >();
-                    if (lbl->Body()) {
-                        unsigned bid = Emit(lbl->Body());
-                        os << "  n" << id << " -> n" << bid << ";\n";
-                    }
+                case SNodeKind::kLabel:
+                    emit_list(node->as< SLabel >()->BodyList(), "");
                     break;
-                }
                 default:
                     break;
                 }

--- a/lib/patchestry/AST/SNodeDebug.cpp
+++ b/lib/patchestry/AST/SNodeDebug.cpp
@@ -32,14 +32,6 @@ namespace patchestry::ast {
                 os << "\"];\n";
 
                 switch (node->Kind()) {
-                case SNodeKind::kSeq: {
-                    auto *seq = node->as< SSeq >();
-                    for (const auto *child : seq->Children()) {
-                        unsigned cid = Emit(child);
-                        os << "  n" << id << " -> n" << cid << ";\n";
-                    }
-                    break;
-                }
                 case SNodeKind::kIfThenElse: {
                     auto *ite = node->as< SIfThenElse >();
                     if (ite->ThenBranch()) {

--- a/lib/patchestry/AST/SNodeDebug.cpp
+++ b/lib/patchestry/AST/SNodeDebug.cpp
@@ -79,8 +79,8 @@ namespace patchestry::ast {
                 case SNodeKind::kSwitch: {
                     auto *sw = node->as< SSwitch >();
                     for (size_t i = 0; i < sw->Cases().size(); ++i) {
-                        if (sw->Cases()[i].body) {
-                            unsigned cid = Emit(sw->Cases()[i].body);
+                        if (auto *b = sw->Cases()[i].body()) {
+                            unsigned cid = Emit(b);
                             os << "  n" << id << " -> n" << cid
                                << " [label=\"case " << i << "\"];\n";
                         }


### PR DESCRIPTION
This pull request refactors the structured AST (SNode) representation by removing the SSeq and SBlock node types and replacing them with a simpler vector-based structure. Control-flow nodes now store their bodies as std::vector<SNode*>, and a new SStmt node type represents individual statements.

The refactor also updates:

* CFG structure helpers and transformation APIs,
* CGraph structured-node storage,
* Clang emission entry points,
* and recursive traversal utilities through a uniform child visitation API.

These changes simplify AST construction and traversal, reduce special-case sequence handling, and provide a more flexible foundation for future control-flow transformations and cleanup passes.