### PR TITLE
ci: add Beaver daily Slack summary workflow

### DIFF
--- a/.github/workflows/beaver.yml
+++ b/.github/workflows/beaver.yml
@@ -1,0 +1,25 @@
+name: Daily GitHub Summary
+
+# Beaver — https://github.com/trailofbits/github-slack-summary
+# Posts a daily activity digest (default-branch commits, PRs, issues from the
+# last 24h) to Slack as one parent message plus threaded replies. If nothing
+# changed in the window, nothing is posted.
+
+on:
+  schedule:
+    - cron: "0 14 * * *"  # Every day at 14:00 UTC (9 AM ET / 3 PM CET).
+  workflow_dispatch:      # Manual trigger for testing; safe to remove later.
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  post-summary:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: trailofbits/github-slack-summary@v1
+        with:
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack-channel-id: C06SUT88X0E


### PR DESCRIPTION
## What

Adds [`trailofbits/github-slack-summary`](https://github.com/trailofbits/github-slack-summary) ("Beaver") as a scheduled GitHub Action. Once a day it walks the last 24 h of activity on `main` and posts a single threaded digest to Slack — one parent message with totals, one thread reply per category (commits, PRs, issues). If nothing happened, nothing is posted.

This replaces the per-event firehose the `/github` Slack integration produces when several active repos share a channel.

## Configuration baked into the workflow

| Knob | Value |
|---|---|
| Schedule | `0 14 * * *` (14:00 UTC = 9 AM ET / 3 PM CET) |
| Target channel | `C0XXXXXXXXX` |
| `slack-bot-token` | `${{ secrets.SLACK_BOT_TOKEN }}` (already set on this repo) |
| `lookback-hours` | default (24h) |
| Permissions | `contents: read`, `pull-requests: read`, `issues: read` |
| `workflow_dispatch` | enabled, so the first run can be triggered manually for verification |

The action uses the workflow's built-in `GITHUB_TOKEN`; no PAT is needed because the target repo is the same as the workflow repo.

## Before merging — one prerequisite outside this PR

`/invite @Beaver` in the target Slack channel (`C0XXXXXX`) so the bot can post. Without that, the workflow will succeed at the GitHub end but Slack will return `not_in_channel`.

## How to verify after merge

1. Confirm `SLACK_BOT_TOKEN` is present in **Settings → Secrets and variables → Actions** (already done per the integration plan, but worth eyeballing).
2. `/invite @Beaver` in `C06SUT88X0E`.
3. Go to **Actions → Daily GitHub Summary → Run workflow** to trigger a manual run.
4. Expect a threaded summary in the channel within ~30 s, or the action's logs to print Slack API errors if a step is misconfigured.

Once the manual run succeeds, the `workflow_dispatch` block can stay (cheap, idempotent) or be removed in a follow-up.

## References

- Upstream action: https://github.com/trailofbits/github-slack-summary
- Action ref pinned in this PR: `@v1` (consumer-friendly major-version tag the upstream maintains)
