### PR TITLE
ghidra: resolve MULTIEQUAL outputs to their merged HighVariable

### DIFF
--- a/scripts/ghidra/util/PcodeSerializer.java
+++ b/scripts/ghidra/util/PcodeSerializer.java
@@ -317,6 +317,12 @@ public class PcodeSerializer {
 		// having to aggressively rewrite things, especially output operands.
 		private Map<PcodeOp, PcodeOp> replacementOperationsMap;
 
+		// Cache of whether a HighVariable is defined (in part) by a MULTIEQUAL
+		// (SSA phi) — see isPhiMerged.  Phi-merged variables are forced to a
+		// declared (named-temporary) classification instead of an inline
+		// TEMPORARY, so the un-serialized phi op is never referenced.
+		private Map<HighVariable, Boolean> phiMergedCache;
+
 		// branch address -> callee Address.toString(true). Space-qualified
 		// string preserves overlay/EXTERNAL/harvard spaces.
 		private ghidra.program.model.util.StringPropertyMap tailCallSiteMap;
@@ -431,6 +437,7 @@ public class PcodeSerializer {
 			this.oldLocalsMap = new HashMap<>();
 			this.temporaryAddressMap = new HashMap<>();
 			this.replacementOperationsMap = new HashMap<>();
+			this.phiMergedCache = new HashMap<>();
 			this.prefixOperationsMap = new HashMap<>();
 			this.addressOfGlobalMap = new HashMap<>();
 			this.callotherUsePcodeOps = new ArrayList<>();
@@ -1632,7 +1639,13 @@ public class PcodeSerializer {
 				//			  introduce a kind of code motion risk into the
 				//			  lifted representation.
 				if (highVariableRepresentativeVarnode.isRegister() || highVariableRepresentativeVarnode.isUnique() || highVariable instanceof HighOther) {
-					if (highVariableRepresentativeVarnode.getLoneDescend() != null) {
+					// A phi-merged variable (defined by a MULTIEQUAL) cannot be an
+					// inline TEMPORARY: its producer (the phi) is never serialized,
+					// and its value arrives from multiple paths.  Force a declared
+					// NAMED_TEMPORARY so reads (phi output) and writes (phi inputs)
+					// all route through one declaration.  See isPhiMerged.
+					if (highVariableRepresentativeVarnode.getLoneDescend() != null
+							&& !isPhiMerged(highVariable)) {
 						return VariableClassification.TEMPORARY;
 					} else {
 						return VariableClassification.NAMED_TEMPORARY;
@@ -3533,6 +3546,37 @@ public class PcodeSerializer {
 
 		// Get or create a local variable pseudo definition op for the high
 		// variable `var`.
+		// Strategy A for MULTIEQUAL (SSA phi): the phi op is never serialized as
+		// a standalone operation, but its output and all its inputs share one
+		// merged HighVariable.  Such a variable cannot be an inline temporary —
+		// its value arrives from multiple control-flow paths — so it must be
+		// promoted to a declared (named-temporary) variable.  classifyVariable
+		// consults this to avoid the TEMPORARY (inline) classification, which
+		// routes both reads (phi output) and writes (phi inputs) through the
+		// variable's declaration.  Cached per HighVariable.
+		boolean isPhiMerged(HighVariable highVariable) {
+			if (highVariable == null) {
+				return false;
+			}
+			Boolean cached = phiMergedCache.get(highVariable);
+			if (cached != null) {
+				return cached.booleanValue();
+			}
+			boolean merged = false;
+			Varnode[] instances = highVariable.getInstances();
+			if (instances != null) {
+				for (Varnode instance : instances) {
+					PcodeOp def = instance == null ? null : instance.getDef();
+					if (def != null && def.getOpcode() == PcodeOp.MULTIEQUAL) {
+						merged = true;
+						break;
+					}
+				}
+			}
+			phiMergedCache.put(highVariable, Boolean.valueOf(merged));
+			return merged;
+		}
+
 		PcodeOp getOrCreateLocalVariable(
 				HighVariable var, PcodeOp userPcodeOp) throws Exception {
 			

--- a/test/scripts/ghidra/util/PcodeSerializerTest.java
+++ b/test/scripts/ghidra/util/PcodeSerializerTest.java
@@ -63,8 +63,11 @@ import java.lang.NullPointerException;
 import java.lang.reflect.Field;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import domain.*;
 // todo why can't we use BaseTest here??
@@ -1935,10 +1938,133 @@ public class PcodeSerializerTest extends AbstractGhidraHeadlessIntegrationTest {
         fail();
     }
 
-    @Disabled 
-    @Test 
+    @Disabled
+    @Test
     public void testSerialize() throws Exception {
         // todo writeme
         fail();
+    }
+
+    // -------- MULTIEQUAL (SSA phi) dangling-reference regression --------
+    //
+    // A MULTIEQUAL is P-Code's phi function and is never serialized as a
+    // standalone operation.  When a phi output is consumed by another op (e.g.
+    // a call argument) and classifies as an inline TEMPORARY, the serializer
+    // used to emit a varnode reference to the un-emitted phi op — a dangling
+    // "operation" reference.  Downstream lifting then failed with "Failed to
+    // get operation for key".  This is exactly what wolfSSL_EC_KEY_generate_key
+    // (cve-2022-39173) hit: the wc_ecc_make_key_ex RNG argument piVar4 is a phi
+    // merge of the stack RNG and a fallback RNG.  The fix classifies phi-merged
+    // variables as declared NAMED_TEMPORARYs so every reference resolves to a
+    // serialized declaration (see PcodeSerializer.isPhiMerged / classifyVariable).
+    //
+    // The CVE binary cannot ship in CI, so this exercises the same shape against
+    // the bloodlight firmware: it picks a function whose decompilation contains a
+    // consumed MULTIEQUAL and asserts the serialized JSON has no dangling
+    // operation references.
+
+    // True when f's decompiled high P-Code contains a MULTIEQUAL whose output is
+    // consumed by another operation — the shape that produced the dangling ref.
+    private boolean hasConsumedMultiEqual(Function f) {
+        try {
+            DecompileResults res = decompInterface.decompileFunction(f, 60, fakeMonitor);
+            HighFunction hf = (res == null) ? null : res.getHighFunction();
+            if (hf == null) {
+                return false;
+            }
+            Iterator<PcodeOpAST> it = hf.getPcodeOps();
+            while (it.hasNext()) {
+                PcodeOpAST op = it.next();
+                if (op.getOpcode() != PcodeOp.MULTIEQUAL) {
+                    continue;
+                }
+                Varnode out = op.getOutput();
+                if (out != null && out.getDescendants() != null
+                        && out.getDescendants().hasNext()) {
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            // Undecompilable function: treat as "no phi" and skip it.
+        }
+        return false;
+    }
+
+    // Recursively collect every "operation" string reference under `element`.
+    private void collectOperationRefs(JsonElement element, List<String> out) {
+        if (element == null) {
+            return;
+        }
+        if (element.isJsonObject()) {
+            for (Map.Entry<String, JsonElement> e : element.getAsJsonObject().entrySet()) {
+                if ("operation".equals(e.getKey()) && e.getValue().isJsonPrimitive()) {
+                    out.add(e.getValue().getAsString());
+                } else {
+                    collectOperationRefs(e.getValue(), out);
+                }
+            }
+        } else if (element.isJsonArray()) {
+            for (JsonElement child : element.getAsJsonArray()) {
+                collectOperationRefs(child, out);
+            }
+        }
+    }
+
+    // "operation" references in `json` that do not resolve to a serialized
+    // operation key in the same function (i.e. dangling references).
+    private List<String> danglingOperationReferences(String json) {
+        List<String> dangling = new ArrayList<>();
+        JsonObject root = JsonParser.parseString(json).getAsJsonObject();
+        JsonObject functions = root.getAsJsonObject("functions");
+        if (functions == null) {
+            return dangling;
+        }
+        for (Map.Entry<String, JsonElement> fe : functions.entrySet()) {
+            JsonObject fn = fe.getValue().getAsJsonObject();
+            JsonObject blocks = fn.getAsJsonObject("basic_blocks");
+            if (blocks == null) {
+                continue;
+            }
+            Set<String> defined = new HashSet<>();
+            for (Map.Entry<String, JsonElement> be : blocks.entrySet()) {
+                JsonObject ops = be.getValue().getAsJsonObject().getAsJsonObject("operations");
+                if (ops != null) {
+                    defined.addAll(ops.keySet());
+                }
+            }
+            List<String> refs = new ArrayList<>();
+            collectOperationRefs(fn, refs);
+            for (String ref : refs) {
+                if (!defined.contains(ref)) {
+                    dangling.add(fe.getKey() + " -> " + ref);
+                }
+            }
+        }
+        return dangling;
+    }
+
+    @Test
+    public void testMultiEqualOutputsHaveNoDanglingReference() throws Exception {
+        Function target = null;
+        for (Function f : fns) {
+            if (f.isThunk() || f.isExternal()) {
+                continue;
+            }
+            if (hasConsumedMultiEqual(f)) {
+                target = f;
+                break;
+            }
+        }
+        assumeTrue(target != null,
+            "no bloodlight function exposes a consumed MULTIEQUAL in this harness");
+
+        SanitizerRunResult result = runSanitizerOnFunction(
+            target, /*sanitize=*/true, PcodeSerializer.AnalyticalTierMode.AUTO);
+
+        List<String> dangling = danglingOperationReferences(result.json);
+        assertTrue(dangling.isEmpty(),
+            "serialized function '" + target.getName() + "' has dangling operation "
+            + "references: a MULTIEQUAL (SSA phi) output was not resolved to its "
+            + "variable declaration: " + dangling);
     }
 }

--- a/test/scripts/ghidra/util/PcodeSerializerTest.java
+++ b/test/scripts/ghidra/util/PcodeSerializerTest.java
@@ -1979,9 +1979,11 @@ public class PcodeSerializerTest extends AbstractGhidraHeadlessIntegrationTest {
                     continue;
                 }
                 Varnode out = op.getOutput();
-                if (out != null && out.getDescendants() != null
-                        && out.getDescendants().hasNext()) {
-                    return true;
+                if (out != null) {
+                    Iterator<PcodeOp> descendants = out.getDescendants();
+                    if (descendants != null && descendants.hasNext()) {
+                        return true;
+                    }
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
MULTIEQUAL is P-Code's phi function and is never serialized as a standalone operation.  When its output (and inputs) are classified as an inline TEMPORARY — a register/unique HighVariable with a lone descendant — the serializer emitted a varnode reference to the un-emitted phi op, producing a dangling "operation" reference.  Downstream, patchir-decomp failed with "Failed to get operation for key", dropped the affected call argument, and the positional shift surfaced as misleading incompatible-pointer-conversion diagnostics (e.g., wolfSSL_EC_KEY_generate_key @ 0x0009acc8 in cve-2022-39173, where the wc_ecc_make_key_ex RNG argument piVar4 is a phi merge of the stack RNG and a fallback RNG).

Strategy A — dissolve the phi the way Ghidra's HighVariable merge does: a phi-merged variable cannot be an inline temporary (its value arrives from multiple paths and its producer is not serialized), so force it to a declared NAMED_TEMPORARY. That single classification change routes both the phi output read and the phi input writes through a single variable declaration, so the lifted C assigns the variable on each incoming path and reads it at the merge — matching Ghidra's own decompilation — rather than leaving it dangling.

- isPhiMerged(HighVariable): cached check for any instance defined by a MULTIEQUAL.
- classifyVariable: phi-merged register/unique/HighOther vars -> NAMED_TEMPORARY instead of TEMPORARY.