### PR TITLE
decomp: model undefined arrays as C arrays; mute spurious ADDRESS_OF coercion warning

### DIFF
--- a/include/patchestry/AST/OperationBuilder.hpp
+++ b/include/patchestry/AST/OperationBuilder.hpp
@@ -269,8 +269,14 @@ namespace patchestry::ast {
             std::string_view op_key
         );
 
+        // Reinterpret a record (struct/union) operand as a same-width integer so
+        // C scalar operators apply.  Records wider than 128 bits are returned
+        // unchanged; pass quiet_oversized=true (e.g. from ADDRESS_OF, which does
+        // not need a scalar result) to suppress the "too large for integer
+        // coercion" warning on that no-op path.
         clang::Expr *coerce_record_to_integer(
-            clang::ASTContext &ctx, clang::Expr *expr, clang::SourceLocation loc
+            clang::ASTContext &ctx, clang::Expr *expr, clang::SourceLocation loc,
+            bool quiet_oversized = false
         );
 
         // Narrow an aggregate lvalue to an integer access (#225).  Tries

--- a/include/patchestry/AST/OperationBuilder.hpp
+++ b/include/patchestry/AST/OperationBuilder.hpp
@@ -269,11 +269,10 @@ namespace patchestry::ast {
             std::string_view op_key
         );
 
-        // Reinterpret a record (struct/union) operand as a same-width integer so
-        // C scalar operators apply.  Records wider than 128 bits are returned
-        // unchanged; pass quiet_oversized=true (e.g. from ADDRESS_OF, which does
-        // not need a scalar result) to suppress the "too large for integer
-        // coercion" warning on that no-op path.
+        // Reinterpret a record operand as a same-width integer for C scalar
+        // operators. Records wider than 128 bits are returned unchanged; pass
+        // quiet_oversized (e.g. from ADDRESS_OF) to mute the "too large for
+        // integer coercion" warning on that no-op path.
         clang::Expr *coerce_record_to_integer(
             clang::ASTContext &ctx, clang::Expr *expr, clang::SourceLocation loc,
             bool quiet_oversized = false

--- a/include/patchestry/AST/TypeBuilder.hpp
+++ b/include/patchestry/AST/TypeBuilder.hpp
@@ -177,19 +177,6 @@ namespace patchestry::ast {
         create_undefined(clang::ASTContext &ctx, const UndefinedType &undefined_type);
 
         /**
-         * @brief Creates a `clang::QualType` for undefined array.
-         *
-         * @param ctx Reference to the `clang::ASTContext`.
-         * @param undefined_type The metadata representing the undefined type, including
-         *                       its size (in bytes) and name.
-         *
-         * @return A `clang::QualType` representing the newly created undefined array
-         */
-        clang::QualType create_type_for_undefined_array(
-            clang::ASTContext &ctx, const ArrayType &undefined_array
-        );
-
-        /**
          * @brief Completes the definition of a composite type (e.g., struct) in the AST.
          *
          * @param ctx The `clang::ASTContext` used for AST node creation.

--- a/lib/patchestry/AST/OperationStmt.cpp
+++ b/lib/patchestry/AST/OperationStmt.cpp
@@ -532,10 +532,9 @@ namespace patchestry::ast {
         } else if (size_bits <= 128 && !ctx.UnsignedInt128Ty.isNull()) {
             int_type = ctx.UnsignedInt128Ty;
         } else {
-            // Record too large for integer coercion — return unchanged and let
-            // the caller deal with the record type directly.  Callers that don't
-            // need a scalar result (e.g. ADDRESS_OF) pass quiet_oversized to
-            // suppress this otherwise-misleading warning.
+            // Too wide for any integer type — return unchanged. Callers that
+            // don't need a scalar (e.g. ADDRESS_OF) pass quiet_oversized to mute
+            // the otherwise-misleading warning.
             if (!quiet_oversized) {
                 LOG(WARNING) << "coerce_record_to_integer: record is " << size_bits
                              << " bits, too large for integer coercion\n";
@@ -2925,14 +2924,10 @@ namespace patchestry::ast {
             return {};
         }
 
-        // Coerce record (struct/union) operands to integers so C scalar
-        // operators apply.  The coercion's reinterpret is load-bearing even for
-        // ADDRESS_OF — it normalizes the operand (including malformed/rvalue
-        // field accesses) into an addressable form — so it must always run.  But
-        // for an oversized-record ADDRESS_OF the coercion is a no-op (the operand
-        // is returned unchanged and `&record` is taken directly), so suppress its
-        // otherwise-misleading "too large for integer coercion" warning:
-        // `&fd_set` / `&stat` are perfectly valid.
+        // Coerce record operands to integers for C scalar operators. The
+        // reinterpret is load-bearing even for ADDRESS_OF (it normalizes the
+        // operand into an addressable form), so it always runs; only mute the
+        // oversized-record warning there — `&fd_set` / `&stat` are valid.
         input_expr = coerce_record_to_integer(
             ctx, input_expr, op_loc, /*quiet_oversized=*/kind == clang::UO_AddrOf);
 

--- a/lib/patchestry/AST/OperationStmt.cpp
+++ b/lib/patchestry/AST/OperationStmt.cpp
@@ -513,7 +513,8 @@ namespace patchestry::ast {
     // the same byte size so that it can participate in C arithmetic / bitwise
     // operations.  Returns the expression unchanged if it is not a record type.
     clang::Expr *OpBuilder::coerce_record_to_integer(
-        clang::ASTContext &ctx, clang::Expr *expr, clang::SourceLocation loc
+        clang::ASTContext &ctx, clang::Expr *expr, clang::SourceLocation loc,
+        bool quiet_oversized
     ) {
         if (!expr || !expr->getType()->isRecordType()) {
             return expr;
@@ -531,10 +532,14 @@ namespace patchestry::ast {
         } else if (size_bits <= 128 && !ctx.UnsignedInt128Ty.isNull()) {
             int_type = ctx.UnsignedInt128Ty;
         } else {
-            // Record too large for integer coercion — return unchanged
-            // and let the caller deal with the record type directly.
-            LOG(WARNING) << "coerce_record_to_integer: record is " << size_bits
-                         << " bits, too large for integer coercion\n";
+            // Record too large for integer coercion — return unchanged and let
+            // the caller deal with the record type directly.  Callers that don't
+            // need a scalar result (e.g. ADDRESS_OF) pass quiet_oversized to
+            // suppress this otherwise-misleading warning.
+            if (!quiet_oversized) {
+                LOG(WARNING) << "coerce_record_to_integer: record is " << size_bits
+                             << " bits, too large for integer coercion\n";
+            }
             return expr;
         }
         return make_reinterpret_cast(ctx, expr, int_type, loc);
@@ -2920,8 +2925,16 @@ namespace patchestry::ast {
             return {};
         }
 
-        // Coerce record (struct/union) operands to integers for C operators.
-        input_expr = coerce_record_to_integer(ctx, input_expr, op_loc);
+        // Coerce record (struct/union) operands to integers so C scalar
+        // operators apply.  The coercion's reinterpret is load-bearing even for
+        // ADDRESS_OF — it normalizes the operand (including malformed/rvalue
+        // field accesses) into an addressable form — so it must always run.  But
+        // for an oversized-record ADDRESS_OF the coercion is a no-op (the operand
+        // is returned unchanged and `&record` is taken directly), so suppress its
+        // otherwise-misleading "too large for integer coercion" warning:
+        // `&fd_set` / `&stat` are perfectly valid.
+        input_expr = coerce_record_to_integer(
+            ctx, input_expr, op_loc, /*quiet_oversized=*/kind == clang::UO_AddrOf);
 
         clang::Expr *result_expr = nullptr;
         // ADDRESS_OF on an array decays to pointer-to-element (Ghidra's `T*`

--- a/lib/patchestry/AST/TypeBuilder.cpp
+++ b/lib/patchestry/AST/TypeBuilder.cpp
@@ -5,8 +5,6 @@
  * the LICENSE file found in the root directory of this source tree.
  */
 
-#include <sstream>
-
 #include <clang/AST/Expr.h>
 #include <clang/AST/Type.h>
 #include <clang/Basic/SourceLocation.h>
@@ -107,17 +105,13 @@ namespace patchestry::ast {
                     /*is_integer=*/false
                 );
 
-            case VarnodeType::VT_ARRAY: {
-                auto array = dynamic_cast< const ArrayType & >(*vnode_type);
-                if (array.GetElementType()
-                    && array.GetElementType()->kind == VarnodeType::VT_UNDEFINED)
-                {
-                    return create_type_for_undefined_array(
-                        ctx, dynamic_cast< const ArrayType & >(*vnode_type)
-                    );
-                }
+            case VarnodeType::VT_ARRAY:
+                // Undefined byte-blobs (`undefinedN[...]`) are modeled as plain C
+                // arrays (`undefined1[N]`) like any other array — not wrapped in a
+                // `struct struct_undefinedN`.  The array decays to a pointer on
+                // ADDRESS_OF / argument passing (no record-to-integer coercion) and
+                // whole-buffer copies lower through create_array_assignment_operation.
                 return create_array(ctx, dynamic_cast< const ArrayType & >(*vnode_type));
-            }
             case VarnodeType::VT_POINTER:
                 return create_pointer(ctx, dynamic_cast< const PointerType & >(*vnode_type));
 
@@ -568,53 +562,6 @@ namespace patchestry::ast {
         ctx.getTranslationUnitDecl()->addDecl(typedef_decl);
 
         return ctx.getTypedefType(clang::ElaboratedTypeKeyword::None, std::nullopt, typedef_decl);
-    }
-
-    /**
-     * @brief Creates a `clang::QualType` for an undefined array type.
-     *
-     * This function generates a struct type wrapping the undefined array.
-     *
-     * @param ctx Reference to the `clang::ASTContext` for type creation.
-     * @param undefined_type The metadata representing the undefined type, including
-     *                       its size (in bytes) and name.
-     *
-     * @return A `clang::QualType` representing the newly created type for undefined array.
-     */
-    clang::QualType TypeBuilder::create_type_for_undefined_array(
-        clang::ASTContext &ctx, const ArrayType &undefined_array
-    ) {
-        auto undef_array = create_array(ctx, undefined_array);
-        if (undef_array.isNull()) {
-            return {};
-        }
-
-        std::stringstream ss;
-        ss << "struct_undefined" << undefined_array.size;
-
-        // Create a RecordDecl for the composite type.
-        auto *decl = clang::RecordDecl::Create(
-            ctx, clang::TagDecl::TagKind::Struct, ctx.getTranslationUnitDecl(),
-            SourceLocation(ctx.getSourceManager(), undefined_array.key),
-            SourceLocation(ctx.getSourceManager(), undefined_array.key),
-            &ctx.Idents.get(ss.str())
-        );
-
-        decl->completeDefinition();
-
-        // Create a field decl with type `undef_array`
-        auto *field_decl = clang::FieldDecl::Create(
-            ctx, decl, SourceLocation(ctx.getSourceManager(), undefined_array.key),
-            SourceLocation(ctx.getSourceManager(), undefined_array.key),
-            &ctx.Idents.get("undefined"), undef_array, nullptr, nullptr, false,
-            clang::ICIS_NoInit
-        );
-
-        decl->addDecl(field_decl);
-        decl->setDeclContext(ctx.getTranslationUnitDecl());
-        ctx.getTranslationUnitDecl()->addDecl(decl);
-
-        return ctx.getCanonicalTagType(decl);
     }
 
 } // namespace patchestry::ast

--- a/lib/patchestry/AST/TypeBuilder.cpp
+++ b/lib/patchestry/AST/TypeBuilder.cpp
@@ -106,11 +106,8 @@ namespace patchestry::ast {
                 );
 
             case VarnodeType::VT_ARRAY:
-                // Undefined byte-blobs (`undefinedN[...]`) are modeled as plain C
-                // arrays (`undefined1[N]`) like any other array — not wrapped in a
-                // `struct struct_undefinedN`.  The array decays to a pointer on
-                // ADDRESS_OF / argument passing (no record-to-integer coercion) and
-                // whole-buffer copies lower through create_array_assignment_operation.
+                // Undefined byte-blobs (`undefinedN[...]`) lift as plain
+                // `undefined1[N]` arrays, not a `struct struct_undefinedN` wrapper.
                 return create_array(ctx, dynamic_cast< const ArrayType & >(*vnode_type));
             case VarnodeType::VT_POINTER:
                 return create_pointer(ctx, dynamic_cast< const PointerType & >(*vnode_type));

--- a/test/patchir-decomp/undefined_array_as_array.json
+++ b/test/patchir-decomp/undefined_array_as_array.json
@@ -1,0 +1,67 @@
+// Undefined byte-blobs (Ghidra `undefinedN[...]`) must be lifted as plain C
+// arrays (`undefined1 x[N]`), NOT wrapped in a `struct struct_undefinedN`.
+//
+// The array model matches Ghidra's own decompiler output and lets `ADDRESS_OF`
+// / argument passing decay the buffer to a pointer naturally, instead of
+// routing through coerce_record_to_integer (which only handles scalars
+// <= 128 bits and otherwise emits "too large for integer coercion").
+//
+// Here `gbuf` is an `undefined1[16]` global; `pass_buf` takes its address and
+// hands it to `sink`.  With the array model the call decays to `sink(gbuf)`
+// with no struct wrapper anywhere in the TU.
+//
+// RUN: bash %strip-json-comments %s > %t.json
+// RUN: %patchir-decomp -input %t.json -emit-cir -print-tu -output %t > %t.stdout 2> %t.stderr
+// RUN: test -e %t.c
+// RUN: test -e %t.cir
+// RUN: %file-check -vv -check-prefix=LIFTED --implicit-check-not=struct_undefined %s --input-file %t.c
+//
+// The undefined-array global is a real C array, not a struct wrapper:
+// LIFTED-DAG: extern undefined1 gbuf[16];
+// LIFTED-DAG: void sink(void *param_0);
+// The array argument decays to a pointer at the call site (no `&gbuf`, no cast):
+// LIFTED:     sink(gbuf);
+{
+  "architecture": "ARM", "id": "ARM:LE:32:Cortex",
+  "format": "Executable and Linking Format (ELF)",
+  "functions": {
+    "ram:40000000": {
+      "name": "sink", "is_intrinsic": false,
+      "type": { "return_type": "type_void", "is_variadic": false, "is_noreturn": false, "parameter_types": ["type_ptr_void"] },
+      "entry_point": "ram:40000000",
+      "address_ranges": [{ "start": "ram:40000000", "end": "ram:40000003" }]
+    },
+    "ram:10000000": {
+      "name": "pass_buf", "is_intrinsic": false,
+      "type": { "return_type": "type_void", "is_variadic": false, "is_noreturn": false, "parameter_types": [] },
+      "basic_blocks": {
+        "ram:10000000:0:basic": {
+          "operations": {
+            "addr": {
+              "mnemonic": "ADDRESS_OF", "type": "type_ptr_undef", "size": 4,
+              "inputs": [{ "type": "type_undef_arr", "size": 16, "kind": "global", "global": "ram:30000000" }]
+            },
+            "call": {
+              "mnemonic": "CALL", "type": "type_void",
+              "target": { "kind": "function", "function": "ram:40000000", "is_variadic": false, "is_noreturn": false },
+              "inputs": [{ "type": "type_ptr_undef", "size": 4, "kind": "temporary", "operation": "addr" }]
+            },
+            "ret": { "mnemonic": "RETURN", "inputs": [] }
+          },
+          "ordered_operations": ["addr", "call", "ret"]
+        }
+      },
+      "entry_block": "ram:10000000:0:basic"
+    }
+  },
+  "globals": {
+    "ram:30000000": { "name": "gbuf", "size": 16, "type": "type_undef_arr" }
+  },
+  "types": {
+    "type_void": { "name": "void", "size": 0, "kind": "void" },
+    "type_ptr_void": { "kind": "pointer", "size": 4, "element_type": "type_void" },
+    "type_undef1": { "name": "undefined1", "size": 1, "kind": "undefined" },
+    "type_undef_arr": { "kind": "array", "size": 16, "num_elements": 16, "element_type": "type_undef1" },
+    "type_ptr_undef": { "kind": "pointer", "size": 4, "element_type": "type_undef1" }
+  }
+}


### PR DESCRIPTION
Lift Ghidra `undefinedN[...]` blobs as `undefined1[N]` instead of a `struct struct_undefinedN` wrapper, and suppress the oversized-record "too large for integer coercion" warning on the ADDRESS_OF no-op path.