### PR TITLE
decomp: fix PIECE shift width to avoid shift count overflow warning

### DIFF
--- a/lib/patchestry/AST/OperationStmt.cpp
+++ b/lib/patchestry/AST/OperationStmt.cpp
@@ -2207,13 +2207,11 @@ namespace patchestry::ast {
                      false };
         }
 
-        // Shift the high part by the number of bits the low part occupies.
-        // Prefer the Ghidra varnode byte size (* 8) over the clang type size:
-        // clang rounds a non-power-of-two width (e.g. a 3-byte `uint3`) up to the
-        // next storage size (32 bits), which makes the shift count meet/exceed
-        // the result width and trips clang's "shift count >= width of type"
-        // diagnostic.  Fall back to the (possibly rounded) type size only when
-        // the varnode size is absent.
+        // Shift the high part by the low part's bit width.  Prefer the varnode
+        // byte size (* 8) over the clang type size: clang rounds non-power-of-two
+        // widths (e.g. 3-byte uint3 -> 32 bits) up, which can push the shift
+        // count >= the result width and trip a warning.  Fall back to the type
+        // size only when the varnode size is absent.
         unsigned low_width = op.inputs[1].size * 8U;
         if (low_width == 0) {
             auto low_type_it =

--- a/lib/patchestry/AST/OperationStmt.cpp
+++ b/lib/patchestry/AST/OperationStmt.cpp
@@ -2207,10 +2207,15 @@ namespace patchestry::ast {
                      false };
         }
 
-        // Determine low-part bit width from input1's type.  The Varnode::size
-        // field is not populated for operation inputs, so look up the type.
-        unsigned low_width = 0;
-        {
+        // Shift the high part by the number of bits the low part occupies.
+        // Prefer the Ghidra varnode byte size (* 8) over the clang type size:
+        // clang rounds a non-power-of-two width (e.g. a 3-byte `uint3`) up to the
+        // next storage size (32 bits), which makes the shift count meet/exceed
+        // the result width and trips clang's "shift count >= width of type"
+        // diagnostic.  Fall back to the (possibly rounded) type size only when
+        // the varnode size is absent.
+        unsigned low_width = op.inputs[1].size * 8U;
+        if (low_width == 0) {
             auto low_type_it =
                 type_builder().GetSerializedTypes().find(op.inputs[1].type_key);
             if (low_type_it != type_builder().GetSerializedTypes().end()) {

--- a/lib/patchestry/AST/Utils.cpp
+++ b/lib/patchestry/AST/Utils.cpp
@@ -312,6 +312,12 @@ namespace patchestry::ast {
                 ctx, il->getValue(), il->getType(), loc
             );
         }
+        if (auto *sl = llvm::dyn_cast< clang::StringLiteral >(expr)) {
+            return clang::StringLiteral::Create(
+                ctx, sl->getBytes(), sl->getKind(), sl->isPascal(), sl->getType(),
+                sl->getBeginLoc()
+            );
+        }
         if (auto *dre = llvm::dyn_cast< clang::DeclRefExpr >(expr)) {
             return clang::DeclRefExpr::Create(
                 ctx, dre->getQualifierLoc(), dre->getTemplateKeywordLoc(),


### PR DESCRIPTION
This pull request makes targeted improvements to the handling of bit width calculation for operations and adds support for cloning string literals in the AST utility functions. The main changes focus on more accurate bit width determination and enhanced AST node cloning.

Bit width calculation improvements:
* In `OperationStmt.cpp`, the logic for determining the bit width of the low part of an operation now prefers using the Ghidra varnode byte size (multiplied by 8) over the clang type size. This avoids issues with clang rounding non-standard widths up to the next storage size, which could lead to incorrect shift counts and warnings. The code falls back to the clang type size only if the varnode size is unavailable.

AST node cloning enhancements:
* In `Utils.cpp`, support for cloning `clang::StringLiteral` nodes was added. This ensures that string literals are correctly duplicated when traversing or copying AST nodes.