### PR TITLE
decomp: fix CIR emission order to address transient failure due to function type mismatch

### DIFF
--- a/include/patchestry/Codegen/Codegen.hpp
+++ b/include/patchestry/Codegen/Codegen.hpp
@@ -61,6 +61,12 @@ namespace patchestry::codegen {
       private:
         void emit_cir(clang::ASTContext &ctx, const patchestry::Options &options);
 
+        // Restore the varargs flag on cir.func declarations that ClangIR
+        // lowering emitted as non-variadic, using the Clang FunctionDecl as
+        // ground truth (works around first-materialization caching in
+        // getOrCreateCIRFunction).
+        void reconcile_variadic_decls(clang::ASTContext &ctx, mlir::ModuleOp mod);
+
         void visit_locations(clang::ASTContext &ctx);
 
         clang::CompilerInstance &ci;

--- a/lib/patchestry/Codegen/Codegen.cpp
+++ b/lib/patchestry/Codegen/Codegen.cpp
@@ -11,7 +11,11 @@
 #include <mlir/Parser/Parser.h>
 #include <optional>
 
+#include <algorithm>
+#include <vector>
+
 #include <clang/AST/ASTContext.h>
+#include <clang/AST/Decl.h>
 #include <clang/AST/DeclBase.h>
 #include <clang/AST/DeclGroup.h>
 #include <clang/CIR/LowerToLLVM.h>
@@ -42,7 +46,44 @@
 namespace patchestry::codegen {
 
     std::optional< mlir::ModuleOp > CodeGenerator::lower_ast_to_mlir(clang::ASTContext &ctx) {
-        for (const auto &decl : ctx.getTranslationUnitDecl()->noload_decls()) {
+        // Emit top-level decls in a deterministic order: non-function decls and
+        // body-less function declarations first (keeping their original relative
+        // order), then function definitions sorted by name — which, because
+        // Ghidra names functions FUN_<address>, is ascending program-address
+        // order.
+        //
+        // The AST that ASTConsumer hands us is already correct and stable; the
+        // problem is purely emission order.  The vendored CIRGen lazily
+        // materializes a `cir.func` for a function the first time it is touched,
+        // and under some orders it creates one whose entry block has fewer
+        // arguments than the function's parameter list (observed: a 2-parameter
+        // function getting a one-fixed-arg variadic `cir.func`).  The subsequent
+        // definition's emitFunctionProlog then zips its 2 ParmVarDecls against 1
+        // block argument, so the trailing parameter never enters localDeclMap;
+        // the body's reference to it aborts with CIRGen's
+        // `emitDeclRefLValue: static local` NYI (seen on FUN_0000a2a8 in
+        // cve-2016-6563).  Because the previous order followed unordered_map
+        // iteration, the abort was non-deterministic across runs.  Emitting in a
+        // fixed program-address order removes the run-to-run variance.
+        std::vector< clang::Decl * > pre;
+        std::vector< clang::Decl * > defs;
+        for (auto *decl : ctx.getTranslationUnitDecl()->noload_decls()) {
+            auto *fd = llvm::dyn_cast< clang::FunctionDecl >(decl);
+            if (fd && fd->doesThisDeclarationHaveABody()) {
+                defs.push_back(decl);
+            } else {
+                pre.push_back(decl);
+            }
+        }
+        std::stable_sort(defs.begin(), defs.end(), [](clang::Decl *a, clang::Decl *b) {
+            return llvm::cast< clang::NamedDecl >(a)->getName()
+                 < llvm::cast< clang::NamedDecl >(b)->getName();
+        });
+
+        for (auto *decl : pre) {
+            cirdriver->HandleTopLevelDecl(clang::DeclGroupRef(decl));
+        }
+        for (auto *decl : defs) {
             cirdriver->HandleTopLevelDecl(clang::DeclGroupRef(decl));
         }
 

--- a/lib/patchestry/Codegen/Codegen.cpp
+++ b/lib/patchestry/Codegen/Codegen.cpp
@@ -50,25 +50,12 @@
 namespace patchestry::codegen {
 
     std::optional< mlir::ModuleOp > CodeGenerator::lower_ast_to_mlir(clang::ASTContext &ctx) {
-        // Emit top-level decls in a deterministic order: non-function decls and
-        // body-less function declarations first (keeping their original relative
-        // order), then function definitions sorted by name — which, because
-        // Ghidra names functions FUN_<address>, is ascending program-address
-        // order.
-        //
-        // The AST that ASTConsumer hands us is already correct and stable; the
-        // problem is purely emission order.  The vendored CIRGen lazily
-        // materializes a `cir.func` for a function the first time it is touched,
-        // and under some orders it creates one whose entry block has fewer
-        // arguments than the function's parameter list (observed: a 2-parameter
-        // function getting a one-fixed-arg variadic `cir.func`).  The subsequent
-        // definition's emitFunctionProlog then zips its 2 ParmVarDecls against 1
-        // block argument, so the trailing parameter never enters localDeclMap;
-        // the body's reference to it aborts with CIRGen's
-        // `emitDeclRefLValue: static local` NYI (seen on FUN_0000a2a8 in
-        // cve-2016-6563).  Because the previous order followed unordered_map
-        // iteration, the abort was non-deterministic across runs.  Emitting in a
-        // fixed program-address order removes the run-to-run variance.
+        // Emit declarations first, then definitions in name (= program-address)
+        // order. CIRGen caches the first cir.func it lazily creates for a symbol;
+        // an unordered emission order let a caller materialize a callee with too
+        // few args before the definition, dropping a parameter from localDeclMap
+        // and aborting (emitDeclRefLValue: static local). A fixed order removes
+        // the run-to-run variance.
         std::vector< clang::Decl * > pre;
         std::vector< clang::Decl * > defs;
         for (auto *decl : ctx.getTranslationUnitDecl()->noload_decls()) {
@@ -103,16 +90,11 @@ namespace patchestry::codegen {
     void CodeGenerator::reconcile_variadic_decls(
         clang::ASTContext &ctx, mlir::ModuleOp mod
     ) {
-        // ClangIR's getOrCreateCIRFunction caches the first-created cir.func for
-        // a given symbol and, for non-definition references, returns it without
-        // upgrading its type (clang/lib/CIR/CodeGen/CIRGenModule.cpp). When a
-        // variadic libc function (e.g. fcntl, printf) is first materialized
-        // through a builtin / no-prototype path, RequiredArgs::All makes its
-        // cir.func non-variadic; every later, correct variadic reference is then
-        // dropped. The CIR verifier subsequently rejects any call site that
-        // passes trailing variadic arguments with "incorrect number of operands
-        // for callee". The Clang FunctionDecl is variadic-correct, so use it as
-        // ground truth and restore the varargs flag on the emitted declaration.
+        // CIRGen can emit a variadic libc function (fcntl, printf, ...) as a
+        // non-variadic cir.func when it first materializes through a builtin /
+        // no-prototype path, making its variadic call sites fail verification.
+        // Use the (variadic-correct) Clang FunctionDecl as ground truth and
+        // restore the varargs flag on the emitted declaration.
         llvm::StringSet<> variadic_names;
         for (const auto *decl : ctx.getTranslationUnitDecl()->noload_decls()) {
             const auto *fd = llvm::dyn_cast< clang::FunctionDecl >(decl);
@@ -132,8 +114,7 @@ namespace patchestry::codegen {
                 return;
             }
             // Widening to varargs only relaxes the operand-count check, so
-            // existing call sites stay valid and now match the real variadic
-            // ABI. Preserve inputs and the (optional, possibly void) return type.
+            // existing call sites stay valid. Preserve inputs and return type.
             func.setFunctionType(cir::FuncType::get(
                 func.getContext(), func_type.getInputs(),
                 func_type.getOptionalReturnType(), /*varArg=*/true

--- a/lib/patchestry/Codegen/Codegen.cpp
+++ b/lib/patchestry/Codegen/Codegen.cpp
@@ -18,9 +18,13 @@
 #include <clang/AST/Decl.h>
 #include <clang/AST/DeclBase.h>
 #include <clang/AST/DeclGroup.h>
+#include <clang/AST/Type.h>
+#include <clang/CIR/Dialect/IR/CIRDialect.h>
+#include <clang/CIR/Dialect/IR/CIRTypes.h>
 #include <clang/CIR/LowerToLLVM.h>
 #include <clang/CIR/Passes.h>
 #include <clang/Tooling/Tooling.h>
+#include <llvm/ADT/StringSet.h>
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/IR/Attributes.h>
 #include <mlir/IR/Builders.h>
@@ -88,9 +92,55 @@ namespace patchestry::codegen {
         }
 
         cirdriver->emitDeferredDecls();
+
+        reconcile_variadic_decls(ctx, cirdriver->getModule());
+
         cirdriver->verifyModule();
 
         return std::make_optional(cirdriver->getModule());
+    }
+
+    void CodeGenerator::reconcile_variadic_decls(
+        clang::ASTContext &ctx, mlir::ModuleOp mod
+    ) {
+        // ClangIR's getOrCreateCIRFunction caches the first-created cir.func for
+        // a given symbol and, for non-definition references, returns it without
+        // upgrading its type (clang/lib/CIR/CodeGen/CIRGenModule.cpp). When a
+        // variadic libc function (e.g. fcntl, printf) is first materialized
+        // through a builtin / no-prototype path, RequiredArgs::All makes its
+        // cir.func non-variadic; every later, correct variadic reference is then
+        // dropped. The CIR verifier subsequently rejects any call site that
+        // passes trailing variadic arguments with "incorrect number of operands
+        // for callee". The Clang FunctionDecl is variadic-correct, so use it as
+        // ground truth and restore the varargs flag on the emitted declaration.
+        llvm::StringSet<> variadic_names;
+        for (const auto *decl : ctx.getTranslationUnitDecl()->noload_decls()) {
+            const auto *fd = llvm::dyn_cast< clang::FunctionDecl >(decl);
+            if (fd == nullptr) {
+                continue;
+            }
+            if (const auto *fpt = fd->getType()->getAs< clang::FunctionProtoType >();
+                fpt != nullptr && fpt->isVariadic())
+            {
+                variadic_names.insert(fd->getName());
+            }
+        }
+
+        mod.walk([&](cir::FuncOp func) {
+            auto func_type = func.getFunctionType();
+            if (func_type.isVarArg() || !variadic_names.contains(func.getSymName())) {
+                return;
+            }
+            // Widening to varargs only relaxes the operand-count check, so
+            // existing call sites stay valid and now match the real variadic
+            // ABI. Preserve inputs and the (optional, possibly void) return type.
+            func.setFunctionType(cir::FuncType::get(
+                func.getContext(), func_type.getInputs(),
+                func_type.getOptionalReturnType(), /*varArg=*/true
+            ));
+            LOG(INFO) << "Restored varargs on cir.func '" << func.getSymName().str()
+                      << "' dropped during CIR lowering\n";
+        });
     }
 
     void

--- a/lib/patchestry/Ghidra/JsonDeserialize.cpp
+++ b/lib/patchestry/Ghidra/JsonDeserialize.cpp
@@ -364,7 +364,16 @@ namespace patchestry::ghidra {
     ) {
         const auto *field_array = composite_obj.getArray("fields");
         if (field_array == nullptr || field_array->empty()) {
-            LOG(ERROR) << "No fields found in composite type object\n";
+            // An opaque / forward-declared composite (e.g. libc's DIR /
+            // __dirstream, FILE, pthread internals) exports no members because
+            // its layout lives inside a library. This is legitimate for types
+            // that are only ever used by pointer, so treat it as an empty
+            // record rather than a hard error -- mirroring the empty-enum case
+            // below. Leaving the composite with zero components lets the AST
+            // layer emit a valid (opaque) struct via complete_definition().
+            LOG(WARNING) << "Composite type '" << varnode.name
+                         << "' (key: " << varnode.key
+                         << ") has no fields; treating as opaque/empty record\n";
             return;
         }
 

--- a/lib/patchestry/Ghidra/JsonDeserialize.cpp
+++ b/lib/patchestry/Ghidra/JsonDeserialize.cpp
@@ -364,13 +364,10 @@ namespace patchestry::ghidra {
     ) {
         const auto *field_array = composite_obj.getArray("fields");
         if (field_array == nullptr || field_array->empty()) {
-            // An opaque / forward-declared composite (e.g. libc's DIR /
-            // __dirstream, FILE, pthread internals) exports no members because
-            // its layout lives inside a library. This is legitimate for types
-            // that are only ever used by pointer, so treat it as an empty
-            // record rather than a hard error -- mirroring the empty-enum case
-            // below. Leaving the composite with zero components lets the AST
-            // layer emit a valid (opaque) struct via complete_definition().
+            // Opaque / forward-declared composites (libc DIR, FILE, pthread
+            // internals) export no members — legitimate for pointer-only types.
+            // Leave it as an empty record; the AST layer emits a valid opaque
+            // struct via complete_definition(). Mirrors the empty-enum case.
             LOG(WARNING) << "Composite type '" << varnode.name
                          << "' (key: " << varnode.key
                          << ") has no fields; treating as opaque/empty record\n";


### PR DESCRIPTION
This pull request introduces improvements to the code generation pipeline, focusing on deterministic emission order for function declarations and robust handling of variadic function declarations in the MLIR lowering process. It also refines the handling of opaque composite types during Ghidra JSON deserialization. The main changes are grouped below:

### Code generation and emission order improvements

* Changed the emission order in `CodeGenerator::lower_ast_to_mlir` to first emit non-function and body-less function declarations, followed by function definitions sorted by name. This ensures deterministic output and resolves non-deterministic bugs related to function parameter mapping during CIR lowering.

### Variadic function declaration reconciliation

* Added the `reconcile_variadic_decls` method to `CodeGenerator` to restore the variadic flag on `cir.func` declarations based on the ground truth from Clang's `FunctionDecl`. This addresses issues where variadic functions were incorrectly emitted as non-variadic, leading to verifier errors. [[1]](diffhunk://#diff-76f0061ebdce435713717fb5e127415a364ddf589ca9c728ee80478104bacbfcR64-R69) [[2]](diffhunk://#diff-ad22dfd22b98a6cbddba165e38ecfd99ecda94d3dff53c97fffc978f05691d9eL45-R145)
* Updated includes in `Codegen.cpp` to support the new reconciliation logic, adding headers for Clang AST types, CIR dialect, and LLVM utilities.

### Ghidra JSON deserialization robustness

* Modified the handling of composite types with no fields in `JsonDeserialize.cpp` to treat them as opaque/empty records instead of hard errors, improving compatibility with forward-declared or library-internal types.