### PR TITLE
fix: improve symbol sanitization, call argument synthesis, and type coercion robustness

### DIFF
--- a/include/patchestry/AST/OperationBuilder.hpp
+++ b/include/patchestry/AST/OperationBuilder.hpp
@@ -49,9 +49,8 @@ namespace patchestry::ast {
         std::pair< clang::Stmt *, bool >
         create_store(clang::ASTContext &ctx, const Function &function, const Operation &op);
 
-        // Coerce a STORE address operand into a dereferenceable pointer (see
-        // definition).  Returns the operand unchanged when it is already a
-        // non-void pointer, or nullptr if the cast cannot be built.
+        // Cast a STORE address operand to a dereferenceable pointer; returns it
+        // unchanged if already a non-void pointer, or nullptr if uncastable.
         clang::Expr *coerce_store_address(
             clang::ASTContext &ctx, clang::Expr *addr, clang::Expr *value,
             const Operation &op, clang::SourceLocation op_loc
@@ -311,11 +310,10 @@ namespace patchestry::ast {
             clang::SourceLocation loc = clang::SourceLocation()
         );
 
-        // Pad `arguments` up to fndecl's minimum required count with synthesized
+        // Pad `arguments` to fndecl's minimum required count with synthesized
         // defaults.  Returns false if a required parameter has no representable
-        // default (so the caller can drop the call instead of building one that
-        // would fail Sema with "too few arguments").
-        [[nodiscard]] bool extend_callexpr_agruments(
+        // default, so the caller can drop the call rather than under-apply it.
+        [[nodiscard]] bool extend_callexpr_arguments(
             clang::ASTContext &ctx, clang::FunctionDecl *fndecl,
             std::vector< clang::Expr * > &arguments
         );

--- a/include/patchestry/AST/OperationBuilder.hpp
+++ b/include/patchestry/AST/OperationBuilder.hpp
@@ -311,7 +311,11 @@ namespace patchestry::ast {
             clang::SourceLocation loc = clang::SourceLocation()
         );
 
-        void extend_callexpr_agruments(
+        // Pad `arguments` up to fndecl's minimum required count with synthesized
+        // defaults.  Returns false if a required parameter has no representable
+        // default (so the caller can drop the call instead of building one that
+        // would fail Sema with "too few arguments").
+        [[nodiscard]] bool extend_callexpr_agruments(
             clang::ASTContext &ctx, clang::FunctionDecl *fndecl,
             std::vector< clang::Expr * > &arguments
         );

--- a/include/patchestry/AST/OperationBuilder.hpp
+++ b/include/patchestry/AST/OperationBuilder.hpp
@@ -49,6 +49,14 @@ namespace patchestry::ast {
         std::pair< clang::Stmt *, bool >
         create_store(clang::ASTContext &ctx, const Function &function, const Operation &op);
 
+        // Coerce a STORE address operand into a dereferenceable pointer (see
+        // definition).  Returns the operand unchanged when it is already a
+        // non-void pointer, or nullptr if the cast cannot be built.
+        clang::Expr *coerce_store_address(
+            clang::ASTContext &ctx, clang::Expr *addr, clang::Expr *value,
+            const Operation &op, clang::SourceLocation op_loc
+        );
+
         std::pair< clang::Stmt *, bool >
         create_branch(clang::ASTContext &ctx, const Operation &op);
 

--- a/lib/patchestry/AST/ASTConsumer.cpp
+++ b/lib/patchestry/AST/ASTConsumer.cpp
@@ -487,14 +487,10 @@ namespace patchestry::ast {
             }
         }
 
-        // Loud guard: a FunctionDecl and a VarDecl that share a C identifier
-        // become two ops under one name in the MLIR module symbol table, which
-        // trips an isa<cir::GlobalOp>/isa<cir::FuncOp> assertion deep inside the
-        // vendored CIRGen (CIRGenModule.cpp getOrCreateCIRGlobal /
-        // GetOrCreateCIRFunction).  The #226 check above only covers same-address
-        // clashes; this catches same-name clashes (e.g. the "__errno" accessor
-        // function colliding with the "errno" global after name sanitization).
-        // Fail here with a clear message instead of asserting in vendor code.
+        // A FunctionDecl and a VarDecl sharing a C identifier collide as one
+        // MLIR symbol and trip an isa<GlobalOp>/isa<FuncOp> assertion in vendored
+        // CIRGen.  The #226 check above covers same-address clashes; this catches
+        // same-name ones (e.g. "__errno" func vs "errno" global).  Fail loudly here.
         {
             std::unordered_set< std::string > function_names;
             std::unordered_set< std::string > variable_names;

--- a/lib/patchestry/AST/ASTConsumer.cpp
+++ b/lib/patchestry/AST/ASTConsumer.cpp
@@ -487,6 +487,41 @@ namespace patchestry::ast {
             }
         }
 
+        // Loud guard: a FunctionDecl and a VarDecl that share a C identifier
+        // become two ops under one name in the MLIR module symbol table, which
+        // trips an isa<cir::GlobalOp>/isa<cir::FuncOp> assertion deep inside the
+        // vendored CIRGen (CIRGenModule.cpp getOrCreateCIRGlobal /
+        // GetOrCreateCIRFunction).  The #226 check above only covers same-address
+        // clashes; this catches same-name clashes (e.g. the "__errno" accessor
+        // function colliding with the "errno" global after name sanitization).
+        // Fail here with a clear message instead of asserting in vendor code.
+        {
+            std::unordered_set< std::string > function_names;
+            std::unordered_set< std::string > variable_names;
+            for (const auto *decl : ctx.getTranslationUnitDecl()->decls()) {
+                const auto *named = llvm::dyn_cast< clang::NamedDecl >(decl);
+                if (!named || !named->getIdentifier()) {
+                    continue;
+                }
+                auto name = named->getName().str();
+                if (llvm::isa< clang::FunctionDecl >(decl)) {
+                    function_names.insert(name);
+                } else if (llvm::isa< clang::VarDecl >(decl)) {
+                    variable_names.insert(name);
+                }
+            }
+            for (const auto &name : function_names) {
+                if (variable_names.count(name)) {
+                    LOG_FATAL("symbol name collision: '{0}' is declared as both a "
+                              "function and a global variable.  These map to a single "
+                              "MLIR module symbol and would trip a CIRGen assertion.  "
+                              "This usually means name sanitization collapsed two "
+                              "distinct binary symbols onto one identifier.",
+                              name);
+                }
+            }
+        }
+
         if (options.print_tu) {
             // Pretty-print before codegen so the C file emits even when
             // CIR lowering later fails.

--- a/lib/patchestry/AST/OperationStmt.cpp
+++ b/lib/patchestry/AST/OperationStmt.cpp
@@ -394,6 +394,19 @@ namespace patchestry::ast {
             (void) ctx;
         };
 
+        // A function designator (e.g. a VARNODE_FUNCTION operand used as a
+        // value) has function type and cannot be materialized or addressed as
+        // an object — doing so builds a function-typed lvalue temporary that
+        // classifies as CL_Function and aborts CheckAddressOfOperand. Apply the
+        // C function-to-pointer decay so we reinterpret the function *pointer*.
+        if (expr->getType()->isFunctionType()) {
+            expr = clang::ImplicitCastExpr::Create(
+                ctx, ctx.getPointerType(expr->getType()),
+                clang::CK_FunctionToPointerDecay, expr, /*BasePath=*/nullptr,
+                clang::VK_PRValue, clang::FPOptionsOverride()
+            );
+        }
+
         auto *temp_expr  = create_temporary_expr(ctx, expr);
         auto addrof_expr = sema().CreateBuiltinUnaryOp(loc, clang::UO_AddrOf, temp_expr);
         if (addrof_expr.isInvalid()) {

--- a/lib/patchestry/AST/OperationStmt.cpp
+++ b/lib/patchestry/AST/OperationStmt.cpp
@@ -625,6 +625,17 @@ namespace patchestry::ast {
         clang::QualType input_type  = input_expr->getType();
         clang::QualType output_type = output_expr->getType();
 
+        // A function designator is not an assignable lvalue (e.g. a
+        // VARNODE_FUNCTION used as a store target).  Attempting `func = value`
+        // makes CreateBuiltinBinOp emit a hard "expression is not assignable"
+        // diagnostic that poisons codegen; bail loudly instead.
+        if (output_type->isFunctionType()) {
+            LOG(ERROR) << "create_assign_operation: assignment target has function "
+                          "type '" << output_type.getAsString()
+                       << "'; dropping non-assignable store\n";
+            return nullptr;
+        }
+
         // Scalar → array: lower as a pointer-cast partial store
         // `*(input_type *)&output[0] = input`.  Width-agnostic — the
         // overflow case (input wider than buffer) is preserved

--- a/lib/patchestry/AST/OperationStmt.cpp
+++ b/lib/patchestry/AST/OperationStmt.cpp
@@ -113,8 +113,20 @@ namespace patchestry::ast {
             } else if (param_type->isBooleanType()) {
                 return new (ctx)
                     clang::CXXBoolLiteralExpr(true, param_type, VirtualLoc(ctx));
+            } else if (param_type->isEnumeralType()) {
+                // IntegerLiteral asserts on non-integer types; emit (E)0 as an
+                // integral cast over an int-typed 0.
+                auto *zero = new (ctx) clang::IntegerLiteral(
+                    ctx, llvm::APInt(ctx.getIntWidth(ctx.IntTy), 0), ctx.IntTy,
+                    VirtualLoc(ctx)
+                );
+                return clang::ImplicitCastExpr::Create(
+                    ctx, param_type, clang::CK_IntegralCast, zero,
+                    /*BasePath=*/nullptr, clang::VK_PRValue, clang::FPOptionsOverride()
+                );
             } else {
-                LOG(ERROR) << "Failed to create default value for paramer\n";
+                LOG(ERROR) << "Failed to create default value for parameter of type '"
+                           << param_type.getAsString() << "'\n";
                 return nullptr;
             }
         }
@@ -1358,15 +1370,28 @@ namespace patchestry::ast {
         return { result_stmt, false };
     }
 
-    void OpBuilder::extend_callexpr_agruments(
+    bool OpBuilder::extend_callexpr_agruments(
         clang::ASTContext &ctx, clang::FunctionDecl *fndecl,
         std::vector< clang::Expr * > &arguments
     ) {
         auto minargs = fndecl->getMinRequiredArguments();
         for (auto i = static_cast< unsigned >(arguments.size()); i < minargs; i++) {
-            auto *param = fndecl->getParamDecl(i);
-            arguments.emplace_back(createDefaultArgument(ctx, param));
+            auto *param       = fndecl->getParamDecl(i);
+            auto *default_arg = createDefaultArgument(ctx, param);
+            if (default_arg == nullptr) {
+                // No representable default for this parameter type (e.g. a
+                // by-value record).  A null Expr* here would crash
+                // Sema::CheckArgsForPlaceholders, and a short argument list
+                // would make BuildCallExpr emit a hard "too few arguments"
+                // error that poisons codegen for the whole module.  Signal
+                // failure so the caller drops just this call.
+                LOG(ERROR) << "Cannot synthesize default argument " << i << " for '"
+                           << fndecl->getNameAsString() << "'. key dropped\n";
+                return false;
+            }
+            arguments.emplace_back(default_arg);
         }
+        return true;
     }
 
     clang::Expr *OpBuilder::build_callexpr_from_function(
@@ -1549,7 +1574,19 @@ namespace patchestry::ast {
         // extend it with the default value.
         unsigned min_args = callee->getMinRequiredArguments();
         if (arguments.size() < min_args) {
-            extend_callexpr_agruments(ctx, callee, arguments);
+            if (!extend_callexpr_agruments(ctx, callee, arguments)) {
+                LOG(ERROR) << "Dropping under-applied call to '"
+                           << callee->getNameAsString() << "'. key: " << op.key << "\n";
+                return nullptr;
+            }
+        }
+
+        // A null Expr* in the argument list dereferences to a crash inside
+        // Sema::CheckArgsForPlaceholders.  Refuse loudly instead.
+        if (llvm::is_contained(arguments, nullptr)) {
+            LOG(ERROR) << "Null argument in call to '" << callee->getNameAsString()
+                       << "'. key: " << op.key << "\n";
+            return nullptr;
         }
 
         auto *refexpr = clang::DeclRefExpr::Create(

--- a/lib/patchestry/AST/OperationStmt.cpp
+++ b/lib/patchestry/AST/OperationStmt.cpp
@@ -2192,7 +2192,18 @@ namespace patchestry::ast {
             auto cast_result = sema().BuildCStyleCastExpr(
                 location, ctx.getTrivialTypeSourceInfo(ret_type), location, zero
             );
-            assert(!cast_result.isInvalid());
+            // `(T)0` is ill-formed when T is a record/reference/opaque type
+            // (common for C++ by-value returns, e.g. a QString). Fall back to a
+            // bare `return;` rather than aborting — this path is the typically
+            // unreachable empty return after a noreturn call.
+            if (cast_result.isInvalid()) {
+                LOG(ERROR) << "create_return: cannot build (T)0 for return type '"
+                           << ret_type.getAsString() << "'; emitting bare return. key: "
+                           << op.key << "\n";
+                return std::make_pair(
+                    clang::ReturnStmt::Create(ctx, location, nullptr, nullptr), false
+                );
+            }
             return std::make_pair(
                 clang::ReturnStmt::Create(
                     ctx, location, cast_result.getAs< clang::Expr >(), nullptr

--- a/lib/patchestry/AST/OperationStmt.cpp
+++ b/lib/patchestry/AST/OperationStmt.cpp
@@ -929,13 +929,10 @@ namespace patchestry::ast {
                  false };
     }
 
-    // The address operand of a STORE must be a dereferenceable pointer, but
-    // Ghidra can hand us a bare integer address (e.g. 'unsigned int') or a
-    // void*, both of which fail Sema's indirection check.  Cast such operands
-    // to a pointer of the stored value's type so the store lowers to
-    // *(T *)addr = value.  A genuine, non-void pointer is returned unchanged so
-    // existing pointer-arithmetic stores keep their shape.  Returns nullptr on
-    // an unrepresentable cast (caller bails loudly).
+    // Ghidra can give a STORE a bare integer address or a void*, which fail
+    // Sema's indirection check.  Cast those to a pointer of the value's type so
+    // the store lowers to *(T *)addr = value; a real non-void pointer passes
+    // through unchanged.  Returns nullptr if the cast cannot be built.
     clang::Expr *OpBuilder::coerce_store_address(
         clang::ASTContext &ctx, clang::Expr *addr, clang::Expr *value,
         const Operation &op, clang::SourceLocation op_loc
@@ -1370,7 +1367,7 @@ namespace patchestry::ast {
         return { result_stmt, false };
     }
 
-    bool OpBuilder::extend_callexpr_agruments(
+    bool OpBuilder::extend_callexpr_arguments(
         clang::ASTContext &ctx, clang::FunctionDecl *fndecl,
         std::vector< clang::Expr * > &arguments
     ) {
@@ -1379,12 +1376,9 @@ namespace patchestry::ast {
             auto *param       = fndecl->getParamDecl(i);
             auto *default_arg = createDefaultArgument(ctx, param);
             if (default_arg == nullptr) {
-                // No representable default for this parameter type (e.g. a
-                // by-value record).  A null Expr* here would crash
-                // Sema::CheckArgsForPlaceholders, and a short argument list
-                // would make BuildCallExpr emit a hard "too few arguments"
-                // error that poisons codegen for the whole module.  Signal
-                // failure so the caller drops just this call.
+                // No representable default (e.g. a by-value record).  Signal
+                // failure so the caller drops the call: a null arg would crash
+                // Sema and a short list would emit a hard "too few arguments".
                 LOG(ERROR) << "Cannot synthesize default argument " << i << " for '"
                            << fndecl->getNameAsString() << "'. key dropped\n";
                 return false;
@@ -1574,7 +1568,7 @@ namespace patchestry::ast {
         // extend it with the default value.
         unsigned min_args = callee->getMinRequiredArguments();
         if (arguments.size() < min_args) {
-            if (!extend_callexpr_agruments(ctx, callee, arguments)) {
+            if (!extend_callexpr_arguments(ctx, callee, arguments)) {
                 LOG(ERROR) << "Dropping under-applied call to '"
                            << callee->getNameAsString() << "'. key: " << op.key << "\n";
                 return nullptr;
@@ -2310,13 +2304,11 @@ namespace patchestry::ast {
 
         auto merge_to_next = !op.output.has_value();
 
-        // PIECE is a bit-level concatenation (high << low_width | low) and must be
-        // computed in an integer domain.  When the result type is non-integral
-        // (e.g. the reconstructed 32-bit value is a float register), shifting the
-        // operands as that type would make the BO_Shl below 'float << int', which
-        // C rejects.  Compute in an unsigned integer of the result's width and
-        // reinterpret the bits back to the result type afterwards (a value
-        // conversion would be wrong — the bytes are a raw bit pattern).
+        // PIECE is a bit concatenation (high << low_width | low), so it must run
+        // in the integer domain.  A non-integral result type (e.g. a float
+        // register) would make the shift below 'float << int', which C rejects:
+        // compute in an unsigned integer of the result width, then reinterpret
+        // the bits (not value-convert) back to the result type.
         clang::QualType piece_result_type;
         bool reinterpret_result = false;
         if (op.type) {

--- a/lib/patchestry/AST/OperationStmt.cpp
+++ b/lib/patchestry/AST/OperationStmt.cpp
@@ -2310,18 +2310,36 @@ namespace patchestry::ast {
 
         auto merge_to_next = !op.output.has_value();
 
-        // If Operation has type, convert expression to operation type and perform bit-shift and
-        // or operation.
+        // PIECE is a bit-level concatenation (high << low_width | low) and must be
+        // computed in an integer domain.  When the result type is non-integral
+        // (e.g. the reconstructed 32-bit value is a float register), shifting the
+        // operands as that type would make the BO_Shl below 'float << int', which
+        // C rejects.  Compute in an unsigned integer of the result's width and
+        // reinterpret the bits back to the result type afterwards (a value
+        // conversion would be wrong — the bytes are a raw bit pattern).
+        clang::QualType piece_result_type;
+        bool reinterpret_result = false;
         if (op.type) {
-            auto op_type           = type_it->second;
-            auto *cast_expr_input0 = make_cast(ctx, input0_expr, op_type, location);
+            piece_result_type   = type_it->second;
+            auto arith_type     = piece_result_type;
+            if (!piece_result_type->isIntegerType()) {
+                arith_type = ctx.getIntTypeForBitwidth(
+                    static_cast< unsigned >(ctx.getTypeSize(piece_result_type)),
+                    /*Signed=*/false
+                );
+                if (arith_type.isNull()) {
+                    arith_type = ctx.UnsignedIntTy;
+                }
+                reinterpret_result = true;
+            }
+            auto *cast_expr_input0 = make_cast(ctx, input0_expr, arith_type, location);
             if (!cast_expr_input0) {
                 LOG(ERROR) << "Failed to create cast expression for PIECE input0. key: "
                            << op.key;
                 return {};
             }
             input0_expr            = cast_expr_input0;
-            auto *cast_expr_input1 = make_cast(ctx, input1_expr, op_type, location);
+            auto *cast_expr_input1 = make_cast(ctx, input1_expr, arith_type, location);
             if (!cast_expr_input1) {
                 LOG(ERROR) << "Failed to create cast expression for PIECE input1. key: "
                            << op.key;
@@ -2362,6 +2380,17 @@ namespace patchestry::ast {
         if (!or_expr) {
             LOG(ERROR) << "PIECE: OR result yielded null Expr. key: " << op.key;
             return {};
+        }
+
+        // The concatenation was computed as an integer; reinterpret its bits as
+        // the (non-integral) result type when one was requested.
+        if (reinterpret_result) {
+            or_expr = make_reinterpret_cast(ctx, or_expr, piece_result_type, location);
+            if (!or_expr) {
+                LOG(ERROR) << "PIECE: reinterpret to result type yielded null Expr. key: "
+                           << op.key;
+                return {};
+            }
         }
 
         if (merge_to_next) {

--- a/lib/patchestry/AST/OperationStmt.cpp
+++ b/lib/patchestry/AST/OperationStmt.cpp
@@ -917,6 +917,35 @@ namespace patchestry::ast {
                  false };
     }
 
+    // The address operand of a STORE must be a dereferenceable pointer, but
+    // Ghidra can hand us a bare integer address (e.g. 'unsigned int') or a
+    // void*, both of which fail Sema's indirection check.  Cast such operands
+    // to a pointer of the stored value's type so the store lowers to
+    // *(T *)addr = value.  A genuine, non-void pointer is returned unchanged so
+    // existing pointer-arithmetic stores keep their shape.  Returns nullptr on
+    // an unrepresentable cast (caller bails loudly).
+    clang::Expr *OpBuilder::coerce_store_address(
+        clang::ASTContext &ctx, clang::Expr *addr, clang::Expr *value,
+        const Operation &op, clang::SourceLocation op_loc
+    ) {
+        auto addr_type = addr->getType();
+        if (addr_type->isPointerType() && !addr_type->isVoidPointerType()) {
+            return addr;
+        }
+
+        clang::QualType pointee = value != nullptr ? value->getType() : clang::QualType();
+        if (pointee.isNull() || pointee->isVoidType()) {
+            pointee = ctx.UnsignedCharTy;
+        }
+
+        auto *casted = make_cast(ctx, addr, ctx.getPointerType(pointee), op_loc);
+        if (!casted) {
+            LOG(ERROR) << "Failed to cast STORE address to pointer. key: " << op.key;
+            return nullptr;
+        }
+        return casted;
+    }
+
     std::pair< clang::Stmt *, bool > OpBuilder::create_store(
         clang::ASTContext &ctx, const Function &function, const Operation &op
     ) {
@@ -938,6 +967,10 @@ namespace patchestry::ast {
             // Cancel *(&expr) from PTRADD's &base[index].
             clang::Expr *deref_expr = simplify_deref_addrof(lhs_expr);
             if (!deref_expr) {
+                lhs_expr = coerce_store_address(ctx, lhs_expr, rhs_expr, op, op_loc);
+                if (!lhs_expr) {
+                    return {};
+                }
                 // Parenthesize pointer arithmetic so the deref binds the whole
                 // expression: *(ptr + offset) instead of *ptr + offset.
                 if (clang::isa< clang::BinaryOperator >(lhs_expr)) {
@@ -945,7 +978,11 @@ namespace patchestry::ast {
                 }
                 auto deref_result =
                     sema().CreateBuiltinUnaryOp(op_loc, clang::UO_Deref, lhs_expr);
-                assert(!deref_result.isInvalid());
+                if (deref_result.isInvalid()) {
+                    LOG(ERROR) << "Failed to create deref expression for STORE. key: "
+                               << op.key;
+                    return {};
+                }
                 deref_expr = deref_result.getAs< clang::Expr >();
             }
 
@@ -968,6 +1005,10 @@ namespace patchestry::ast {
             // Cancel *(&expr) from PTRADD's &base[index].
             clang::Expr *deref_expr = simplify_deref_addrof(lhs_expr);
             if (!deref_expr) {
+                lhs_expr = coerce_store_address(ctx, lhs_expr, rhs_expr, op, op_loc);
+                if (!lhs_expr) {
+                    return {};
+                }
                 if (clang::isa< clang::BinaryOperator >(lhs_expr)) {
                     lhs_expr = new (ctx) clang::ParenExpr(op_loc, op_loc, lhs_expr);
                 }

--- a/lib/patchestry/AST/OperationStmt.cpp
+++ b/lib/patchestry/AST/OperationStmt.cpp
@@ -2355,7 +2355,13 @@ namespace patchestry::ast {
                     /*Signed=*/false
                 );
                 if (arith_type.isNull()) {
-                    arith_type = ctx.UnsignedIntTy;
+                    // No integer type matches the result width.  Falling back to
+                    // a narrower int would make the later reinterpret read past
+                    // the temporary (*(wide *)&narrow) — UB.  Skip the op.
+                    LOG(ERROR) << "PIECE: no integer type for result width "
+                               << ctx.getTypeSize(piece_result_type)
+                               << "; skipping. key: " << op.key;
+                    return {};
                 }
                 reinterpret_result = true;
             }

--- a/lib/patchestry/AST/TypeBuilder.cpp
+++ b/lib/patchestry/AST/TypeBuilder.cpp
@@ -497,20 +497,26 @@ namespace patchestry::ast {
             bit_width       = TypeBuilder::kNumBitsUint;
         }
 
-        // Populate enum with actual serialized constants.
+        // Populate enum with actual serialized constants.  Build each value
+        // with implicitTrunc=true: unsigned flag enumerators (e.g. Qt's
+        // InputMethodQuery::ImQueryAll = 0xFFFFFFFF in a 4-byte enum) are not
+        // valid *signed* bit_width values, so the APInt ctor would otherwise
+        // assert (isIntN).  Truncation keeps the low bit_width bits, which
+        // already hold the full value here, preserving the bit pattern.
         const auto &constants = enum_type.GetConstants();
         for (const auto &c : constants) {
+            auto make_apint = [&] {
+                return llvm::APInt(
+                    bit_width, static_cast< uint64_t >(c.value),
+                    /*isSigned=*/true, /*implicitTrunc=*/true
+                );
+            };
             auto *val = clang::IntegerLiteral::Create(
-                ctx,
-                llvm::APInt(bit_width, static_cast< uint64_t >(c.value), /*isSigned=*/true),
-                underlying_type, loc
+                ctx, make_apint(), underlying_type, loc
             );
             auto *ecd = clang::EnumConstantDecl::Create(
                 ctx, enum_decl, loc, &ctx.Idents.get(c.name), underlying_type, val,
-                llvm::APSInt(
-                    llvm::APInt(bit_width, static_cast< uint64_t >(c.value), /*isSigned=*/true),
-                    /*isUnsigned=*/false
-                )
+                llvm::APSInt(make_apint(), /*isUnsigned=*/false)
             );
             enum_decl->addDecl(ecd);
         }

--- a/lib/patchestry/AST/Utils.cpp
+++ b/lib/patchestry/AST/Utils.cpp
@@ -68,14 +68,25 @@ namespace patchestry::ast {
         }
 
         switch (bit_size) {
+            case 16:
+                return ctx.Float16Ty;
             case 32:
                 return ctx.FloatTy;
             case 64:
                 return ctx.DoubleTy;
             case 80:
                 return ctx.LongDoubleTy;
+            case 128:
+                // 128-bit IEEE quad (Ghidra's 16-byte 'float16'; aarch64 long
+                // double).  Ghidra carries this as a native wide-float type
+                // rather than lowering it, so map it instead of aborting.
+                return ctx.Float128Ty;
             default:
-                llvm_unreachable("Unsupported float bit size in GetTypeFromSize");
+                // Mirror the integer branch's graceful fallback: fail loudly but
+                // do not abort the whole lift on an unexpected float width.
+                LOG(ERROR) << "GetTypeFromSize: unsupported float bit size "
+                           << bit_size << "; falling back to double\n";
+                return ctx.DoubleTy;
         }
     }
 

--- a/lib/patchestry/AST/Utils.cpp
+++ b/lib/patchestry/AST/Utils.cpp
@@ -14,6 +14,7 @@
 #include <clang/AST/Type.h>
 #include <clang/Basic/SourceLocation.h>
 #include <clang/Basic/SourceManager.h>
+#include <clang/Basic/TargetInfo.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <llvm/Support/MemoryBuffer.h>
 
@@ -69,7 +70,15 @@ namespace patchestry::ast {
 
         switch (bit_size) {
             case 16:
-                return ctx.Float16Ty;
+                // _Float16 is not supported on every target; only emit it where
+                // the target genuinely has it, otherwise fall back to float so
+                // we never hand CIRGen an unusable type.
+                if (ctx.getTargetInfo().hasFloat16Type()) {
+                    return ctx.Float16Ty;
+                }
+                LOG(ERROR) << "GetTypeFromSize: _Float16 unsupported on target; "
+                              "falling back to float\n";
+                return ctx.FloatTy;
             case 32:
                 return ctx.FloatTy;
             case 64:

--- a/lib/patchestry/Ghidra/JsonDeserialize.cpp
+++ b/lib/patchestry/Ghidra/JsonDeserialize.cpp
@@ -641,7 +641,7 @@ namespace patchestry::ghidra {
             if (result[i] == '_' && i > 0 && collapsed.back() == '_') {
                 // Two adjacent underscores — collapse only if the current
                 // or previous underscore was synthetic.
-                if (is_synthetic[i] || is_synthetic[i - 1]) {
+                if (is_synthetic[i] || collapsed_synthetic.back()) {
                     continue; // skip this duplicate
                 }
             }

--- a/lib/patchestry/Ghidra/JsonDeserialize.cpp
+++ b/lib/patchestry/Ghidra/JsonDeserialize.cpp
@@ -629,10 +629,10 @@ namespace patchestry::ghidra {
             }
         }
 
-        // Collapse consecutive underscores only when at least one in the
-        // run is synthetic (from character replacement above).  Carry the
-        // synthetic flag forward for each surviving char so the edge-trim
-        // below can tell synthetic underscores from original ones.
+        // Collapse consecutive underscores only when at least one in the run is
+        // synthetic (from character replacement above), carrying the synthetic
+        // flag forward so the edge-trim below can distinguish synthetic from
+        // original underscores.
         std::string collapsed;
         std::vector< bool > collapsed_synthetic;
         collapsed.reserve(result.size());
@@ -649,15 +649,10 @@ namespace patchestry::ghidra {
             collapsed_synthetic.push_back(is_synthetic[i]);
         }
 
-        // Remove leading/trailing underscores only when they are *synthetic*
-        // (introduced by the character replacement above when cleaning up a
-        // demangled C++ name, e.g. "::Foo" -> "_Foo").  Original leading/
-        // trailing underscores are valid, semantically significant C
-        // identifier characters: stripping them is lossy and collapses
-        // distinct symbols onto one name ("__errno" -> "errno"), which then
-        // collides with a same-named global and trips a CIRGen symbol-table
-        // assertion.  This mirrors the interior-collapse logic above, which
-        // already preserves intentional underscores via is_synthetic.
+        // Trim only *synthetic* leading/trailing underscores (from replacing C++
+        // artifacts like "::Foo").  Original ones are meaningful: stripping them
+        // collapses distinct symbols ("__errno" -> "errno") and collides with a
+        // same-named global.  Matches the interior-collapse logic above.
         while (!collapsed.empty() && collapsed.front() == '_' && collapsed_synthetic.front()) {
             collapsed.erase(collapsed.begin());
             collapsed_synthetic.erase(collapsed_synthetic.begin());

--- a/lib/patchestry/Ghidra/JsonDeserialize.cpp
+++ b/lib/patchestry/Ghidra/JsonDeserialize.cpp
@@ -629,20 +629,22 @@ namespace patchestry::ghidra {
             }
         }
 
-        // Collapse consecutive underscores only when at least one in the run is
-        // synthetic (from character replacement above), carrying the synthetic
-        // flag forward so the edge-trim below can distinguish synthetic from
-        // original underscores.
+        // Collapse a consecutive underscore only when the current one is
+        // synthetic (from character replacement above): a synthetic '_' adjacent
+        // to an existing '_' is redundant, but an original '_' is always kept
+        // (so "bl_usb__send_message" and "::_bar" -> "_bar" both survive).
+        // Carry the synthetic flag forward so the edge-trim below can
+        // distinguish synthetic from original underscores.
         std::string collapsed;
         std::vector< bool > collapsed_synthetic;
         collapsed.reserve(result.size());
         collapsed_synthetic.reserve(result.size());
         for (size_t i = 0; i < result.size(); ++i) {
             if (result[i] == '_' && i > 0 && collapsed.back() == '_') {
-                // Two adjacent underscores — collapse only if the current
-                // or previous underscore was synthetic.
-                if (is_synthetic[i] || collapsed_synthetic.back()) {
-                    continue; // skip this duplicate
+                // Two adjacent underscores — drop the current one only if it is
+                // synthetic; keep original underscores.
+                if (is_synthetic[i]) {
+                    continue; // skip this redundant synthetic underscore
                 }
             }
             collapsed.push_back(result[i]);

--- a/lib/patchestry/Ghidra/JsonDeserialize.cpp
+++ b/lib/patchestry/Ghidra/JsonDeserialize.cpp
@@ -630,9 +630,13 @@ namespace patchestry::ghidra {
         }
 
         // Collapse consecutive underscores only when at least one in the
-        // run is synthetic (from character replacement above).
+        // run is synthetic (from character replacement above).  Carry the
+        // synthetic flag forward for each surviving char so the edge-trim
+        // below can tell synthetic underscores from original ones.
         std::string collapsed;
+        std::vector< bool > collapsed_synthetic;
         collapsed.reserve(result.size());
+        collapsed_synthetic.reserve(result.size());
         for (size_t i = 0; i < result.size(); ++i) {
             if (result[i] == '_' && i > 0 && collapsed.back() == '_') {
                 // Two adjacent underscores — collapse only if the current
@@ -642,14 +646,25 @@ namespace patchestry::ghidra {
                 }
             }
             collapsed.push_back(result[i]);
+            collapsed_synthetic.push_back(is_synthetic[i]);
         }
 
-        // Remove leading/trailing underscores
-        while (!collapsed.empty() && collapsed.front() == '_') {
+        // Remove leading/trailing underscores only when they are *synthetic*
+        // (introduced by the character replacement above when cleaning up a
+        // demangled C++ name, e.g. "::Foo" -> "_Foo").  Original leading/
+        // trailing underscores are valid, semantically significant C
+        // identifier characters: stripping them is lossy and collapses
+        // distinct symbols onto one name ("__errno" -> "errno"), which then
+        // collides with a same-named global and trips a CIRGen symbol-table
+        // assertion.  This mirrors the interior-collapse logic above, which
+        // already preserves intentional underscores via is_synthetic.
+        while (!collapsed.empty() && collapsed.front() == '_' && collapsed_synthetic.front()) {
             collapsed.erase(collapsed.begin());
+            collapsed_synthetic.erase(collapsed_synthetic.begin());
         }
-        while (!collapsed.empty() && collapsed.back() == '_') {
+        while (!collapsed.empty() && collapsed.back() == '_' && collapsed_synthetic.back()) {
             collapsed.pop_back();
+            collapsed_synthetic.pop_back();
         }
 
         // If stripping produced an empty string (input was all non-alnum),

--- a/scripts/gen-call-checks.py
+++ b/scripts/gen-call-checks.py
@@ -35,7 +35,12 @@ def sanitize_to_c_identifier(name):
 
     - Replace non-alnum characters with '_', preserving runs of '_'
       (do not collapse multiple underscores).
-    - Strip leading/trailing '_'.
+    - Strip leading/trailing '_' only when they are *synthetic* (introduced
+      by the replacement above).  Original leading/trailing underscores are
+      meaningful (e.g. "__errno", "__stack_chk_fail") and are preserved.
+      This mirrors sanitize_to_c_identifier in
+      lib/patchestry/Ghidra/JsonDeserialize.cpp so the generated checks match
+      the symbols the lifter actually emits.
     - Prepend '_' if the identifier would start with a digit.
     - Apply simple normalization for destructor (~Foo) and operator*
       forms (operator<<, operator new, etc.) before generic cleanup.
@@ -52,15 +57,27 @@ def sanitize_to_c_identifier(name):
         # (the rest will be sanitized char-by-char).
         name = "op" + name[len("operator"):]
 
-    # Generic character-wise sanitization: keep alnum and '_', map others to '_'.
+    # Generic character-wise sanitization: keep alnum and '_', map others to
+    # '_'.  Track which '_' are synthetic (from a replaced non-identifier char)
+    # so only those can be trimmed from the edges below.
     chars = []
+    synthetic = []
     for ch in name:
         if ch.isalnum() or ch == "_":
             chars.append(ch)
+            synthetic.append(False)
         else:
             chars.append("_")
+            synthetic.append(True)
 
-    result = "".join(chars).strip("_")
+    # Trim synthetic edge underscores; keep original ones.
+    start = 0
+    end = len(chars)
+    while start < end and chars[start] == "_" and synthetic[start]:
+        start += 1
+    while end > start and chars[end - 1] == "_" and synthetic[end - 1]:
+        end -= 1
+    result = "".join(chars[start:end])
     if not result:
         return "fn"
     if result[0].isdigit():

--- a/scripts/gen-call-checks.py
+++ b/scripts/gen-call-checks.py
@@ -36,11 +36,11 @@ def sanitize_to_c_identifier(name):
     - Replace non-alnum characters with '_', preserving runs of '_'
       (do not collapse multiple underscores).
     - Strip leading/trailing '_' only when they are *synthetic* (introduced
-      by the replacement above).  Original leading/trailing underscores are
-      meaningful (e.g. "__errno", "__stack_chk_fail") and are preserved.
-      This mirrors sanitize_to_c_identifier in
-      lib/patchestry/Ghidra/JsonDeserialize.cpp so the generated checks match
-      the symbols the lifter actually emits.
+      by the replacement above).  Original ones are meaningful (e.g. "__errno")
+      and are preserved, matching the edge-trim in sanitize_to_c_identifier in
+      lib/patchestry/Ghidra/JsonDeserialize.cpp.  (That C++ helper also collapses
+      interior synthetic underscore runs; this does not — names with replaced
+      interior chars can still differ.)
     - Prepend '_' if the identifier would start with a digit.
     - Apply simple normalization for destructor (~Foo) and operator*
       forms (operator<<, operator new, etc.) before generic cleanup.


### PR DESCRIPTION
This pull request improves the correctness and robustness of symbol handling, function call synthesis, and type coercion across the Patchestry codebase.

Key changes include:

* Fixing C identifier sanitization to preserve original underscores and avoid accidental symbol collisions during code generation.
* Adding runtime checks for conflicting function and variable identifiers to fail early on invalid symbol tables.
* Improving function call argument synthesis with better error handling and support for enum default arguments.
* Introducing stricter pointer coercion for STORE operations to ensure generated addresses are valid and dereferenceable.
* Fixing PIECE lowering to consistently operate in the integer domain before reinterpreting non-integer results, improving correctness for bit-level operations.