### PR TITLE
fix: Improve logging controls and robust integer literal generation

### DIFF
--- a/include/patchestry/AST/Utils.hpp
+++ b/include/patchestry/AST/Utils.hpp
@@ -43,14 +43,9 @@ namespace patchestry::ast {
     /// is then handled by downstream ClangEmitter cloning).
     clang::Expr *CloneExpr(clang::ASTContext &ctx, clang::Expr *expr);
 
-    /// Build an IntegerLiteral with a type the Clang StmtPrinter can print.
-    /// StmtPrinter's integer-literal printer only accepts the standard
-    /// signed/unsigned char..int128 builtins (+ wchar); a literal typed
-    /// _Bool / char8_t / char16_t / char32_t / enum (or any non-builtin) trips
-    /// llvm_unreachable("Unexpected type for integer literal") during -print-tu.
-    /// When `operand_type` isn't printable (or isn't an integer/enum type at
-    /// all), a same-width standard integer is used instead; callers compare or
-    /// assign through the usual conversions, so semantics are unchanged.
+    /// IntegerLiteral whose type StmtPrinter can print. _Bool/char8_16_32/enum
+    /// (or any non-builtin) crash StmtPrinter; for those, a same-width standard
+    /// integer is used (callers convert as usual, so semantics are unchanged).
     clang::Expr *MakeIntLiteralPrintable(
         clang::ASTContext &ctx, uint64_t value, clang::QualType operand_type,
         bool is_signed, clang::SourceLocation loc

--- a/include/patchestry/AST/Utils.hpp
+++ b/include/patchestry/AST/Utils.hpp
@@ -42,7 +42,20 @@ namespace patchestry::ast {
     /// leaving the subtree shared — acceptable because subtree sharing
     /// is then handled by downstream ClangEmitter cloning).
     clang::Expr *CloneExpr(clang::ASTContext &ctx, clang::Expr *expr);
-    
+
+    /// Build an IntegerLiteral with a type the Clang StmtPrinter can print.
+    /// StmtPrinter's integer-literal printer only accepts the standard
+    /// signed/unsigned char..int128 builtins (+ wchar); a literal typed
+    /// _Bool / char8_t / char16_t / char32_t / enum (or any non-builtin) trips
+    /// llvm_unreachable("Unexpected type for integer literal") during -print-tu.
+    /// When `operand_type` isn't printable (or isn't an integer/enum type at
+    /// all), a same-width standard integer is used instead; callers compare or
+    /// assign through the usual conversions, so semantics are unchanged.
+    clang::Expr *MakeIntLiteralPrintable(
+        clang::ASTContext &ctx, uint64_t value, clang::QualType operand_type,
+        bool is_signed, clang::SourceLocation loc
+    );
+
     clang::SourceLocation SourceLocation(clang::SourceManager &sm, std::string key);
 
     /// Returns a valid SourceLocation backed by a virtual "<patchestry-virtual>"

--- a/include/patchestry/Util/Log.hpp
+++ b/include/patchestry/Util/Log.hpp
@@ -14,13 +14,13 @@
 enum LogLevel { DEBUG, INFO, WARNING, ERROR, FATAL };
 
 namespace patchestry::logging {
-    // Global minimum level a LOG() must meet to be emitted (glog-style).
-    // Default WARNING: DEBUG/INFO are suppressed unless `--verbose` lowers it.
+    // Min level a LOG() must meet to emit (glog-style); default suppresses
+    // DEBUG/INFO. Set via --verbose.
     inline LogLevel &MinLogLevel() {
         static LogLevel level = WARNING;
         return level;
     }
-    // Sink for suppressed levels — discards everything written to it.
+    // Sink for suppressed levels.
     inline llvm::raw_ostream &NullLogStream() {
         static llvm::raw_null_ostream stream;
         return stream;

--- a/include/patchestry/Util/Log.hpp
+++ b/include/patchestry/Util/Log.hpp
@@ -13,15 +13,30 @@
 
 enum LogLevel { DEBUG, INFO, WARNING, ERROR, FATAL };
 
+namespace patchestry::logging {
+    // Global minimum level a LOG() must meet to be emitted (glog-style).
+    // Default WARNING: DEBUG/INFO are suppressed unless `--verbose` lowers it.
+    inline LogLevel &MinLogLevel() {
+        static LogLevel level = WARNING;
+        return level;
+    }
+    // Sink for suppressed levels — discards everything written to it.
+    inline llvm::raw_ostream &NullLogStream() {
+        static llvm::raw_null_ostream stream;
+        return stream;
+    }
+} // namespace patchestry::logging
+
 #define LOG(level) \
-    (((level) == DEBUG)         ? llvm::outs() << "[DEBUG] " \
-         : ((level) == INFO)    ? llvm::outs() << "[INFO] " \
-         : ((level) == WARNING) ? llvm::outs() << "[WARNING] " \
-         : ((level) == FATAL)   ? llvm::errs() << "[FATAL] " \
-         : ((level) == ERROR)   ? llvm::errs() << "[ERROR] " \
-                                : llvm::outs() \
-    ) << "(" \
-      << __FILE__ << ":" << __LINE__ << ") "
+    (((level) < ::patchestry::logging::MinLogLevel()) \
+         ? ::patchestry::logging::NullLogStream() \
+         : ((((level) == DEBUG)     ? llvm::outs() << "[DEBUG] " \
+              : ((level) == INFO)    ? llvm::outs() << "[INFO] " \
+              : ((level) == WARNING) ? llvm::outs() << "[WARNING] " \
+              : ((level) == FATAL)   ? llvm::errs() << "[FATAL] " \
+              : ((level) == ERROR)   ? llvm::errs() << "[ERROR] " \
+                                     : llvm::outs()) \
+            << "(" << __FILE__ << ":" << __LINE__ << ") "))
 
 #define LOG_FATAL(...) \
     do { \

--- a/include/patchestry/Util/Log.hpp
+++ b/include/patchestry/Util/Log.hpp
@@ -14,10 +14,11 @@
 enum LogLevel { DEBUG, INFO, WARNING, ERROR, FATAL };
 
 namespace patchestry::logging {
-    // Min level a LOG() must meet to emit (glog-style); default suppresses
-    // DEBUG/INFO. Set via --verbose.
+    // Min level a LOG() must meet to emit (glog-style). Default DEBUG keeps the
+    // historical "print everything" behavior for tools that don't opt in;
+    // patchir-decomp raises it to WARNING (INFO off) unless --verbose.
     inline LogLevel &MinLogLevel() {
-        static LogLevel level = WARNING;
+        static LogLevel level = DEBUG;
         return level;
     }
     // Sink for suppressed levels.

--- a/lib/patchestry/AST/BuildSNodeFromRegion.cpp
+++ b/lib/patchestry/AST/BuildSNodeFromRegion.cpp
@@ -480,7 +480,6 @@ namespace patchestry::ast {
             case_type = case_type->castAs< clang::EnumType >()
                             ->getDecl()->getIntegerType();
         }
-        unsigned case_width = ctx_.getIntWidth(case_type);
 
         auto *sw = factory_.Make< SSwitch >(disp.branch_cond);
 
@@ -527,10 +526,9 @@ namespace patchestry::ast {
             const size_t body_pos = total_labels - 1;
             size_t pos = 0;
             for (std::int64_t v : arm.values) {
-                auto *val = clang::IntegerLiteral::Create(
-                    ctx_,
-                    llvm::APInt(case_width, static_cast< uint64_t >(v), true),
-                    case_type, VirtualLoc(ctx_));
+                auto *val = MakeIntLiteralPrintable(
+                    ctx_, static_cast< uint64_t >(v), case_type,
+                    /*is_signed=*/true, VirtualLoc(ctx_));
                 if (pos == body_pos) {
                     sw->AddCase(val, *body_seq);
                 } else {
@@ -572,10 +570,9 @@ namespace patchestry::ast {
             const size_t body_pos = total_labels - 1;
             size_t pos = 0;
             for (std::int64_t v : arm.values) {
-                auto *val = clang::IntegerLiteral::Create(
-                    ctx_,
-                    llvm::APInt(case_width, static_cast< uint64_t >(v), true),
-                    case_type, VirtualLoc(ctx_));
+                auto *val = MakeIntLiteralPrintable(
+                    ctx_, static_cast< uint64_t >(v), case_type,
+                    /*is_signed=*/true, VirtualLoc(ctx_));
                 if (pos == body_pos) {
                     sw->AddCase(val, std::vector< SNode * >{terminator});
                 } else {

--- a/lib/patchestry/AST/OperationStmt.cpp
+++ b/lib/patchestry/AST/OperationStmt.cpp
@@ -49,6 +49,56 @@ namespace patchestry::ast {
 
     namespace {
 
+        // StmtPrinter's integer-literal printer only accepts the standard
+        // signed/unsigned char..int128 builtins (+ wchar); a literal typed
+        // _Bool / char8_t / char16_t / char32_t (or any non-builtin) trips
+        // llvm_unreachable("Unexpected type for integer literal") during
+        // -print-tu.  Build such literals with a printable same-width integer
+        // type instead; callers compare/assign through the usual conversions, so
+        // semantics are unchanged.
+        clang::Expr *make_int_literal_printable(
+            clang::ASTContext &ctx, uint64_t value, clang::QualType operand_type,
+            bool is_signed, clang::SourceLocation loc
+        ) {
+            auto printable = [](clang::QualType t) -> bool {
+                const auto *bt = t->getAs< clang::BuiltinType >();
+                if (bt == nullptr) {
+                    return false;
+                }
+                switch (bt->getKind()) {
+                    case clang::BuiltinType::Char_S:
+                    case clang::BuiltinType::Char_U:
+                    case clang::BuiltinType::SChar:
+                    case clang::BuiltinType::UChar:
+                    case clang::BuiltinType::Short:
+                    case clang::BuiltinType::UShort:
+                    case clang::BuiltinType::Int:
+                    case clang::BuiltinType::UInt:
+                    case clang::BuiltinType::Long:
+                    case clang::BuiltinType::ULong:
+                    case clang::BuiltinType::LongLong:
+                    case clang::BuiltinType::ULongLong:
+                    case clang::BuiltinType::Int128:
+                    case clang::BuiltinType::UInt128:
+                    case clang::BuiltinType::WChar_S:
+                    case clang::BuiltinType::WChar_U:
+                        return true;
+                    default:
+                        return false;
+                }
+            };
+            clang::QualType lit_type = operand_type;
+            if (operand_type.isNull() || !printable(operand_type)) {
+                unsigned w = operand_type.isNull() ? 32U : ctx.getIntWidth(operand_type);
+                auto t     = ctx.getIntTypeForBitwidth(w <= 1U ? 32U : w, is_signed);
+                lit_type   = t.isNull() ? (is_signed ? ctx.IntTy : ctx.UnsignedIntTy) : t;
+            }
+            unsigned lw = ctx.getIntWidth(lit_type);
+            return clang::IntegerLiteral::Create(
+                ctx, llvm::APInt(lw, value, is_signed), lit_type, loc
+            );
+        }
+
         // Simplify *(&expr) → expr.  When PTRADD produces &base[index] and
         // STORE/LOAD dereferences it, this cancels the redundant &/* pair so the
         // output reads base[index] instead of *(&base[index]).
@@ -2672,8 +2722,8 @@ namespace patchestry::ast {
         // getIntWidth(type).
         unsigned operand_bits = ctx.getIntWidth(expr->getType());
         if (operand_bits != 0 && shift_bits >= operand_bits) {
-            result_expr = clang::IntegerLiteral::Create(
-                ctx, llvm::APInt(operand_bits, 0), expr->getType(), op_location
+            result_expr = make_int_literal_printable(
+                ctx, 0, expr->getType(), /*is_signed=*/false, op_location
             );
         } else if (shift_bits != 0) {
             // Apply right-shift only when byte_offset > 0 (skip ">> 0").
@@ -2996,9 +3046,8 @@ namespace patchestry::ast {
         assert(!and_result.isInvalid() && "Failed to create and operation");
 
         // scarry = and_result < 0
-        auto *zero = clang::IntegerLiteral::Create(
-            ctx, llvm::APInt(ctx.getIntWidth(input0->getType()), 0, true), input0->getType(),
-            op_loc
+        auto *zero = make_int_literal_printable(
+            ctx, 0, input0->getType(), /*is_signed=*/true, op_loc
         );
         auto scarry = sema().BuildBinOp(
             sema().getCurScope(), op_loc, clang::BO_LT, and_result.getAs< clang::Expr >(),
@@ -3067,9 +3116,8 @@ namespace patchestry::ast {
         assert(!and_result.isInvalid() && "Failed to create and operation");
 
         // sborrow = and_result < 0
-        auto *zero = clang::IntegerLiteral::Create(
-            ctx, llvm::APInt(ctx.getIntWidth(input0->getType()), 0, true), input0->getType(),
-            op_loc
+        auto *zero = make_int_literal_printable(
+            ctx, 0, input0->getType(), /*is_signed=*/true, op_loc
         );
         auto sborrow = sema().BuildBinOp(
             sema().getCurScope(), op_loc, clang::BO_LT, and_result.getAs< clang::Expr >(),

--- a/lib/patchestry/AST/OperationStmt.cpp
+++ b/lib/patchestry/AST/OperationStmt.cpp
@@ -89,9 +89,7 @@ namespace patchestry::ast {
 
             auto param_type = param->getType();
             if (param_type->isIntegerType()) {
-                // param_type may be _Bool/enum/char8_t (isIntegerType() is true
-                // for them) — those crash StmtPrinter, so route through the
-                // printable-literal helper.
+                // param_type may be _Bool/enum (crash StmtPrinter).
                 return MakeIntLiteralPrintable(
                     ctx, 0, param_type, param_type->isSignedIntegerType(),
                     VirtualLoc(ctx)
@@ -1242,9 +1240,7 @@ namespace patchestry::ast {
             }
 
             auto create_case = [&](const SwitchCase &sc) -> clang::CaseStmt * {
-                // disc_type may be _Bool/char32_t (enum is already lowered to
-                // its underlying type above) — route through the printable
-                // helper so the case value never trips StmtPrinter.
+                // disc_type may be _Bool/char32_t (enum lowered above).
                 auto *case_val = MakeIntLiteralPrintable(
                     ctx, static_cast< uint64_t >(sc.value), disc_type,
                     /*is_signed=*/true, loc

--- a/lib/patchestry/AST/OperationStmt.cpp
+++ b/lib/patchestry/AST/OperationStmt.cpp
@@ -139,8 +139,11 @@ namespace patchestry::ast {
 
             auto param_type = param->getType();
             if (param_type->isIntegerType()) {
-                return new (ctx) clang::IntegerLiteral(
-                    ctx, llvm::APInt(ctx.getIntWidth(param_type), 0), param_type,
+                // param_type may be _Bool/enum/char8_t (isIntegerType() is true
+                // for them) — those crash StmtPrinter, so route through the
+                // printable-literal helper.
+                return make_int_literal_printable(
+                    ctx, 0, param_type, param_type->isSignedIntegerType(),
                     VirtualLoc(ctx)
                 );
             } else if (param_type->isFloatingType()) {

--- a/lib/patchestry/AST/OperationStmt.cpp
+++ b/lib/patchestry/AST/OperationStmt.cpp
@@ -49,56 +49,6 @@ namespace patchestry::ast {
 
     namespace {
 
-        // StmtPrinter's integer-literal printer only accepts the standard
-        // signed/unsigned char..int128 builtins (+ wchar); a literal typed
-        // _Bool / char8_t / char16_t / char32_t (or any non-builtin) trips
-        // llvm_unreachable("Unexpected type for integer literal") during
-        // -print-tu.  Build such literals with a printable same-width integer
-        // type instead; callers compare/assign through the usual conversions, so
-        // semantics are unchanged.
-        clang::Expr *make_int_literal_printable(
-            clang::ASTContext &ctx, uint64_t value, clang::QualType operand_type,
-            bool is_signed, clang::SourceLocation loc
-        ) {
-            auto printable = [](clang::QualType t) -> bool {
-                const auto *bt = t->getAs< clang::BuiltinType >();
-                if (bt == nullptr) {
-                    return false;
-                }
-                switch (bt->getKind()) {
-                    case clang::BuiltinType::Char_S:
-                    case clang::BuiltinType::Char_U:
-                    case clang::BuiltinType::SChar:
-                    case clang::BuiltinType::UChar:
-                    case clang::BuiltinType::Short:
-                    case clang::BuiltinType::UShort:
-                    case clang::BuiltinType::Int:
-                    case clang::BuiltinType::UInt:
-                    case clang::BuiltinType::Long:
-                    case clang::BuiltinType::ULong:
-                    case clang::BuiltinType::LongLong:
-                    case clang::BuiltinType::ULongLong:
-                    case clang::BuiltinType::Int128:
-                    case clang::BuiltinType::UInt128:
-                    case clang::BuiltinType::WChar_S:
-                    case clang::BuiltinType::WChar_U:
-                        return true;
-                    default:
-                        return false;
-                }
-            };
-            clang::QualType lit_type = operand_type;
-            if (operand_type.isNull() || !printable(operand_type)) {
-                unsigned w = operand_type.isNull() ? 32U : ctx.getIntWidth(operand_type);
-                auto t     = ctx.getIntTypeForBitwidth(w <= 1U ? 32U : w, is_signed);
-                lit_type   = t.isNull() ? (is_signed ? ctx.IntTy : ctx.UnsignedIntTy) : t;
-            }
-            unsigned lw = ctx.getIntWidth(lit_type);
-            return clang::IntegerLiteral::Create(
-                ctx, llvm::APInt(lw, value, is_signed), lit_type, loc
-            );
-        }
-
         // Simplify *(&expr) → expr.  When PTRADD produces &base[index] and
         // STORE/LOAD dereferences it, this cancels the redundant &/* pair so the
         // output reads base[index] instead of *(&base[index]).
@@ -142,7 +92,7 @@ namespace patchestry::ast {
                 // param_type may be _Bool/enum/char8_t (isIntegerType() is true
                 // for them) — those crash StmtPrinter, so route through the
                 // printable-literal helper.
-                return make_int_literal_printable(
+                return MakeIntLiteralPrintable(
                     ctx, 0, param_type, param_type->isSignedIntegerType(),
                     VirtualLoc(ctx)
                 );
@@ -1290,13 +1240,14 @@ namespace patchestry::ast {
                 disc_type = disc_type->castAs< clang::EnumType >()
                     ->getDecl()->getIntegerType();
             }
-            const auto disc_width = ctx.getIntWidth(disc_type);
 
             auto create_case = [&](const SwitchCase &sc) -> clang::CaseStmt * {
-                auto *case_val = clang::IntegerLiteral::Create(
-                    ctx,
-                    llvm::APInt(disc_width, static_cast< uint64_t >(sc.value), /*isSigned=*/true),
-                    disc_type, loc
+                // disc_type may be _Bool/char32_t (enum is already lowered to
+                // its underlying type above) — route through the printable
+                // helper so the case value never trips StmtPrinter.
+                auto *case_val = MakeIntLiteralPrintable(
+                    ctx, static_cast< uint64_t >(sc.value), disc_type,
+                    /*is_signed=*/true, loc
                 );
                 auto *case_stmt =
                     clang::CaseStmt::Create(ctx, case_val, nullptr, loc, loc, loc);
@@ -1445,7 +1396,6 @@ namespace patchestry::ast {
                 clang::SwitchStmt::Create(ctx, nullptr, nullptr, disc_expr, loc, loc);
 
             std::vector< clang::Stmt * > sw_body;
-            const auto disc_width = ctx.getIntWidth(disc_type);
             for (const auto &block_key : op.successor_blocks) {
                 if (!function_builder().labels_declaration.contains(block_key)) {
                     continue;
@@ -1454,8 +1404,8 @@ namespace patchestry::ast {
                 if (!maybe_addr) {
                     continue;
                 }
-                auto *case_val = clang::IntegerLiteral::Create(
-                    ctx, llvm::APInt(disc_width, *maybe_addr), disc_type, loc
+                auto *case_val = MakeIntLiteralPrintable(
+                    ctx, *maybe_addr, disc_type, /*is_signed=*/false, loc
                 );
                 auto *case_stmt =
                     clang::CaseStmt::Create(ctx, case_val, nullptr, loc, loc, loc);
@@ -2725,7 +2675,7 @@ namespace patchestry::ast {
         // getIntWidth(type).
         unsigned operand_bits = ctx.getIntWidth(expr->getType());
         if (operand_bits != 0 && shift_bits >= operand_bits) {
-            result_expr = make_int_literal_printable(
+            result_expr = MakeIntLiteralPrintable(
                 ctx, 0, expr->getType(), /*is_signed=*/false, op_location
             );
         } else if (shift_bits != 0) {
@@ -3049,7 +2999,7 @@ namespace patchestry::ast {
         assert(!and_result.isInvalid() && "Failed to create and operation");
 
         // scarry = and_result < 0
-        auto *zero = make_int_literal_printable(
+        auto *zero = MakeIntLiteralPrintable(
             ctx, 0, input0->getType(), /*is_signed=*/true, op_loc
         );
         auto scarry = sema().BuildBinOp(
@@ -3119,7 +3069,7 @@ namespace patchestry::ast {
         assert(!and_result.isInvalid() && "Failed to create and operation");
 
         // sborrow = and_result < 0
-        auto *zero = make_int_literal_printable(
+        auto *zero = MakeIntLiteralPrintable(
             ctx, 0, input0->getType(), /*is_signed=*/true, op_loc
         );
         auto sborrow = sema().BuildBinOp(

--- a/lib/patchestry/AST/Utils.cpp
+++ b/lib/patchestry/AST/Utils.cpp
@@ -353,8 +353,7 @@ namespace patchestry::ast {
                     return false;
             }
         };
-        // getIntWidth() asserts on non-integer/enum types, so only consult it
-        // when the operand is genuinely integral; otherwise fall back to int.
+        // getIntWidth() asserts on non-integer types; fall back to int.
         const bool integral =
             !operand_type.isNull() && operand_type->isIntegralOrEnumerationType();
         clang::QualType lit_type = operand_type;

--- a/lib/patchestry/AST/Utils.cpp
+++ b/lib/patchestry/AST/Utils.cpp
@@ -322,6 +322,53 @@ namespace patchestry::ast {
         );
     }
 
+    clang::Expr *MakeIntLiteralPrintable(
+        clang::ASTContext &ctx, uint64_t value, clang::QualType operand_type,
+        bool is_signed, clang::SourceLocation loc
+    ) {
+        auto printable = [](clang::QualType t) -> bool {
+            const auto *bt = t->getAs< clang::BuiltinType >();
+            if (bt == nullptr) {
+                return false;
+            }
+            switch (bt->getKind()) {
+                case clang::BuiltinType::Char_S:
+                case clang::BuiltinType::Char_U:
+                case clang::BuiltinType::SChar:
+                case clang::BuiltinType::UChar:
+                case clang::BuiltinType::Short:
+                case clang::BuiltinType::UShort:
+                case clang::BuiltinType::Int:
+                case clang::BuiltinType::UInt:
+                case clang::BuiltinType::Long:
+                case clang::BuiltinType::ULong:
+                case clang::BuiltinType::LongLong:
+                case clang::BuiltinType::ULongLong:
+                case clang::BuiltinType::Int128:
+                case clang::BuiltinType::UInt128:
+                case clang::BuiltinType::WChar_S:
+                case clang::BuiltinType::WChar_U:
+                    return true;
+                default:
+                    return false;
+            }
+        };
+        // getIntWidth() asserts on non-integer/enum types, so only consult it
+        // when the operand is genuinely integral; otherwise fall back to int.
+        const bool integral =
+            !operand_type.isNull() && operand_type->isIntegralOrEnumerationType();
+        clang::QualType lit_type = operand_type;
+        if (!integral || !printable(operand_type)) {
+            unsigned w = integral ? ctx.getIntWidth(operand_type) : 32U;
+            auto t     = ctx.getIntTypeForBitwidth(w <= 1U ? 32U : w, is_signed);
+            lit_type   = t.isNull() ? (is_signed ? ctx.IntTy : ctx.UnsignedIntTy) : t;
+        }
+        unsigned lw = ctx.getIntWidth(lit_type);
+        return clang::IntegerLiteral::Create(
+            ctx, llvm::APInt(lw, value, is_signed), lit_type, loc
+        );
+    }
+
     clang::Expr *CloneExpr(clang::ASTContext &ctx, clang::Expr *expr) {
         if (!expr) return nullptr;
 

--- a/tools/patchir-decomp/main.cpp
+++ b/tools/patchir-decomp/main.cpp
@@ -104,8 +104,7 @@ namespace {
             argc, argv, "patche-lifter to represent high pcode into mlir representations\n"
         );
 
-        // glog-style verbosity: DEBUG/INFO are suppressed by default; --verbose
-        // lowers the threshold so they're emitted. WARNING/ERROR/FATAL always show.
+        // --verbose enables DEBUG/INFO; otherwise only WARNING/ERROR/FATAL.
         ::patchestry::logging::MinLogLevel() = verbose.getValue() ? DEBUG : WARNING;
 
         return {

--- a/tools/patchir-decomp/main.cpp
+++ b/tools/patchir-decomp/main.cpp
@@ -104,6 +104,10 @@ namespace {
             argc, argv, "patche-lifter to represent high pcode into mlir representations\n"
         );
 
+        // glog-style verbosity: DEBUG/INFO are suppressed by default; --verbose
+        // lowers the threshold so they're emitted. WARNING/ERROR/FATAL always show.
+        ::patchestry::logging::MinLogLevel() = verbose.getValue() ? DEBUG : WARNING;
+
         return {
             .emit_cir                   = emit_cir.getValue(),
             .emit_mlir                  = emit_mlir.getValue(), // It is set to true by default


### PR DESCRIPTION
This pull request improves logging configuration and fixes several robustness issues related to integer literal generation in AST operations.

Key changes include:
* Adding a glog-style minimum log level to suppress low-priority logs unless verbose mode is enabled.
* Updating the LOG macro and main.cpp to respect the configured verbosity level.
* Introducing make_int_literal_printable, a helper that safely creates printable integer literals for problematic types such as _Bool, char8_t, and enums.
* Updating integer literal creation sites in OperationStmt.cpp to use the new helper, preventing AST printer crashes and improving type handling consistency.